### PR TITLE
Bump version to 1.0.11 and update linter versions in Trunk config

### DIFF
--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -7,7 +7,7 @@ cli:
 plugins:
   sources:
     - id: trunk
-      ref: v1.7.0
+      ref: v1.7.1
       uri: https://github.com/trunk-io/plugins
 # Many linters and tools depend on runtimes - configure them here. (https://docs.trunk.io/runtimes)
 runtimes:
@@ -19,16 +19,16 @@ lint:
   enabled:
     - taplo@0.9.3
     - actionlint@1.7.7
-    - bandit@1.8.3
+    - bandit@1.8.5
     - black@25.1.0
-    - checkov@3.2.436
+    - checkov@3.2.447
     - git-diff-check
     - isort@6.0.1
     - markdownlint@0.45.0
-    - osv-scanner@2.0.2
-    - prettier@3.5.3
-    - ruff@0.11.12
-    - trufflehog@3.88.35
+    - osv-scanner@2.0.3
+    - prettier@3.6.2
+    - ruff@0.12.1
+    - trufflehog@3.89.2
     - yamllint@1.37.1
   # Remove map_plugin.py after staticmaps is updated and we're able to work on it again
   # For more info: https://github.com/geoffwhittington/meshtastic-matrix-relay/issues/117

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = mmrelay
-version = 1.0.10
+version = 1.0.11
 author = Geoff Whittington, Jeremiah K., and contributors
 author_email = jeremiahk@gmx.com
 description = Bridge between Meshtastic mesh networks and Matrix chat rooms

--- a/src/mmrelay/__init__.py
+++ b/src/mmrelay/__init__.py
@@ -14,4 +14,4 @@ else:
         __version__ = version("mmrelay")
     except PackageNotFoundError:
         # If all else fails, use hardcoded version
-        __version__ = "1.0.10"
+        __version__ = "1.0.11"


### PR DESCRIPTION
* **Chores**
  * Updated internal configuration to use newer versions of several tools and plugins.
  * Bumped the package version to 1.0.11 in relevant files.