### PR TITLE
Fix plugin system issues with directory selection, dependency handling, and branch/tag support

### DIFF
--- a/src/mmrelay/plugin_loader.py
+++ b/src/mmrelay/plugin_loader.py
@@ -524,7 +524,7 @@ def load_plugins(passed_config=None):
 
     # Get the first directory for cloning (prefer user directory)
     community_plugins_dir = community_plugin_dirs[
-        -1
+        0
     ]  # Use the user directory for new clones
 
     # Create community plugins directory if needed

--- a/src/mmrelay/plugin_loader.py
+++ b/src/mmrelay/plugin_loader.py
@@ -110,7 +110,10 @@ def clone_or_update_repo(repo_url, ref, plugins_dir):
                         subprocess.check_call(
                             ["git", "-C", repo_path, "pull", "origin", ref_value]
                         )
-                        logger.info(f"Switched to and updated branch {ref_value}")
+                        if ref_type == "branch":
+                            logger.info(f"Switched to and updated branch {ref_value}")
+                        else:
+                            logger.info(f"Switched to and updated tag {ref_value}")
                         return True
                 except subprocess.CalledProcessError:
                     # If we can't checkout the specified branch, try the other default branch
@@ -161,7 +164,10 @@ def clone_or_update_repo(repo_url, ref, plugins_dir):
 
                     # Otherwise, try to checkout the tag
                     subprocess.check_call(["git", "-C", repo_path, "checkout", ref_value])
-                    logger.info(f"Updated repository {repo_name} to tag {ref_value}")
+                    if ref_type == "branch":
+                        logger.info(f"Updated repository {repo_name} to branch {ref_value}")
+                    else:
+                        logger.info(f"Updated repository {repo_name} to tag {ref_value}")
                     return True
                 except subprocess.CalledProcessError:
                     # If tag checkout fails, try to fetch it specifically
@@ -206,7 +212,10 @@ def clone_or_update_repo(repo_url, ref, plugins_dir):
                             )
 
                         subprocess.check_call(["git", "-C", repo_path, "checkout", ref_value])
-                        logger.info(f"Successfully fetched and checked out tag {ref_value}")
+                        if ref_type == "branch":
+                            logger.info(f"Successfully fetched and checked out branch {ref_value}")
+                        else:
+                            logger.info(f"Successfully fetched and checked out tag {ref_value}")
                         return True
                     except subprocess.CalledProcessError:
                         # If that fails too, try as a branch
@@ -281,9 +290,14 @@ def clone_or_update_repo(repo_url, ref, plugins_dir):
                     subprocess.check_call(
                         ["git", "clone", "--branch", ref_value, repo_url], cwd=plugins_dir
                     )
-                    logger.info(
-                        f"Cloned repository {repo_name} from {repo_url} at branch {ref_value}"
-                    )
+                    if ref_type == "branch":
+                        logger.info(
+                            f"Cloned repository {repo_name} from {repo_url} at branch {ref_value}"
+                        )
+                    else:
+                        logger.info(
+                            f"Cloned repository {repo_name} from {repo_url} at tag {ref_value}"
+                        )
                     return True
                 except subprocess.CalledProcessError:
                     # If that fails, try the other default branch
@@ -319,9 +333,14 @@ def clone_or_update_repo(repo_url, ref, plugins_dir):
                     subprocess.check_call(
                         ["git", "clone", "--branch", ref_value, repo_url], cwd=plugins_dir
                     )
-                    logger.info(
-                        f"Cloned repository {repo_name} from {repo_url} at tag {ref_value}"
-                    )
+                    if ref_type == "branch":
+                        logger.info(
+                            f"Cloned repository {repo_name} from {repo_url} at branch {ref_value}"
+                        )
+                    else:
+                        logger.info(
+                            f"Cloned repository {repo_name} from {repo_url} at tag {ref_value}"
+                        )
                     return True
                 except subprocess.CalledProcessError:
                     # If that fails, clone without specifying a tag
@@ -359,9 +378,14 @@ def clone_or_update_repo(repo_url, ref, plugins_dir):
 
                         # Now checkout the tag
                         subprocess.check_call(["git", "-C", repo_path, "checkout", ref_value])
-                        logger.info(
-                            f"Cloned repository {repo_name} and checked out tag {ref_value}"
-                        )
+                        if ref_type == "branch":
+                            logger.info(
+                                f"Cloned repository {repo_name} and checked out branch {ref_value}"
+                            )
+                        else:
+                            logger.info(
+                                f"Cloned repository {repo_name} and checked out tag {ref_value}"
+                            )
                         return True
                     except subprocess.CalledProcessError:
                         # If that fails, try as a branch


### PR DESCRIPTION
This PR addresses several issues with the plugin system:

1. **Fixed plugin directory selection**
   - Changed the index from `-1` to `0` to use the user's ~/.mmrelay/plugins/community/ directory
   - This ensures plugins are cloned to the correct location regardless of installation method
   - Fixes the issue where plugins were being cloned to the site-packages directory

2. **Added automatic dependency installation**
   - Automatically detects if mmrelay is installed with pipx or pip
   - Uses the appropriate method to install missing dependencies (pipx inject or pip install)
   - Provides helpful error messages if automatic installation fails
   - Handles requirements.txt files for both pipx and pip installations

3. **Added separate tag and branch parameters**
   - Added support for both `tag` and `branch` parameters in config.yaml
   - Prioritizes tag over branch if both are specified
   - Defaults to 'main' branch if neither is specified
   - Logs clear messages about which reference type is being used

4. **Improved error handling and logging**
   - Added more detailed error messages for missing dependencies
   - Updated all log messages to correctly indicate whether a branch or tag is being used
   - Added plugin directory paths to error messages for easier troubleshooting
