### PR TITLE
Fix pkg_resources deprecation warning in mmrelay v1.0.9

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = mmrelay
-version = 1.0.9
+version = 1.0.10
 author = Geoff Whittington, Jeremiah K., and contributors
 author_email = jeremiahk@gmx.com
 description = Bridge between Meshtastic mesh networks and Matrix chat rooms

--- a/src/mmrelay/__init__.py
+++ b/src/mmrelay/__init__.py
@@ -3,12 +3,7 @@ Meshtastic Matrix Relay - Bridge between Meshtastic mesh networks and Matrix cha
 """
 
 import os
-
-try:
-    from importlib.metadata import PackageNotFoundError, version
-except ImportError:
-    # Fallback for Python < 3.8
-    from importlib_metadata import PackageNotFoundError, version
+from importlib.metadata import PackageNotFoundError, version
 
 # First try to get version from environment variable (GitHub tag)
 if "GITHUB_REF_NAME" in os.environ:

--- a/src/mmrelay/__init__.py
+++ b/src/mmrelay/__init__.py
@@ -4,15 +4,19 @@ Meshtastic Matrix Relay - Bridge between Meshtastic mesh networks and Matrix cha
 
 import os
 
-import pkg_resources
+try:
+    from importlib.metadata import PackageNotFoundError, version
+except ImportError:
+    # Fallback for Python < 3.8
+    from importlib_metadata import PackageNotFoundError, version
 
 # First try to get version from environment variable (GitHub tag)
 if "GITHUB_REF_NAME" in os.environ:
     __version__ = os.environ.get("GITHUB_REF_NAME")
 else:
-    # Fall back to setup.cfg metadata using pkg_resources (compatible with PyInstaller)
+    # Fall back to package metadata using importlib.metadata (modern replacement for pkg_resources)
     try:
-        __version__ = pkg_resources.get_distribution("mmrelay").version
-    except pkg_resources.DistributionNotFound:
+        __version__ = version("mmrelay")
+    except PackageNotFoundError:
         # If all else fails, use hardcoded version
         __version__ = "1.0.8"

--- a/src/mmrelay/__init__.py
+++ b/src/mmrelay/__init__.py
@@ -19,4 +19,4 @@ else:
         __version__ = version("mmrelay")
     except PackageNotFoundError:
         # If all else fails, use hardcoded version
-        __version__ = "1.0.8"
+        __version__ = "1.0.10"


### PR DESCRIPTION
Fix pkg_resources deprecation warning in mmrelay v1.0.9

This PR resolves the deprecation warning that appears when running mmrelay:
```pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html. The pkg_resources package is slated for removal as early as 2025-11-30.```

**Changes:**
- Replace deprecated `pkg_resources.get_distribution()` with modern `importlib.metadata.version()`
- Replace `pkg_resources.DistributionNotFound`` with ``PackageNotFoundError`
- Use direct import since mmrelay requires Python >=3.8 (importlib.metadata is standard library from 3.8+)
- Update comments to reflect the modern approach

**Testing:**
- Verified version detection still works correctly
- Ran trunk check --fix --all with no issues
- No breaking changes to existing functionality

This fix ensures mmrelay will continue working when setuptools removes pkg_resources support.