### PR TITLE
Bump matplotlib version to latest

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ meshtastic
 Pillow==9.5.0
 py-staticmaps==0.4.0
 matrix-nio==0.20.2
-matplotlib==3.7.1
+matplotlib==3.9.0
 requests==2.31.0
 markdown==3.4.3
 haversine==2.8.0


### PR DESCRIPTION
Had to update matplotlib to 3.9.0 so the Windows installer builds correctly (hopefully)