### PR TITLE
Implemented initial fix to enable custom plugins

### DIFF
--- a/plugin_loader.py
+++ b/plugin_loader.py
@@ -1,9 +1,10 @@
+import os
+import importlib.util
 from log_utils import get_logger
 
 logger = get_logger(name="Plugins")
 
 sorted_active_plugins = []
-
 
 def load_plugins():
     from plugins.health_plugin import Plugin as HealthPlugin
@@ -21,6 +22,7 @@ def load_plugins():
     if sorted_active_plugins:
         return sorted_active_plugins
 
+    # List of core plugins
     plugins = [
         HealthPlugin(),
         MapPlugin(),
@@ -34,14 +36,25 @@ def load_plugins():
         DebugPlugin(),
     ]
 
+    # Load custom plugins from the 'custom_plugins' directory
+    custom_plugins_dir = os.path.join(os.path.dirname(__file__), 'custom_plugins')
+    if os.path.isdir(custom_plugins_dir):
+        for filename in os.listdir(custom_plugins_dir):
+            if filename.endswith('.py'):
+                plugin_path = os.path.join(custom_plugins_dir, filename)
+                spec = importlib.util.spec_from_file_location("custom_plugin", plugin_path)
+                custom_module = importlib.util.module_from_spec(spec)
+                spec.loader.exec_module(custom_module)
+                if hasattr(custom_module, 'Plugin'):
+                    plugins.append(custom_module.Plugin())
+                else:
+                    logger.warning(f"{filename} does not define a Plugin class.")
+
+    # Filter and sort active plugins by priority
     active_plugins = []
     for plugin in plugins:
-        if plugin.config["active"]:
-            plugin.priority = (
-                plugin.config["priority"]
-                if "priority" in plugin.config
-                else plugin.priority
-            )
+        if plugin.config.get("active", False):
+            plugin.priority = plugin.config.get("priority", plugin.priority)
             active_plugins.append(plugin)
             plugin.start()
 


### PR DESCRIPTION
The plugin loader was previously limited to loading only a predefined list of core plugins.

I added functionality to the load_plugins() function that allows it to load custom plugins from the custom_plugins directory. This includes dynamically importing each .py file in the directory, checking for the presence of a Plugin class, and then appending it to the plugins list if available.