### PR TITLE
Support messages sent by detection sensor module

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -48,6 +48,7 @@ meshtastic:
   host: "meshtastic.local" # Only used when connection is "network"
   meshnet_name: "Your Meshnet Name" # This is displayed in full on Matrix, but is truncated when sent to a Meshnet
   broadcast_enabled: true
+  detection_sensor: true
 
 logging:
   level: "info"

--- a/gui/config_editor.py
+++ b/gui/config_editor.py
@@ -132,12 +132,19 @@ def create_meshtastic_frame(root):
     broadcast_enabled_checkbox = tk.Checkbutton(frame, variable=broadcast_enabled_var)
     broadcast_enabled_checkbox.grid(row=4, column=1, sticky="w")
 
+    detection_sensor_label = tk.Label(frame, text="Detection Messages Enabled:")
+    detection_sensor_label.grid(row=5, column=0, sticky="w")
+    detection_sensor_var = tk.BooleanVar(value=config["meshtastic"]["detection_sensor"])
+    detection_sensor_checkbox = tk.Checkbutton(frame, variable=detection_sensor_var)
+    detection_sensor_checkbox.grid(row=5, column=1, sticky="w")
+
     return {
         "connection_type": connection_type_var,
         "serial_port": serial_port_var,
         "host": host_var,
         "meshnet_name": meshnet_name_var,
         "broadcast_enabled": broadcast_enabled_var,
+        "detection_sensor": detection_sensor_var
     }
 
 def create_logging_frame(root):

--- a/matrix_utils.py
+++ b/matrix_utils.py
@@ -18,6 +18,7 @@ from log_utils import get_logger
 from plugin_loader import load_plugins
 from meshtastic_utils import connect_meshtastic
 from PIL import Image
+import meshtastic.protobuf.portnums_pb2
 
 matrix_homeserver = relay_config["matrix"]["homeserver"]
 matrix_rooms: List[dict] = relay_config["matrix_rooms"]
@@ -93,7 +94,7 @@ async def join_matrix_room(matrix_client, room_id_or_alias: str) -> None:
 
 
 # Send message to the Matrix room
-async def matrix_relay(room_id, message, longname, shortname, meshnet_name):
+async def matrix_relay(room_id, message, longname, shortname, meshnet_name, portnum):
     matrix_client = await connect_matrix()
     try:
         content = {
@@ -102,6 +103,7 @@ async def matrix_relay(room_id, message, longname, shortname, meshnet_name):
             "meshtastic_longname": longname,
             "meshtastic_shortname": shortname,
             "meshtastic_meshnet": meshnet_name,
+            "meshtastic_portnum": portnum,
         }
         await asyncio.wait_for(
             matrix_client.room_send(
@@ -215,9 +217,16 @@ async def on_room_message(
             meshtastic_logger.info(
                 f"Relaying message from {full_display_name} to radio broadcast"
             )
-            meshtastic_interface.sendText(
-                text=full_message, channelIndex=meshtastic_channel
-            )
+            if event.source["content"].get("meshtastic_portnum") == "DETECTION_SENSOR_APP":
+                meshtastic_interface.sendData(
+                    data=full_message.encode('utf-8'),
+                    channelIndex=meshtastic_channel,
+                    portNum=meshtastic.protobuf.portnums_pb2.PortNum.DETECTION_SENSOR_APP,
+                )
+            else:
+                meshtastic_interface.sendText(
+                    text=full_message, channelIndex=meshtastic_channel
+                )
 
         else:
             logger.debug(

--- a/matrix_utils.py
+++ b/matrix_utils.py
@@ -214,16 +214,22 @@ async def on_room_message(
 
     if not found_matching_plugin and event.sender != bot_user_id:
         if relay_config["meshtastic"]["broadcast_enabled"]:
-            meshtastic_logger.info(
-                f"Relaying message from {full_display_name} to radio broadcast"
-            )
             if event.source["content"].get("meshtastic_portnum") == "DETECTION_SENSOR_APP":
-                meshtastic_interface.sendData(
-                    data=full_message.encode('utf-8'),
-                    channelIndex=meshtastic_channel,
-                    portNum=meshtastic.protobuf.portnums_pb2.PortNum.DETECTION_SENSOR_APP,
-                )
+                if relay_config["meshtastic"].get("detection_sensor", False):
+                    meshtastic_interface.sendData(
+                        data=full_message.encode("utf-8"),
+                        channelIndex=meshtastic_channel,
+                        portNum=meshtastic.protobuf.portnums_pb2.PortNum.DETECTION_SENSOR_APP,
+                    )
+                else:
+                    meshtastic_logger.debug(
+                        f"Detection sensor packet received from {full_display_name}, "
+                        + "but detection sensor processing is disabled."
+                    )
             else:
+                meshtastic_logger.info(
+                    f"Relaying message from {full_display_name} to radio broadcast"
+                )
                 meshtastic_interface.sendText(
                     text=full_message, channelIndex=meshtastic_channel
                 )

--- a/meshtastic_utils.py
+++ b/meshtastic_utils.py
@@ -237,6 +237,10 @@ def on_meshtastic_message(packet, interface):
         if not channel_mapped:
             logger.debug(f"Skipping message from unmapped channel {channel}")
             return
+        if (decoded.get("portnum") == "DETECTION_SENSOR_APP"
+            and not relay_config["meshtastic"].get("detection_sensor", False)):
+            logger.debug("Detection sensor packet received, but detection sensor processing is disabled.")
+            return
 
         logger.info(f"Processing inbound radio message from {sender} on channel {channel}")
 

--- a/meshtastic_utils.py
+++ b/meshtastic_utils.py
@@ -197,7 +197,6 @@ def on_meshtastic_message(packet, interface):
     """
     Handle incoming Meshtastic messages and relay them to Matrix.
     """
-    logger.info('on_meshtastic_message(packet=%r)', packet)
     from matrix_utils import matrix_relay
     global event_loop
 
@@ -221,6 +220,8 @@ def on_meshtastic_message(packet, interface):
         channel = packet.get("channel")
         if channel is None:
             if decoded.get("portnum") == "TEXT_MESSAGE_APP" or decoded.get("portnum") == 1:
+                channel = 0
+            elif decoded.get("portnum") == "DETECTION_SENSOR_APP":
                 channel = 0
             else:
                 logger.debug(f"Unknown portnum {decoded.get('portnum')}, cannot determine channel")
@@ -275,6 +276,7 @@ def on_meshtastic_message(packet, interface):
                         longname,
                         shortname,
                         meshnet_name,
+                        decoded.get("portnum"),
                     ),
                     loop=loop,
                 )

--- a/meshtastic_utils.py
+++ b/meshtastic_utils.py
@@ -197,6 +197,7 @@ def on_meshtastic_message(packet, interface):
     """
     Handle incoming Meshtastic messages and relay them to Matrix.
     """
+    logger.info('on_meshtastic_message(packet=%r)', packet)
     from matrix_utils import matrix_relay
     global event_loop
 

--- a/sample_config.yaml
+++ b/sample_config.yaml
@@ -16,6 +16,7 @@ meshtastic:
   ble_address: "AA:BB:CC:DD:EE:FF" # Only used when connection is "ble" - Uses either an address or name from a `meshtastic --ble-scan`
   meshnet_name: "Your Meshnet Name" # This is displayed in full on Matrix, but is truncated when sent to a Meshnet
   broadcast_enabled: true # Must be set to true to enable Matrix to Meshtastic messages
+  detection_sensor: true # Must be set to true to forward messages of Meshtastic's detection sensor module
 
 logging:
   level: "info"


### PR DESCRIPTION
Hi @jeremiah-k,

I created a draft supporting detection messages (https://meshtastic.org/docs/configuration/module/detection-sensor/)

Block invoking `meshtastic_interface.sendData(…)` is untested.
Remaining part tested successfully with meshtasticd v2.3.13.83f5ba0.

Could you review my changes? Thank you!

Solves second part of https://github.com/geoffwhittington/meshtastic-matrix-relay/issues/75


