### PR TITLE
Consolidate new config fields

### DIFF
--- a/meshtastic_utils.py
+++ b/meshtastic_utils.py
@@ -40,17 +40,12 @@ def connect_meshtastic(force_connect=False):
                 meshtastic_client = meshtastic.serial_interface.SerialInterface(serial_port)
             
             elif connection_type == "ble":
-                ble_address = relay_config["meshtastic"].get("ble_address")
-                ble_name = relay_config["meshtastic"].get("ble_name")
-
-                if ble_address:
-                    logger.info(f"Connecting to BLE address {ble_address} ...")
-                    meshtastic_client = meshtastic.ble_interface.BLEInterface(address=ble_address)
-                elif ble_name:
-                    logger.info(f"Connecting to BLE name {ble_name} ...")
-                    meshtastic_client = meshtastic.ble_interface.BLEInterface(address=ble_name)
+                ble_node = relay_config["meshtastic"].get("ble_node")
+                if ble_node:
+                    logger.info(f"Connecting to BLE node {ble_node} ...")
+                    meshtastic_client = meshtastic.ble_interface.BLEInterface(address=ble_node)
                 else:
-                    logger.error("No BLE address or name provided.")
+                    logger.error("No BLE node provided.")
                     return None
             
             else:

--- a/sample_config.yaml
+++ b/sample_config.yaml
@@ -13,8 +13,7 @@ meshtastic:
   connection_type: serial # Choose either "network", "serial", or "ble"
   serial_port: /dev/ttyUSB0 # Only used when connection is "serial"
   host: "meshtastic.local" # Only used when connection is "network"
-  ble_address: "AA:BB:CC:DD:EE:FF" # Only used when connection is "ble" - Choose one. If used, don't set `ble_name`
-  ble_name: "Your BLE Name" # Only used when connection is "ble" - Choose one. If used, don't set `ble_address`
+  ble_node: "AA:BB:CC:DD:EE:FF" # Only used when connection is "ble" - Can be either an address or a name from a `meshtastic --ble-scan`
   meshnet_name: "Your Meshnet Name" # This is displayed in full on Matrix, but is truncated when sent to a Meshnet
   broadcast_enabled: true # Must be set to true to enable Matrix to Meshtastic messages
 


### PR DESCRIPTION
Consolidating `ble_address` and `ble_name` into `ble_node` where either an address or a name can be used.