### PR TITLE
Reactions prerelease adjustments

### DIFF
--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -7,12 +7,12 @@ cli:
 plugins:
   sources:
     - id: trunk
-      ref: v1.6.5
+      ref: v1.6.6
       uri: https://github.com/trunk-io/plugins
 # Many linters and tools depend on runtimes - configure them here. (https://docs.trunk.io/runtimes)
 runtimes:
   enabled:
-    - node@18.12.1
+    - node@18.20.5
     - python@3.10.8
 # This is the section where you manage your linters. (https://docs.trunk.io/check/configuration)
 lint:
@@ -21,14 +21,14 @@ lint:
     - actionlint@1.7.4
     - bandit@1.8.0
     - black@24.10.0
-    - checkov@3.2.317
+    - checkov@3.2.334
     - git-diff-check
     - isort@5.13.2
     - markdownlint@0.43.0
     - osv-scanner@1.9.1
-    - prettier@3.4.1
-    - ruff@0.8.0
-    - trufflehog@3.84.1
+    - prettier@3.4.2
+    - ruff@0.8.3
+    - trufflehog@3.86.1
     - yamllint@1.35.1
 actions:
   disabled:

--- a/db_utils.py
+++ b/db_utils.py
@@ -5,6 +5,7 @@ from log_utils import get_logger
 
 logger = get_logger(name="db_utils")
 
+
 # Initialize SQLite database
 def initialize_database():
     with sqlite3.connect("meshtastic.sqlite") as conn:
@@ -37,6 +38,7 @@ def initialize_database():
 
         conn.commit()
 
+
 def store_plugin_data(plugin_name, meshtastic_id, data):
     with sqlite3.connect("meshtastic.sqlite") as conn:
         cursor = conn.cursor()
@@ -46,6 +48,7 @@ def store_plugin_data(plugin_name, meshtastic_id, data):
         )
         conn.commit()
 
+
 def delete_plugin_data(plugin_name, meshtastic_id):
     with sqlite3.connect("meshtastic.sqlite") as conn:
         cursor = conn.cursor()
@@ -54,6 +57,7 @@ def delete_plugin_data(plugin_name, meshtastic_id):
             (plugin_name, meshtastic_id),
         )
         conn.commit()
+
 
 # Get the data for a given plugin and Meshtastic ID
 def get_plugin_data_for_node(plugin_name, meshtastic_id):
@@ -69,6 +73,7 @@ def get_plugin_data_for_node(plugin_name, meshtastic_id):
         result = cursor.fetchone()
     return json.loads(result[0] if result else "[]")
 
+
 # Get the data for a given plugin
 def get_plugin_data(plugin_name):
     with sqlite3.connect("meshtastic.sqlite") as conn:
@@ -78,6 +83,7 @@ def get_plugin_data(plugin_name):
             (plugin_name,),
         )
         return cursor.fetchall()
+
 
 # Get the longname for a given Meshtastic ID
 def get_longname(meshtastic_id):
@@ -89,6 +95,7 @@ def get_longname(meshtastic_id):
         result = cursor.fetchone()
     return result[0] if result else None
 
+
 def save_longname(meshtastic_id, longname):
     with sqlite3.connect("meshtastic.sqlite") as conn:
         cursor = conn.cursor()
@@ -97,6 +104,7 @@ def save_longname(meshtastic_id, longname):
             (meshtastic_id, longname),
         )
         conn.commit()
+
 
 def update_longnames(nodes):
     if nodes:
@@ -107,6 +115,7 @@ def update_longnames(nodes):
                 longname = user.get("longName", "N/A")
                 save_longname(meshtastic_id, longname)
 
+
 def get_shortname(meshtastic_id):
     with sqlite3.connect("meshtastic.sqlite") as conn:
         cursor = conn.cursor()
@@ -115,6 +124,7 @@ def get_shortname(meshtastic_id):
         )
         result = cursor.fetchone()
     return result[0] if result else None
+
 
 def save_shortname(meshtastic_id, shortname):
     with sqlite3.connect("meshtastic.sqlite") as conn:
@@ -125,6 +135,7 @@ def save_shortname(meshtastic_id, shortname):
         )
         conn.commit()
 
+
 def update_shortnames(nodes):
     if nodes:
         for node in nodes.values():
@@ -134,7 +145,14 @@ def update_shortnames(nodes):
                 shortname = user.get("shortName", "N/A")
                 save_shortname(meshtastic_id, shortname)
 
-def store_message_map(meshtastic_id, matrix_event_id, matrix_room_id, meshtastic_text, meshtastic_meshnet=None):
+
+def store_message_map(
+    meshtastic_id,
+    matrix_event_id,
+    matrix_room_id,
+    meshtastic_text,
+    meshtastic_meshnet=None,
+):
     """
     Stores a message map in the database.
 
@@ -152,9 +170,16 @@ def store_message_map(meshtastic_id, matrix_event_id, matrix_room_id, meshtastic
         )
         cursor.execute(
             "INSERT OR REPLACE INTO message_map (meshtastic_id, matrix_event_id, matrix_room_id, meshtastic_text, meshtastic_meshnet) VALUES (?, ?, ?, ?, ?)",
-            (meshtastic_id, matrix_event_id, matrix_room_id, meshtastic_text, meshtastic_meshnet),
+            (
+                meshtastic_id,
+                matrix_event_id,
+                matrix_room_id,
+                meshtastic_text,
+                meshtastic_meshnet,
+            ),
         )
         conn.commit()
+
 
 def get_message_map_by_meshtastic_id(meshtastic_id):
     with sqlite3.connect("meshtastic.sqlite") as conn:
@@ -172,6 +197,7 @@ def get_message_map_by_meshtastic_id(meshtastic_id):
             return result[0], result[1], result[2], result[3]
         return None
 
+
 def get_message_map_by_matrix_event_id(matrix_event_id):
     with sqlite3.connect("meshtastic.sqlite") as conn:
         cursor = conn.cursor()
@@ -188,6 +214,7 @@ def get_message_map_by_matrix_event_id(matrix_event_id):
             return result[0], result[1], result[2], result[3]
         return None
 
+
 def wipe_message_map():
     """
     Wipes all entries from the message_map table.
@@ -198,6 +225,7 @@ def wipe_message_map():
         cursor.execute("DELETE FROM message_map")
         conn.commit()
     logger.info("message_map table wiped successfully.")
+
 
 def prune_message_map(msgs_to_keep):
     """
@@ -222,7 +250,9 @@ def prune_message_map(msgs_to_keep):
             to_delete = total - msgs_to_keep
             cursor.execute(
                 "DELETE FROM message_map WHERE rowid IN (SELECT rowid FROM message_map ORDER BY rowid ASC LIMIT ?)",
-                (to_delete,)
+                (to_delete,),
             )
             conn.commit()
-            logger.info(f"Pruned {to_delete} old message_map entries, keeping last {msgs_to_keep}.")
+            logger.info(
+                f"Pruned {to_delete} old message_map entries, keeping last {msgs_to_keep}."
+            )

--- a/log_utils.py
+++ b/log_utils.py
@@ -40,7 +40,7 @@ def get_logger(name):
             "backup_count", 1
         )  # Default to 1 backup
         file_handler = RotatingFileHandler(
-            log_file, maxBytes=max_bytes, backupCount=backup_count, encoding='utf-8'
+            log_file, maxBytes=max_bytes, backupCount=backup_count, encoding="utf-8"
         )
 
         file_handler.setFormatter(

--- a/main.py
+++ b/main.py
@@ -9,12 +9,17 @@ import signal
 import sys
 from typing import List
 
-from nio import RoomMessageNotice, RoomMessageText, ReactionEvent, RoomMessageEmote
+from nio import ReactionEvent, RoomMessageEmote, RoomMessageNotice, RoomMessageText
 
 # Import meshtastic_utils as a module to set event_loop
 import meshtastic_utils
 from config import relay_config
-from db_utils import initialize_database, update_longnames, update_shortnames, wipe_message_map
+from db_utils import (
+    initialize_database,
+    update_longnames,
+    update_shortnames,
+    wipe_message_map,
+)
 from log_utils import get_logger
 from matrix_utils import connect_matrix, join_matrix_room
 from matrix_utils import logger as matrix_logger

--- a/meshtastic_utils.py
+++ b/meshtastic_utils.py
@@ -12,7 +12,13 @@ from bleak.exc import BleakDBusError, BleakError
 from pubsub import pub
 
 from config import relay_config
-from db_utils import get_longname, get_shortname, save_longname, save_shortname, get_message_map_by_meshtastic_id
+from db_utils import (
+    get_longname,
+    get_message_map_by_meshtastic_id,
+    get_shortname,
+    save_longname,
+    save_shortname,
+)
 from log_utils import get_logger
 
 # Do not import plugin_loader here to avoid circular imports
@@ -27,11 +33,14 @@ logger = get_logger(name="Meshtastic")
 meshtastic_client = None
 event_loop = None  # Will be set from main.py
 
-meshtastic_lock = threading.Lock()  # To prevent race conditions on meshtastic_client access
+meshtastic_lock = (
+    threading.Lock()
+)  # To prevent race conditions on meshtastic_client access
 
 reconnecting = False
 shutting_down = False
 reconnect_task = None  # To keep track of the reconnect task
+
 
 def serial_port_exists(port_name):
     """
@@ -40,6 +49,7 @@ def serial_port_exists(port_name):
     """
     ports = [port.device for port in serial.tools.list_ports.comports()]
     return port_name in ports
+
 
 def connect_meshtastic(force_connect=False):
     """
@@ -141,7 +151,9 @@ def connect_meshtastic(force_connect=False):
                     break
                 attempts += 1
                 if retry_limit == 0 or attempts <= retry_limit:
-                    wait_time = min(attempts * 2, 30)  # Exponential backoff capped at 30s
+                    wait_time = min(
+                        attempts * 2, 30
+                    )  # Exponential backoff capped at 30s
                     logger.warning(
                         f"Attempt #{attempts - 1} failed. Retrying in {wait_time} secs: {e}"
                     )
@@ -151,6 +163,7 @@ def connect_meshtastic(force_connect=False):
                     return None
 
     return meshtastic_client
+
 
 def on_lost_meshtastic_connection(interface=None):
     """
@@ -186,6 +199,7 @@ def on_lost_meshtastic_connection(interface=None):
         if event_loop:
             reconnect_task = asyncio.run_coroutine_threadsafe(reconnect(), event_loop)
 
+
 async def reconnect():
     """
     Asynchronously attempts to reconnect with exponential backoff.
@@ -219,6 +233,7 @@ async def reconnect():
     finally:
         reconnecting = False
 
+
 def on_meshtastic_message(packet, interface):
     """
     Handle incoming Meshtastic messages. For reaction messages, if relay_reactions is False,
@@ -229,10 +244,12 @@ def on_meshtastic_message(packet, interface):
     relay_reactions = relay_config["meshtastic"].get("relay_reactions", False)
 
     # If relay_reactions is False, filter out reaction/tapback packets to avoid complexity
-    if packet.get('decoded', {}).get('portnum') == 'TEXT_MESSAGE_APP':
-        decoded = packet.get('decoded', {})
-        if not relay_reactions and ('emoji' in decoded or 'replyId' in decoded):
-            logger.debug('Filtered out reaction/tapback packet due to relay_reactions=false.')
+    if packet.get("decoded", {}).get("portnum") == "TEXT_MESSAGE_APP":
+        decoded = packet.get("decoded", {})
+        if not relay_reactions and ("emoji" in decoded or "replyId" in decoded):
+            logger.debug(
+                "Filtered out reaction/tapback packet due to relay_reactions=false."
+            )
             return
 
     from matrix_utils import matrix_relay
@@ -255,10 +272,11 @@ def on_meshtastic_message(packet, interface):
     decoded = packet.get("decoded", {})
     text = decoded.get("text")
     replyId = decoded.get("replyId")
-    emoji_flag = 'emoji' in decoded and decoded['emoji'] == 1
+    emoji_flag = "emoji" in decoded and decoded["emoji"] == 1
 
     # Determine if this is a direct message to the relay node
     from meshtastic.mesh_interface import BROADCAST_NUM
+
     myId = interface.myInfo.my_node_num
 
     if toId == myId:
@@ -280,13 +298,17 @@ def on_meshtastic_message(packet, interface):
         if orig:
             # orig = (matrix_event_id, matrix_room_id, meshtastic_text, meshtastic_meshnet)
             matrix_event_id, matrix_room_id, meshtastic_text, meshtastic_meshnet = orig
-            abbreviated_text = meshtastic_text[:40] + "..." if len(meshtastic_text) > 40 else meshtastic_text
+            abbreviated_text = (
+                meshtastic_text[:40] + "..."
+                if len(meshtastic_text) > 40
+                else meshtastic_text
+            )
 
             # Ensure that meshnet_name is always included, using our own meshnet for accuracy.
             full_display_name = f"{longname}/{meshnet_name}"
 
-            reaction_symbol = text.strip() if (text and text.strip()) else '⚠️'
-            reaction_message = f"\n [{full_display_name}] reacted {reaction_symbol} to \"{abbreviated_text}\""
+            reaction_symbol = text.strip() if (text and text.strip()) else "⚠️"
+            reaction_message = f'\n [{full_display_name}] reacted {reaction_symbol} to "{abbreviated_text}"'
 
             # Relay the reaction as emote to Matrix, preserving the original meshnet name
             asyncio.run_coroutine_threadsafe(
@@ -301,7 +323,7 @@ def on_meshtastic_message(packet, interface):
                     meshtastic_replyId=replyId,
                     meshtastic_text=meshtastic_text,
                     emote=True,
-                    emoji=True
+                    emoji=True,
                 ),
                 loop=loop,
             )
@@ -340,7 +362,9 @@ def on_meshtastic_message(packet, interface):
             return
 
         # If detection_sensor is disabled and this is a detection sensor packet, skip it
-        if decoded.get("portnum") == "DETECTION_SENSOR_APP" and not relay_config["meshtastic"].get("detection_sensor", False):
+        if decoded.get("portnum") == "DETECTION_SENSOR_APP" and not relay_config[
+            "meshtastic"
+        ].get("detection_sensor", False):
             logger.debug(
                 "Detection sensor packet received, but detection sensor processing is disabled."
             )
@@ -376,6 +400,7 @@ def on_meshtastic_message(packet, interface):
 
         # Plugin functionality - Check if any plugin handles this message before relaying
         from plugin_loader import load_plugins
+
         plugins = load_plugins()
 
         found_matching_plugin = False
@@ -419,7 +444,7 @@ def on_meshtastic_message(packet, interface):
                         meshnet_name,
                         decoded.get("portnum"),
                         meshtastic_id=packet.get("id"),
-                        meshtastic_text=text
+                        meshtastic_text=text,
                     ),
                     loop=loop,
                 )
@@ -427,6 +452,7 @@ def on_meshtastic_message(packet, interface):
         # Non-text messages via plugins
         portnum = decoded.get("portnum")
         from plugin_loader import load_plugins
+
         plugins = load_plugins()
         found_matching_plugin = False
         for plugin in plugins:
@@ -446,6 +472,7 @@ def on_meshtastic_message(packet, interface):
                         f"Processed {portnum} with plugin {plugin.plugin_name}"
                     )
 
+
 async def check_connection():
     """
     Periodically checks the Meshtastic connection by sending a ping.
@@ -461,6 +488,7 @@ async def check_connection():
                 logger.error(f"{connection_type.capitalize()} connection lost: {e}")
                 on_lost_meshtastic_connection(meshtastic_client)
         await asyncio.sleep(5)  # Check connection every 5 seconds
+
 
 if __name__ == "__main__":
     # If running this standalone (normally the main.py does the loop), just try connecting and run forever.

--- a/sample_config.yaml
+++ b/sample_config.yaml
@@ -27,6 +27,11 @@ logging:
   #max_log_size: 10485760       # 10 MB default if omitted
   #backup_count: 1              # Keeps 1 backup as the default if omitted
 
+#db:
+#  msg_map: # The message map is necessary for the relay_reactions functionality. If `relay_reactions` is set to false, nothing will be saved to the message map.
+#    msgs_to_keep: 500 # If set to 0, it will not delete any messages; Defaults to 500
+#    wipe_on_restart: true # Clears out the message map when the relay is restarted; Defaults to False
+
 # These are core Plugins - Note: Some plugins are experimental and some need maintenance.
 plugins:
   ping:


### PR DESCRIPTION
Implemented the logic for:

- Defaulting relay_reactions to False.
- Not storing message_map entries unless relay_reactions is True.
- Implementing wipe_on_restart to clear message_map on startup and shutdown.
- Implementing msgs_to_keep to prune the message_map after each storage operation.