### PR TITLE
Fix pipx installation issues and improve template file handling

### DIFF
--- a/.github/workflows/build-pyz-armv7.yml
+++ b/.github/workflows/build-pyz-armv7.yml
@@ -31,6 +31,12 @@ jobs:
           echo "Extracted version: $VERSION"
           GIT_SHA=$(git rev-parse --short HEAD)
           echo "GIT_SHA=$GIT_SHA" >> $GITHUB_ENV
+          # Set FILE_VERSION to just the version for releases, or version-dev-SHA for PRs/manual runs
+          if [ "${{ github.event_name }}" == "release" ]; then
+            echo "FILE_VERSION=$VERSION" >> $GITHUB_ENV
+          else
+            echo "FILE_VERSION=$VERSION-dev-$GIT_SHA" >> $GITHUB_ENV
+          fi
 
       - name: Build inside ARMv7 Docker (shiv, rustup, fixed cargo config)
         uses: addnab/docker-run-action@v3
@@ -59,18 +65,18 @@ jobs:
               --compile-pyc \
               --reproducible \
               --entry-point mmrelay.cli:main \
-              --output-file dist/mmrelay-${{ env.VERSION }}-dev-${{ env.GIT_SHA }}-armv7.pyz \
+              --output-file dist/mmrelay-${{ env.FILE_VERSION }}-armv7.pyz \
               .
 
             # Test the PYZ file
             echo "--- Testing PYZ file ---"
-            chmod +x dist/mmrelay-${{ env.VERSION }}-dev-${{ env.GIT_SHA }}-armv7.pyz
-            dist/mmrelay-${{ env.VERSION }}-dev-${{ env.GIT_SHA }}-armv7.pyz --version || echo "PYZ test failed"
+            chmod +x dist/mmrelay-${{ env.FILE_VERSION }}-armv7.pyz
+            dist/mmrelay-${{ env.FILE_VERSION }}-armv7.pyz --version || echo "PYZ test failed"
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
-          name: mmrelay-${{ env.VERSION }}-dev-${{ env.GIT_SHA }}-armv7
+          name: mmrelay-${{ env.FILE_VERSION }}-armv7
           path: dist/*.pyz
 
       - name: Upload PYZ to GitHub Release

--- a/.github/workflows/package-windows.yml
+++ b/.github/workflows/package-windows.yml
@@ -32,6 +32,12 @@ jobs:
           echo "Extracted version: $VERSION"
           GIT_SHA=$(git rev-parse --short HEAD)
           echo "GIT_SHA=$GIT_SHA" >> $GITHUB_ENV
+          # Set FILE_VERSION to just the version for releases, or version-dev-SHA for PRs/manual runs
+          if [ "${{ github.event_name }}" == "release" ]; then
+            echo "FILE_VERSION=$VERSION" >> $GITHUB_ENV
+          else
+            echo "FILE_VERSION=$VERSION-dev-$GIT_SHA" >> $GITHUB_ENV
+          fi
 
       - name: Install dependencies
         run: |
@@ -45,20 +51,20 @@ jobs:
       - name: Build installer
         uses: nadeemjazmawe/inno-setup-action-cli@v6.0.5
         with:
-          filepath: "/DAppVersion=${{ env.VERSION }}-dev-${{ env.GIT_SHA }} ./mmrelay.iss"
+          filepath: "/DAppVersion=${{ env.FILE_VERSION }} ./mmrelay.iss"
 
       - name: Upload installer as artifact
         uses: actions/upload-artifact@v4
         with:
-          name: MMRelay_setup_${{ env.VERSION }}-dev-${{ env.GIT_SHA }}
-          path: MMRelay_setup_${{ env.VERSION }}-dev-${{ env.GIT_SHA }}.exe
+          name: MMRelay_setup_${{ env.FILE_VERSION }}
+          path: MMRelay_setup_${{ env.FILE_VERSION }}.exe
 
       - name: Upload installer to GitHub Release
         if: github.event_name == 'release'
         uses: svenstaro/upload-release-action@v2
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
-          file: MMRelay_setup_${{ env.VERSION }}-dev-${{ env.GIT_SHA }}.exe
-          asset_name: MMRelay_setup_${{ env.VERSION }}-dev-${{ env.GIT_SHA }}.exe
+          file: MMRelay_setup_${{ env.FILE_VERSION }}.exe
+          asset_name: MMRelay_setup_${{ env.FILE_VERSION }}.exe
           tag: ${{ github.ref }}
           overwrite: true

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ schedule==1.2.2
 platformdirs==4.3.7
 py-staticmaps>=0.4.0
 rich==14.0.0
+setuptools==80.3.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -34,6 +34,7 @@ install_requires =
     py-staticmaps>=0.4.0
     rich==14.0.0
     setuptools==80.3.1
+include_package_data = True
 
 [options.packages.find]
 where = src

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = mmrelay
-version = 1.0.5
+version = 1.0.6
 author = Geoff Whittington, Jeremiah K., and contributors
 author_email = jeremiahk@gmx.com
 description = Bridge between Meshtastic mesh networks and Matrix chat rooms

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,6 +33,7 @@ install_requires =
     platformdirs==4.3.7
     py-staticmaps>=0.4.0
     rich==14.0.0
+    setuptools==80.3.1
 
 [options.packages.find]
 where = src


### PR DESCRIPTION
Fix pipx installation issues and improve template file handling for v1.0.6

This PR addresses several issues with pipx installations:

1. Fixes the "ModuleNotFoundError: No module named 'pkg_resources'" error by adding setuptools as an explicit dependency
2. Ensures template files (sample_config.yaml and mmrelay.service) are properly included in the wheel by adding include_package_data=True
3. Improves the service template file lookup to check in more locations
4. Adds a fallback template for the service file in case it can't be found