### PR TITLE
lower max_bytes in truncate_message

### DIFF
--- a/main.py
+++ b/main.py
@@ -249,7 +249,7 @@ def on_meshtastic_message(packet, loop=None):
 
 
 def truncate_message(
-    text, max_bytes=234
+    text, max_bytes=230
 ):  # 234 is the maximum that we can run without an error. Trying it for awhile, otherwise lower this to 230 or less.
     """
     Truncate the given text to fit within the specified byte size.

--- a/mmrelay.iss
+++ b/mmrelay.iss
@@ -4,7 +4,7 @@
 //WizardSmallImageFile=smallwiz.bmp
 
 AppName=Matrix <> Meshtastic Relay
-AppVersion=0.3.4
+AppVersion=0.3.5
 DefaultDirName={userpf}\MM Relay
 DefaultGroupName=MM Relay
 UninstallFilesDir={app}


### PR DESCRIPTION
Minor change in how much the relayed message is truncated, before sending to local meshnet