### PR TITLE
Fix plugin loading issue in Windows

### DIFF
--- a/log_utils.py
+++ b/log_utils.py
@@ -24,11 +24,10 @@ def get_logger(name):
         # Default to `logs/mmrelay.log` if no filename is provided
         log_file = relay_config["logging"].get("filename", "logs/mmrelay.log")
 
-        # Only create directories if the path is not the default
-        if log_file != "logs/mmrelay.log":
-            log_dir = os.path.dirname(log_file)
-            if log_dir:  # Ensure non-empty directory paths exist
-                os.makedirs(log_dir, exist_ok=True)
+        # Always create directories regardless of the log file path
+        log_dir = os.path.dirname(log_file)
+        if log_dir:  # Ensure non-empty directory paths exist
+            os.makedirs(log_dir, exist_ok=True)
 
         # Set up size-based log rotation
         max_bytes = relay_config["logging"].get("max_log_size", 10 * 1024 * 1024)  # Default 10 MB

--- a/matrix_utils.py
+++ b/matrix_utils.py
@@ -228,9 +228,9 @@ async def on_room_message(
         text = truncate_message(text)
 
     # Plugin functionality
-    from plugin_loader import load_plugins  # Import here to avoid circular imports
+    import plugin_loader  # Import here to avoid circular imports
 
-    plugins = load_plugins()  # Load plugins within the function
+    plugins = plugin_loader.load_plugins()  # Load plugins within the function
 
     found_matching_plugin = False
     for plugin in plugins:

--- a/meshtastic_utils.py
+++ b/meshtastic_utils.py
@@ -233,6 +233,9 @@ def on_meshtastic_message(packet, interface):
     """
     Handle incoming Meshtastic messages and relay them to Matrix.
     """
+    # Import plugin_loader module to avoid circular imports
+    import plugin_loader  # Import here to avoid circular imports
+
     from matrix_utils import matrix_relay
 
     global event_loop
@@ -328,9 +331,7 @@ def on_meshtastic_message(packet, interface):
         formatted_message = f"[{longname}/{meshnet_name}]: {text}"
 
         # Plugin functionality
-        from plugin_loader import load_plugins  # Import here to avoid circular imports
-
-        plugins = load_plugins()  # Load plugins within the function
+        plugins = plugin_loader.load_plugins()  # Load plugins within the function
 
         found_matching_plugin = False
         for plugin in plugins:
@@ -367,9 +368,8 @@ def on_meshtastic_message(packet, interface):
     else:
         # Handle non-text messages via plugins
         portnum = decoded.get("portnum")
-        from plugin_loader import load_plugins  # Import here to avoid circular imports
 
-        plugins = load_plugins()
+        plugins = plugin_loader.load_plugins()
         found_matching_plugin = False
         for plugin in plugins:
             if not found_matching_plugin:


### PR DESCRIPTION
Switching from function imports to module imports for the plugin_loader to fix infinite loop that could occur when loading plugins with the Windows executable