### PR TITLE
Snr and air_util_tx filter

### DIFF
--- a/plugins/health_plugin.py
+++ b/plugins/health_plugin.py
@@ -26,7 +26,9 @@ class Plugin(BasePlugin):
                     air_util_tx.append(info["deviceMetrics"]["airUtilTx"])
             if "snr" in info:
                 snr.append(info["snr"])
-        #filter out none type values from snr
+        print(str(snr))
+        #filter out none type values from snr and air_util_tx just in case
+        air_util_tx = [value for value in air_util_tx if value is not None]
         snr = [value for value in snr if value is not None]
 
         low_battery = len([n for n in battery_levels if n <= 10])

--- a/plugins/health_plugin.py
+++ b/plugins/health_plugin.py
@@ -26,6 +26,8 @@ class Plugin(BasePlugin):
                     air_util_tx.append(info["deviceMetrics"]["airUtilTx"])
             if "snr" in info:
                 snr.append(info["snr"])
+        #filter out none type values from snr
+        snr = [value for value in snr if value is not None]
 
         low_battery = len([n for n in battery_levels if n <= 10])
         radios = len(meshtastic_client.nodes)


### PR DESCRIPTION
I have implemented a simple filter to remove None values from snr and air_util_tx variable from health report. This could be just fix for a minor firmware bug. Fixes  #126