### PR TITLE
Ironing out the last of the plugin loading issues (hopefully)

### DIFF
--- a/main.py
+++ b/main.py
@@ -43,9 +43,6 @@ async def main():
     # Initialize the SQLite database
     initialize_database()
 
-    # Load plugins early
-    load_plugins()
-
     # Connect to Meshtastic
     meshtastic_utils.meshtastic_client = connect_meshtastic()
 

--- a/main.py
+++ b/main.py
@@ -21,7 +21,7 @@ from matrix_utils import logger as matrix_logger
 from matrix_utils import on_room_message
 from meshtastic_utils import connect_meshtastic
 from meshtastic_utils import logger as meshtastic_logger
-from plugin_loader import load_plugins
+import plugin_loader  # Changed from 'from plugin_loader import load_plugins'
 
 # Initialize logger
 logger = get_logger(name="M<>M Relay")
@@ -42,6 +42,9 @@ async def main():
 
     # Initialize the SQLite database
     initialize_database()
+
+    # Load plugins early
+    plugin_loader.load_plugins()  # Updated function call
 
     # Connect to Meshtastic
     meshtastic_utils.meshtastic_client = connect_meshtastic()

--- a/matrix_utils.py
+++ b/matrix_utils.py
@@ -21,8 +21,10 @@ from PIL import Image
 from config import relay_config
 from log_utils import get_logger
 
-# Do not import plugin_loader here to avoid circular imports
 from meshtastic_utils import connect_meshtastic
+
+# Import plugin_loader module to access loaded plugins
+import plugin_loader
 
 # Extract Matrix configuration
 matrix_homeserver = relay_config["matrix"]["homeserver"]
@@ -228,9 +230,7 @@ async def on_room_message(
         text = truncate_message(text)
 
     # Plugin functionality
-    import plugin_loader  # Import here to avoid circular imports
-
-    plugins = plugin_loader.load_plugins()  # Load plugins within the function
+    plugins = plugin_loader.sorted_active_plugins  # Use loaded plugins
 
     found_matching_plugin = False
     for plugin in plugins:

--- a/meshtastic_utils.py
+++ b/meshtastic_utils.py
@@ -15,7 +15,8 @@ from config import relay_config
 from db_utils import get_longname, get_shortname, save_longname, save_shortname
 from log_utils import get_logger
 
-# Do not import plugin_loader here to avoid circular imports
+# Import plugin_loader module to access loaded plugins
+import plugin_loader
 
 # Extract matrix rooms configuration
 matrix_rooms: List[dict] = relay_config["matrix_rooms"]
@@ -233,9 +234,6 @@ def on_meshtastic_message(packet, interface):
     """
     Handle incoming Meshtastic messages and relay them to Matrix.
     """
-    # Import plugin_loader module to avoid circular imports
-    import plugin_loader  # Import here to avoid circular imports
-
     from matrix_utils import matrix_relay
 
     global event_loop
@@ -331,7 +329,7 @@ def on_meshtastic_message(packet, interface):
         formatted_message = f"[{longname}/{meshnet_name}]: {text}"
 
         # Plugin functionality
-        plugins = plugin_loader.load_plugins()  # Load plugins within the function
+        plugins = plugin_loader.sorted_active_plugins  # Use loaded plugins
 
         found_matching_plugin = False
         for plugin in plugins:
@@ -369,7 +367,7 @@ def on_meshtastic_message(packet, interface):
         # Handle non-text messages via plugins
         portnum = decoded.get("portnum")
 
-        plugins = plugin_loader.load_plugins()
+        plugins = plugin_loader.sorted_active_plugins  # Use loaded plugins
         found_matching_plugin = False
         for plugin in plugins:
             if not found_matching_plugin:

--- a/plugin_loader.py
+++ b/plugin_loader.py
@@ -8,9 +8,8 @@ from config import get_app_path, relay_config
 from log_utils import get_logger
 
 logger = get_logger(name="Plugins")
-sorted_active_plugins = []
 plugins_loaded = False
-
+sorted_active_plugins = []  # Store the loaded plugins here
 
 def clone_or_update_repo(repo_url, tag, plugins_dir):
     # Extract the repository name from the URL


### PR DESCRIPTION
Root Cause of the problem:

- Multiple Calls to load_plugins(): The load_plugins() function is being called in `main.py`, `meshtastic_utils.py`, and `matrix_utils.py`. Each call can cause the plugins to be reloaded, especially if the `plugins_loaded` flag isn't respected across modules due to import mechanisms.

- Global State Not Shared Properly: The plugins_loaded flag and the loaded plugins list might not be shared properly across modules due to the way Python handles module imports, especially when relative imports or certain packaging tools are involved.

Solution:

- Load Plugins Only Once: Modify the code to ensure that load_plugins() is called only once, ideally in `main.py`.

- Make Plugins Accessible Globally: Store the loaded plugins in a way that they can be accessed by other modules without re-importing or re-loading them.

- Avoid Multiple Calls to load_plugins(): Remove calls to load_plugins() from meshtastic_utils.py and matrix_utils.py.

- Use a Singleton Pattern or Module-Level Variable: Store the plugins list in a module-level variable in plugin_loader.py, which can be imported and accessed by other modules.