### PR TITLE
Simplify Plugin Initialization

### DIFF
--- a/src/mmrelay/plugins/base_plugin.py
+++ b/src/mmrelay/plugins/base_plugin.py
@@ -69,6 +69,8 @@ class BasePlugin(ABC):
                 room.get("meshtastic_channel")
                 for room in config.get("matrix_rooms", [])
             ]
+        else:
+            self.mapped_channels = []
 
         # Get the channels specified for this plugin, or default to all mapped channels
         self.channels = self.config.get("channels", self.mapped_channels)

--- a/src/mmrelay/plugins/base_plugin.py
+++ b/src/mmrelay/plugins/base_plugin.py
@@ -29,25 +29,28 @@ class BasePlugin(ABC):
     def description(self):
         return ""
 
-    def __init__(self) -> None:
-        # IMPORTANT NOTE FOR PLUGIN DEVELOPERS:
-        # When creating a plugin that inherits from BasePlugin, you MUST set
-        # self.plugin_name in your __init__ method BEFORE calling super().__init__()
-        # Example:
-        #   def __init__(self):
-        #       self.plugin_name = "your_plugin_name"  # Set this FIRST
-        #       super().__init__()                     # Then call parent
-        #
-        # Failure to do this will cause command recognition issues and other problems.
-
+    def __init__(self, plugin_name=None) -> None:
+        # Allow plugin_name to be passed as a parameter for simpler initialization
+        # This maintains backward compatibility while providing a cleaner API
         super().__init__()
 
-        # Verify plugin_name is properly defined
+        # If plugin_name is provided as a parameter, use it
+        if plugin_name is not None:
+            self.plugin_name = plugin_name
+
+        # For backward compatibility: if plugin_name is not provided as a parameter,
+        # check if it's set as an instance attribute (old way) or use the class attribute
         if not hasattr(self, "plugin_name") or self.plugin_name is None:
-            raise ValueError(
-                f"{self.__class__.__name__} is missing plugin_name definition. "
-                f"Make sure to set self.plugin_name BEFORE calling super().__init__()"
-            )
+            # Try to get the class-level plugin_name
+            class_plugin_name = getattr(self.__class__, "plugin_name", None)
+            if class_plugin_name is not None:
+                self.plugin_name = class_plugin_name
+            else:
+                raise ValueError(
+                    f"{self.__class__.__name__} is missing plugin_name definition. "
+                    f"Either set class.plugin_name, pass plugin_name to __init__, "
+                    f"or set self.plugin_name before calling super().__init__()"
+                )
 
         self.logger = get_logger(f"Plugin:{self.plugin_name}")
         self.config = {"active": False}

--- a/src/mmrelay/plugins/drop_plugin.py
+++ b/src/mmrelay/plugins/drop_plugin.py
@@ -10,9 +10,8 @@ class Plugin(BasePlugin):
     plugin_name = "drop"
     special_node = "!NODE_MSGS!"
 
-    def __init__(self):
-        self.plugin_name = "drop"
-        super().__init__()
+    # No __init__ method needed with the simplified plugin system
+    # The BasePlugin will automatically use the class-level plugin_name
 
     def get_position(self, meshtastic_client, node_id):
         for _node, info in meshtastic_client.nodes.items():

--- a/src/mmrelay/plugins/help_plugin.py
+++ b/src/mmrelay/plugins/help_plugin.py
@@ -7,9 +7,8 @@ from mmrelay.plugins.base_plugin import BasePlugin
 class Plugin(BasePlugin):
     plugin_name = "help"
 
-    def __init__(self):
-        self.plugin_name = "help"
-        super().__init__()
+    # No __init__ method needed with the simplified plugin system
+    # The BasePlugin will automatically use the class-level plugin_name
 
     @property
     def description(self):

--- a/src/mmrelay/plugins/map_plugin.py
+++ b/src/mmrelay/plugins/map_plugin.py
@@ -235,9 +235,8 @@ async def send_image(client: AsyncClient, room_id: str, image: Image.Image):
 class Plugin(BasePlugin):
     plugin_name = "map"
 
-    def __init__(self):
-        self.plugin_name = "map"
-        super().__init__()
+    # No __init__ method needed with the simplified plugin system
+    # The BasePlugin will automatically use the class-level plugin_name
 
     @property
     def description(self):

--- a/src/mmrelay/plugins/ping_plugin.py
+++ b/src/mmrelay/plugins/ping_plugin.py
@@ -17,9 +17,8 @@ class Plugin(BasePlugin):
     plugin_name = "ping"
     punctuation = string.punctuation
 
-    def __init__(self):
-        self.plugin_name = "ping"
-        super().__init__()
+    # No __init__ method needed with the simplified plugin system
+    # The BasePlugin will automatically use the class-level plugin_name
 
     @property
     def description(self):

--- a/src/mmrelay/plugins/weather_plugin.py
+++ b/src/mmrelay/plugins/weather_plugin.py
@@ -9,9 +9,8 @@ from mmrelay.plugins.base_plugin import BasePlugin
 class Plugin(BasePlugin):
     plugin_name = "weather"
 
-    def __init__(self):
-        self.plugin_name = "weather"
-        super().__init__()
+    # No __init__ method needed with the simplified plugin system
+    # The BasePlugin will automatically use the class-level plugin_name
 
     @property
     def description(self):


### PR DESCRIPTION
Title: Simplify Plugin Initialization System

## Description
Simplifies plugin development by allowing plugins to define `plugin_name` just once as a class variable instead of requiring it to be set twice (class variable + instance variable in `__init__`). Maintains full backward compatibility.

## Changes
- Added optional `plugin_name` parameter to `BasePlugin.__init__()`
- BasePlugin now automatically uses class-level `plugin_name` if available
- Fixed `mapped_channels` initialization bug when config is None
- Updated all core plugins to use simplified class-variable-only approach

## Backward Compatibility
All existing plugin initialization patterns continue to work:
- Legacy method (set in `__init__` before `super().__init__()`)
- Parameter method (pass to `super().__init__(plugin_name="name")`)
- New simplified method (class variable only)

## Files Changed
- `src/mmrelay/plugins/base_plugin.py` - Core implementation + bug fix
- 5 core plugin files - Simplified to use class variables only
