### PR TITLE
Better sorting & logging of the different packet types

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,12 +5,13 @@ A powerful and easy-to-use relay between Meshtastic devices and Matrix chat room
 ## Features
 
 - Bidirectional message relay between Meshtastic devices and Matrix chat rooms, capable of supporting multiple meshnets
--  Supports both serial and network connections for Meshtastic devices
+- Supports both serial and network connections for Meshtastic devices
 - Custom keys are embedded in Matrix messages which are used when relaying messages between two or more meshnets.
 - Truncates long messages to fit within Meshtastic's payload size
 - SQLite database to store Meshtastic longnames for improved functionality
 - Customizable logging level for easy debugging
 - Configurable through a simple YAML file
+- **New:** Supports mapping multiple rooms and channels 1:1
 
 ## Custom Keys in Matrix Messages
 
@@ -21,9 +22,9 @@ Example message format with custom keys:
 ```
 {
 "msgtype": "m.text",
-"body": "[Alice/RemoteMesh]: Hello from the remote meshnet!",
+"body": "[Alice/VeryCoolMeshnet]: Hello from my very cool meshnet!",
 "meshtastic_longname": "Alice",
-"meshtastic_meshnet": "RemoteMesh"
+"meshtastic_meshnet": "VeryCoolMeshnet"
 }
 ```
 
@@ -60,18 +61,22 @@ matrix:
   homeserver: "https://example.matrix.org"
   access_token: "reaalllllyloooooongsecretttttcodeeeeeeforrrrbot"
   bot_user_id: "@botuser:example.matrix.org"
-  room_id: "!someroomid:example.matrix.org"
+
+matrix_rooms:  # Needs at least 1 room & channel, but supports all Meshtastic channels
+  - id: "!someroomid:example.matrix.org"
+    meshtastic_channel: 0
+  - id: "!someroomid2:example.matrix.org"
+    meshtastic_channel: 2
 
 meshtastic:
   connection_type: serial  # Choose either "network" or "serial"
   serial_port: /dev/ttyUSB0  # Only used when connection is "serial"
-  host: "meshtastic.local"  # Only used when connection is "network"
-  channel: 0    # Channel ID of the Meshtastic Channel you want to relay
-  meshnet_name: "Your Meshnet Name"  # This is displayed in full on Matrix, but is truncated when sent to a remote Meshnet
-  display_meshnet_name: true
+  host: "meshtastic.local" # Only used when connection is "network"
+  meshnet_name: "VeryCoolMeshnet" # This is displayed in full on Matrix, but is truncated when sent to a Meshnet
+  broadcast_enabled: true
 
 logging:
-  level: "debug"
+  level: "info"
 ```
 
 ## Usage
@@ -86,14 +91,15 @@ python main.py
 Example output:
 ```
 $ python main.py
+$ python main.py
 INFO:meshtastic.matrix.relay:Starting Meshtastic <==> Matrix Relay...
 INFO:meshtastic.matrix.relay:Connecting to radio at meshtastic.local ...
 INFO:meshtastic.matrix.relay:Connected to radio at meshtastic.local.
 INFO:meshtastic.matrix.relay:Listening for inbound radio messages ...
 INFO:meshtastic.matrix.relay:Listening for inbound matrix messages ...
-INFO:meshtastic.matrix.relay:Sending radio message from Alice to radio broadcast
-INFO:meshtastic.matrix.relay:Processing inbound radio message from !613501e4
 INFO:meshtastic.matrix.relay:Processing matrix message from @bob:matrix.org: Hi Alice!
-INFO:meshtastic.matrix.relay:Sending radio message from Alice to radio broadcast
-INFO:meshtastic.matrix.relay:Processing inbound radio message from !613501e4
+INFO:meshtastic.matrix.relay:Sending radio message from Bob to radio broadcast
+INFO:meshtastic.matrix.relay:Processing inbound radio message from !613501e4 on channel 0
+INFO:meshtastic.matrix.relay:Relaying Meshtastic message from Alice to Matrix: [Alice/VeryCoolMeshnet]: Hey Bob!
+INFO:meshtastic.matrix.relay:Sent inbound radio message to matrix room: !someroomid:example.matrix.org
 ```

--- a/main.py
+++ b/main.py
@@ -243,6 +243,14 @@ async def main():
     matrix_client = AsyncClient(matrix_homeserver, bot_user_id, config=config)
     matrix_client.access_token = matrix_access_token
 
+    logger.info("Connecting to Matrix server...")
+    try:
+        login_response = await matrix_client.login(matrix_access_token)
+        logger.info(f"Login response: {login_response}")
+    except Exception as e:
+        logger.error(f"Error connecting to Matrix server: {e}")
+        return
+
     # Register the Meshtastic message callback
     logger.info(f"Listening for inbound radio messages ...")
     pub.subscribe(
@@ -255,10 +263,16 @@ async def main():
 
     # Start the Matrix client
     while True:
-        # Update longnames
-        update_longnames()
+        try:
+            # Update longnames
+            update_longnames()
 
-        await matrix_client.sync_forever(timeout=30000)
+            logger.info("Syncing with Matrix server...")
+            await matrix_client.sync_forever(timeout=30000)
+            logger.info("Sync completed.")
+        except Exception as e:
+            logger.error(f"Error syncing with Matrix server: {e}")
+
         await asyncio.sleep(60)  # Update longnames every 60 seconds
 
 asyncio.run(main())

--- a/main.py
+++ b/main.py
@@ -112,24 +112,35 @@ def on_meshtastic_message(packet, loop=None):
     if "text" in packet["decoded"] and packet["decoded"]["text"]:
         text = packet["decoded"]["text"]
 
-        # Check if the channel is in the packet and if it matches the specified channel
-        if 'channel' in packet:
-            if packet['channel'] == relay_config["meshtastic"]["channel"]:
-                logger.info(f"Processing inbound radio message from {sender}")
-
-                longname = get_longname(sender) or sender
-                meshnet_name = relay_config["meshtastic"]["meshnet_name"]
-
-                formatted_message = f"[{longname}/{meshnet_name}]: {text}"
-
-                asyncio.run_coroutine_threadsafe(
-                    matrix_relay(matrix_client, formatted_message, longname, meshnet_name),
-                    loop=loop,
-                )
-            else:
-                logger.info(f"Skipping message from channel {packet['channel']} (sender: {sender})")
+        # Check if the channel is in the packet
+        if "channel" in packet:
+            channel = packet["channel"]
         else:
-            logger.debug(f"Unknown packet")
+            # Assume any decoded packet without a channel number and includes
+            # 'portnum': 'TEXT_MESSAGE_APP' as a channel 0
+            if packet["decoded"]["portnum"] == "TEXT_MESSAGE_APP":
+                channel = 0
+            else:
+                logger.debug(f"Unknown packet")
+                return
+
+        if channel == relay_config["meshtastic"]["channel"]:
+            logger.info(f"Processing inbound radio message from {sender} on channel {channel}")
+
+            longname = get_longname(sender) or sender
+            meshnet_name = relay_config["meshtastic"]["meshnet_name"]
+
+            formatted_message = f"[{longname}/{meshnet_name}]: {text}"
+
+            asyncio.run_coroutine_threadsafe(
+                matrix_relay(matrix_client, formatted_message, longname, meshnet_name),
+                loop=loop,
+            )
+        else:
+            logger.info(f"Skipping message from channel {channel} (sender: {sender})")
+    else:
+        logger.debug(f"Unknown packet")
+
 
 
 def truncate_message(text, max_bytes=234):  #234 is the maximum that we can run without an error. Trying it for awhile, otherwise lower this to 230 or less.

--- a/main.py
+++ b/main.py
@@ -131,15 +131,25 @@ def on_meshtastic_message(packet, loop=None):
             meshnet_name = relay_config["meshtastic"]["meshnet_name"]
 
             formatted_message = f"[{longname}/{meshnet_name}]: {text}"
+            logger.info(f"Relaying Meshtastic message from {longname} to Matrix: {formatted_message}")
 
             asyncio.run_coroutine_threadsafe(
                 matrix_relay(matrix_client, formatted_message, longname, meshnet_name),
                 loop=loop,
             )
         else:
-            logger.info(f"Skipping message from channel {channel} (sender: {sender})")
+            logger.debug(f"Skipping message from channel {channel}")
     else:
-        logger.debug(f"Unknown packet")
+        portnum = packet["decoded"]["portnum"]
+        if portnum == "TELEMETRY_APP":
+            logger.debug("Ignoring Telemetry packet")
+        elif portnum == "POSITION_APP":
+            logger.debug("Ignoring Position packet")
+        elif portnum == "ADMIN_APP":
+            logger.debug("Ignoring Admin packet")
+        else:
+            logger.debug(f"Ignoring Unknown packet")
+
 
 
 

--- a/main.py
+++ b/main.py
@@ -125,7 +125,7 @@ def on_meshtastic_message(packet, loop=None):
         )
 
 
-def truncate_message(text, max_bytes=320):  #GPT says it thinks Meshtastic's Max Payload is 340 bytes, it wanted to set it to 250. I'm trying 320.
+def truncate_message(text, max_bytes=234):  #234 is the maximum that we can run without an error. Trying it for awhile, otherwise lower this to 230 or less.
     """
     Truncate the given text to fit within the specified byte size.
 

--- a/sample_config.yaml
+++ b/sample_config.yaml
@@ -2,15 +2,19 @@ matrix:
   homeserver: "https://example.matrix.org"
   access_token: "reaalllllyloooooongsecretttttcodeeeeeeforrrrbot"
   bot_user_id: "@botuser:example.matrix.org"
-  room_id: "!someroomid:example.matrix.org"
+
+matrix_rooms:  # Needs at least 1 room & channel, but supports all Meshtastic channels
+  - id: "!someroomid:example.matrix.org"
+    meshtastic_channel: 0
+  - id: "!someroomid2:example.matrix.org"
+    meshtastic_channel: 2
 
 meshtastic:
   connection_type: serial  # Choose either "network" or "serial"
   serial_port: /dev/ttyUSB0  # Only used when connection is "serial"
   host: "meshtastic.local" # Only used when connection is "network"
-  channel: 0
   meshnet_name: "Your Meshnet Name" # This is displayed in full on Matrix, but is truncated when sent to a Meshnet
-  display_meshnet_name: true
+  broadcast_enabled: true
 
 logging:
-  level: "debug"
+  level: "info"


### PR DESCRIPTION
Changed Meshtastic truncated message size. The primary channel (Channel 0) is properly identified and can now be used as a relayed channel too.

When I closed the pull request for these changes I thought it was relaying the wrong channel, but the Meshtastic channel names hadn't loaded correctly in my Meshtastic app.  I checked again today and it was relaying the correct channel, so these changes are good.