### PR TITLE
Support room-specific display names in Matrix relay

### DIFF
--- a/src/mmrelay/main.py
+++ b/src/mmrelay/main.py
@@ -9,6 +9,7 @@ import signal
 import sys
 
 from nio import ReactionEvent, RoomMessageEmote, RoomMessageNotice, RoomMessageText
+from nio.events.room_events import RoomMemberEvent
 
 # Import version from package
 # Import meshtastic_utils as a module to set event_loop
@@ -22,7 +23,7 @@ from mmrelay.db_utils import (
 from mmrelay.log_utils import get_logger
 from mmrelay.matrix_utils import connect_matrix, join_matrix_room
 from mmrelay.matrix_utils import logger as matrix_logger
-from mmrelay.matrix_utils import on_room_message
+from mmrelay.matrix_utils import on_room_message, on_room_member
 from mmrelay.meshtastic_utils import connect_meshtastic
 from mmrelay.meshtastic_utils import logger as meshtastic_logger
 from mmrelay.plugin_loader import load_plugins
@@ -109,6 +110,8 @@ async def main(config):
     )
     # Add ReactionEvent callback so we can handle matrix reactions
     matrix_client.add_event_callback(on_room_message, ReactionEvent)
+    # Add RoomMemberEvent callback to track room-specific display name changes
+    matrix_client.add_event_callback(on_room_member, RoomMemberEvent)
 
     # Set up shutdown event
     shutdown_event = asyncio.Event()

--- a/src/mmrelay/matrix_utils.py
+++ b/src/mmrelay/matrix_utils.py
@@ -517,8 +517,14 @@ async def on_room_message(
             meshtastic_id, matrix_room_id, meshtastic_text_db, meshtastic_meshnet_db = (
                 orig
             )
-            display_name_response = await matrix_client.get_displayname(event.sender)
-            full_display_name = display_name_response.displayname or event.sender
+            # Get room-specific display name if available, fallback to global display name
+            room_display_name = room.user_name(event.sender)
+            if room_display_name:
+                full_display_name = room_display_name
+            else:
+                # Fallback to global display name if room-specific name is not available
+                display_name_response = await matrix_client.get_displayname(event.sender)
+                full_display_name = display_name_response.displayname or event.sender
 
             # If not from a remote meshnet, proceed as normal to relay back to the originating meshnet
             short_display_name = full_display_name[:5]
@@ -578,8 +584,14 @@ async def on_room_message(
             return
     else:
         # Normal Matrix message from a Matrix user
-        display_name_response = await matrix_client.get_displayname(event.sender)
-        full_display_name = display_name_response.displayname or event.sender
+        # Get room-specific display name if available, fallback to global display name
+        room_display_name = room.user_name(event.sender)
+        if room_display_name:
+            full_display_name = room_display_name
+        else:
+            # Fallback to global display name if room-specific name is not available
+            display_name_response = await matrix_client.get_displayname(event.sender)
+            full_display_name = display_name_response.displayname or event.sender
         short_display_name = full_display_name[:5]
         prefix = f"{short_display_name}[M]: "
         logger.debug(f"Processing matrix message from [{full_display_name}]: {text}")


### PR DESCRIPTION
Previously, the relay always used a user's global Matrix display name when relaying messages to Meshtastic, even if they had set a different display name for that specific room.

This change:
- Uses room.user_name() instead of matrix_client.get_displayname() to get room-specific names
- Adds a callback to detect when users change their room display names
- Falls back to global display name if no room-specific name is set
- Applies to both regular messages and reactions

Now when someone sets a room-specific display name, that name will be used in relayed messages instead of their global name.