### PR TITLE
feat: Extend plugin configuration loader to support dynamic levels

### DIFF
--- a/plugins/base_plugin.py
+++ b/plugins/base_plugin.py
@@ -28,8 +28,12 @@ class BasePlugin(ABC):
         super().__init__()
         self.logger = get_logger(f"Plugin:{self.plugin_name}")
         self.config = {"active": False}
-        if "plugins" in relay_config and self.plugin_name in relay_config["plugins"]:
-            self.config = relay_config["plugins"][self.plugin_name]
+        plugin_levels = ["plugins", "community-plugins", "custom-plugins"]
+
+        for level in plugin_levels:
+            if level in relay_config and self.plugin_name in relay_config[level]:
+                self.config = relay_config[level][self.plugin_name]
+                break
 
     def start(self):
         if "schedule" not in self.config or (


### PR DESCRIPTION
### Problem

The configuration loader in BasePlugin was designed to load plugin configurations exclusively from the plugins section of config.yaml. This approach was rigid and incompatible with newer configuration structures that introduced sections like community-plugins and custom-plugins.

This limitation caused plugins defined outside the plugins section to fail to load their configurations.

### Solution

The configuration loader was enhanced to support dynamic levels (plugins, community-plugins, custom-plugins) without breaking existing setups:

- Added a list of levels to search for plugin configurations.
- Iterated through these levels to find the appropriate configuration for each plugin.
- Ensured backward compatibility by prioritizing plugins.

### Usage

Plugin developers can access their configuration options dynamically through self.config, which contains all the options defined in the configuration file for that plugin.

### Example:

```
gpx_directory = self.config.get("gpx_directory", "./default/path")
allowed_device_ids = self.config.get("allowed_device_ids", [])
```

### Backward Compatibility

- Existing plugins defined in plugins continue to work as before.
- Additional sections like community-plugins and custom-plugins are seamlessly supported.