### PR TITLE
Fix BLE Connections Hanging, TCP Reconnection Duplicate Messages, and Bot Command Detection

### DIFF
--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -27,7 +27,7 @@ lint:
     - markdownlint@0.45.0
     - osv-scanner@2.0.3
     - prettier@3.6.2
-    - ruff@0.12.1
+    - ruff@0.12.2
     - trufflehog@3.89.2
     - yamllint@1.37.1
   # Remove map_plugin.py after staticmaps is updated and we're able to work on it again

--- a/setup.py
+++ b/setup.py
@@ -1,12 +1,16 @@
 from setuptools import setup, find_packages
 
+# Read README file with proper resource management
+with open("README.md", encoding="utf-8") as f:
+    long_description = f.read()
+
 setup(
     name="mmrelay",
     version="1.0.11",
     author="Geoff Whittington, Jeremiah K., and contributors",
     author_email="jeremiahk@gmx.com",
     description="Bridge between Meshtastic mesh networks and Matrix chat rooms",
-    long_description=open("README.md").read(),
+    long_description=long_description,
     long_description_content_type="text/markdown",
     url="https://github.com/geoffwhittington/meshtastic-matrix-relay",
     project_urls={

--- a/setup.py
+++ b/setup.py
@@ -43,5 +43,6 @@ setup(
     packages=find_packages(where="src"),
     package_dir={"": "src"},
     include_package_data=True,
+    package_data={"mmrelay.tools": ["sample_config.yaml"]},
     entry_points={"console_scripts": ["mmrelay = mmrelay.cli:main"]},
 )

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
     ],
     python_requires=">=3.8",
     install_requires=[
-        "meshtastic @ git+https://github.com/jeremiah-k/meshtastic-python.git@1dfd8fb5525a9b58a033db56bfd7c9862115d1ca",
+        "meshtastic @ git+https://github.com/jeremiah-k/meshtastic-python.git@fix-ble-hanging-issues",
         "Pillow==11.2.1",
         "matrix-nio==0.25.2",
         "matplotlib==3.10.1",

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
     ],
     python_requires=">=3.8",
     install_requires=[
-        "meshtastic @ git+https://github.com/jeremiah-k/meshtastic-python.git@fix-ble-hanging-issues",
+        "meshtastic @ git+https://github.com/jeremiah-k/meshtastic-python.git@fix-ble-hanging-clean",
         "Pillow==11.2.1",
         "matrix-nio==0.25.2",
         "matplotlib==3.10.1",

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-from setuptools import setup, find_packages
+from setuptools import find_packages, setup
 
 # Read README file with proper resource management
 with open("README.md", encoding="utf-8") as f:
@@ -25,7 +25,9 @@ setup(
     ],
     python_requires=">=3.8",
     install_requires=[
-        "meshtastic @ git+https://github.com/jeremiah-k/meshtastic-python.git@fix-ble-hanging-clean",
+        # TEMPORARY: Using fork with BLE hanging fix until upstream merge
+        # Commit: 19f5174a7ee3d166dceea317be09782d663263d5
+        "meshtastic @ git+https://github.com/jeremiah-k/meshtastic-python.git@19f5174a7ee3d166dceea317be09782d663263d5",
         "Pillow==11.2.1",
         "matrix-nio==0.25.2",
         "matplotlib==3.10.1",
@@ -41,9 +43,5 @@ setup(
     packages=find_packages(where="src"),
     package_dir={"": "src"},
     include_package_data=True,
-    entry_points={
-        "console_scripts": [
-            "mmrelay = mmrelay.cli:main"
-        ]
-    },
+    entry_points={"console_scripts": ["mmrelay = mmrelay.cli:main"]},
 )

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,45 @@
+from setuptools import setup, find_packages
+
+setup(
+    name="mmrelay",
+    version="1.0.11",
+    author="Geoff Whittington, Jeremiah K., and contributors",
+    author_email="jeremiahk@gmx.com",
+    description="Bridge between Meshtastic mesh networks and Matrix chat rooms",
+    long_description=open("README.md").read(),
+    long_description_content_type="text/markdown",
+    url="https://github.com/geoffwhittington/meshtastic-matrix-relay",
+    project_urls={
+        "Bug Tracker": "https://github.com/geoffwhittington/meshtastic-matrix-relay/issues"
+    },
+    classifiers=[
+        "Programming Language :: Python :: 3",
+        "License :: OSI Approved :: MIT License",
+        "Operating System :: OS Independent",
+        "Development Status :: 4 - Beta",
+        "Topic :: Communications",
+    ],
+    python_requires=">=3.8",
+    install_requires=[
+        "meshtastic @ git+https://github.com/jeremiah-k/meshtastic-python.git@1dfd8fb5525a9b58a033db56bfd7c9862115d1ca",
+        "Pillow==11.2.1",
+        "matrix-nio==0.25.2",
+        "matplotlib==3.10.1",
+        "requests==2.32.4",
+        "markdown==3.8.2",
+        "haversine==2.9.0",
+        "schedule==1.2.2",
+        "platformdirs==4.3.8",
+        "py-staticmaps>=0.4.0",
+        "rich==14.0.0",
+        "setuptools==80.9.0",
+    ],
+    packages=find_packages(where="src"),
+    package_dir={"": "src"},
+    include_package_data=True,
+    entry_points={
+        "console_scripts": [
+            "mmrelay = mmrelay.cli:main"
+        ]
+    },
+)

--- a/src/mmrelay/main.py
+++ b/src/mmrelay/main.py
@@ -50,13 +50,9 @@ def print_banner():
 
 async def main(config):
     """
-    Main asynchronous function to set up and run the relay.
-    Includes logic for wiping the message_map if configured in database.msg_map.wipe_on_restart
-    or db.msg_map.wipe_on_restart (legacy format).
-    Also updates longnames and shortnames periodically as before.
-
-    Args:
-        config: The loaded configuration
+    Initializes and runs the Meshtastic-to-Matrix relay, managing connections, event handling, and graceful shutdown.
+    
+    This function sets up the relay according to the provided configuration, including database initialization, plugin loading, and connection to both Meshtastic and Matrix clients. It handles joining Matrix rooms, registering event callbacks, and periodically updating node information. The function also manages shutdown signals, cleans up resources, and optionally wipes the message map on startup and shutdown if configured.
     """
     # Extract Matrix configuration
     from typing import List

--- a/src/mmrelay/main.py
+++ b/src/mmrelay/main.py
@@ -188,6 +188,9 @@ async def main(config):
             except Exception as e:
                 meshtastic_logger.warning(f"Error closing Meshtastic client: {e}")
 
+        # Clean up Meshtastic pubsub subscriptions to prevent memory leaks
+        meshtastic_utils._unsubscribe_from_meshtastic_events()
+
         # Attempt to wipe message_map on shutdown if enabled
         if wipe_on_restart:
             logger.debug("wipe_on_restart enabled. Wiping message_map now (shutdown).")

--- a/src/mmrelay/matrix_utils.py
+++ b/src/mmrelay/matrix_utils.py
@@ -161,14 +161,17 @@ def is_bot_command_message(event):
         return True
 
     # Check if the message starts with bot_user_id or bot_user_name and contains a command
-    if full_message.startswith(bot_user_id) or text_content.startswith(bot_user_id):
+    if (
+        full_message.startswith(bot_user_id)
+        or text_content.startswith(bot_user_id)
+        or full_message.startswith(bot_user_name)
+        or text_content.startswith(bot_user_name)
+    ):
         # Look for any command pattern after bot mention
         pattern = rf"^(?:{re.escape(bot_user_id)}|{re.escape(bot_user_name)}|[#@].+?)[,:;]?\s*!"
-        return bool(re.search(pattern, full_message)) or bool(re.search(pattern, text_content))
-    elif full_message.startswith(bot_user_name) or text_content.startswith(bot_user_name):
-        # Look for any command pattern after bot mention
-        pattern = rf"^(?:{re.escape(bot_user_id)}|{re.escape(bot_user_name)}|[#@].+?)[,:;]?\s*!"
-        return bool(re.search(pattern, full_message)) or bool(re.search(pattern, text_content))
+        return bool(re.search(pattern, full_message)) or bool(
+            re.search(pattern, text_content)
+        )
 
     return False
 

--- a/src/mmrelay/matrix_utils.py
+++ b/src/mmrelay/matrix_utils.py
@@ -101,14 +101,14 @@ matrix_client = None
 
 def bot_command(command, event):
     """
-    Determine if a given command string is directed at the bot in a Matrix message event.
-    
-    Checks for command invocation using both plain text and formatted message content, supporting variations such as direct bot mentions, display name references, and different Matrix client formats.
-    
-    Parameters:
+    Checks if the given command is directed at the bot,
+    accounting for variations in different Matrix clients.
+
+    Args:
         command (str): The command string to check for (without the leading '!').
+                      If None, checks for any command directed at the bot.
         event: The Matrix event object containing the message.
-    
+
     Returns:
         bool: True if the command is directed at the bot, otherwise False.
     """
@@ -119,61 +119,34 @@ def bot_command(command, event):
     # Remove HTML tags and extract the text content
     text_content = re.sub(r"<[^>]+>", "", formatted_body).strip()
 
-    # Check for simple !command format first
+    # If command is None, check for any command directed at the bot
+    if command is None:
+        # Check for simple !command format first
+        if full_message.startswith("!") or text_content.startswith("!"):
+            return True
+        # Check if the message starts with bot_user_id or bot_user_name and contains any command
+        if (full_message.startswith(bot_user_id) or text_content.startswith(bot_user_id) or
+            full_message.startswith(bot_user_name) or text_content.startswith(bot_user_name)):
+            # Look for any command pattern after bot mention
+            pattern = rf"^(?:{re.escape(bot_user_id)}|{re.escape(bot_user_name)}|[#@].+?)[,:;]?\s*!"
+            return bool(re.search(pattern, full_message)) or bool(re.search(pattern, text_content))
+        return False
+
+    # Check for specific command
     if full_message.startswith(f"!{command}") or text_content.startswith(f"!{command}"):
         return True
 
     # Check if the message starts with bot_user_id or bot_user_name
-    if full_message.startswith(bot_user_id) or text_content.startswith(bot_user_id):
+    if (full_message.startswith(bot_user_id) or text_content.startswith(bot_user_id) or
+        full_message.startswith(bot_user_name) or text_content.startswith(bot_user_name)):
         # Construct a regex pattern to match variations of bot mention and command
         pattern = rf"^(?:{re.escape(bot_user_id)}|{re.escape(bot_user_name)}|[#@].+?)[,:;]?\s*!{command}"
-        return bool(re.match(pattern, full_message)) or bool(
-            re.match(pattern, text_content)
-        )
-    elif full_message.startswith(bot_user_name) or text_content.startswith(
-        bot_user_name
-    ):
-        # Construct a regex pattern to match variations of bot mention and command
-        pattern = rf"^(?:{re.escape(bot_user_id)}|{re.escape(bot_user_name)}|[#@].+?)[,:;]?\s*!{command}"
-        return bool(re.match(pattern, full_message)) or bool(
-            re.match(pattern, text_content)
-        )
-    else:
-        return False
-
-
-def is_bot_command_message(event):
-    """
-    Determine if a Matrix message event is a command directed at the bot.
-    
-    Returns:
-        bool: True if the message is a bot command, otherwise False.
-    """
-    full_message = event.body.strip()
-    content = event.source.get("content", {})
-    formatted_body = content.get("formatted_body", "")
-
-    # Remove HTML tags and extract the text content
-    text_content = re.sub(r"<[^>]+>", "", formatted_body).strip()
-
-    # Check for simple !command format first
-    if full_message.startswith("!") or text_content.startswith("!"):
-        return True
-
-    # Check if the message starts with bot_user_id or bot_user_name and contains a command
-    if (
-        full_message.startswith(bot_user_id)
-        or text_content.startswith(bot_user_id)
-        or full_message.startswith(bot_user_name)
-        or text_content.startswith(bot_user_name)
-    ):
-        # Look for any command pattern after bot mention
-        pattern = rf"^(?:{re.escape(bot_user_id)}|{re.escape(bot_user_name)}|[#@].+?)[,:;]?\s*!"
-        return bool(re.search(pattern, full_message)) or bool(
-            re.search(pattern, text_content)
-        )
+        return bool(re.match(pattern, full_message)) or bool(re.match(pattern, text_content))
 
     return False
+
+
+
 
 
 async def connect_matrix(passed_config=None):
@@ -955,10 +928,11 @@ async def on_room_message(
             break
 
     # Also check if this is any command directed at this bot to prevent relaying
-    is_bot_command_detected = is_bot_command_message(event)
+    # Use bot_command with None to check for any command
+    is_any_bot_command = bot_command(None, event)
 
     # If this is a command, we do not send it to the mesh
-    if is_command or is_bot_command_detected:
+    if is_command or is_any_bot_command:
         logger.debug("Message is a bot command, not sending to mesh")
         return
 

--- a/src/mmrelay/matrix_utils.py
+++ b/src/mmrelay/matrix_utils.py
@@ -134,12 +134,12 @@ def bot_command(command, event):
         return False
 
 
-def is_any_bot_command(event):
+def is_bot_command_message(event):
     """
-    Checks if the message is any bot command (directed at any bot),
-    to prevent relaying bot commands to Meshtastic regardless of target.
+    Checks if the message is any command directed at this bot,
+    to prevent relaying bot commands to Meshtastic.
 
-    Returns True if the message appears to be a bot command directed at any bot.
+    Returns True if the message appears to be a command directed at this bot.
     """
     full_message = event.body.strip()
     content = event.source.get("content", {})
@@ -148,16 +148,19 @@ def is_any_bot_command(event):
     # Remove HTML tags and extract the text content
     text_content = re.sub(r"<[^>]+>", "", formatted_body).strip()
 
-    # Check for bot mention patterns followed by commands
-    # Patterns like: @bot:server.com: !command or @bot:server.com !command
-    bot_command_pattern = r"^@[^:]+:[^:\s]+[:\s]+!\w+"
-
-    if re.match(bot_command_pattern, full_message) or re.match(bot_command_pattern, text_content):
-        return True
-
-    # Check for simple !command at start of message (could be directed at any bot)
+    # Check for simple !command format first
     if full_message.startswith("!") or text_content.startswith("!"):
         return True
+
+    # Check if the message starts with bot_user_id or bot_user_name and contains a command
+    if full_message.startswith(bot_user_id) or text_content.startswith(bot_user_id):
+        # Look for any command pattern after bot mention
+        pattern = rf"^(?:{re.escape(bot_user_id)}|{re.escape(bot_user_name)}|[#@].+?)[,:;]?\s*!"
+        return bool(re.search(pattern, full_message)) or bool(re.search(pattern, text_content))
+    elif full_message.startswith(bot_user_name) or text_content.startswith(bot_user_name):
+        # Look for any command pattern after bot mention
+        pattern = rf"^(?:{re.escape(bot_user_id)}|{re.escape(bot_user_name)}|[#@].+?)[,:;]?\s*!"
+        return bool(re.search(pattern, full_message)) or bool(re.search(pattern, text_content))
 
     return False
 
@@ -942,16 +945,12 @@ async def on_room_message(
         if is_command:
             break
 
-    # Also check if this is any bot command (directed at any bot)
-    # to prevent relaying bot commands to Meshtastic regardless of target
-    is_any_bot_command_detected = is_any_bot_command(event)
+    # Also check if this is any command directed at this bot to prevent relaying
+    is_bot_command_detected = is_bot_command_message(event)
 
-    # If this is a command (directed at us or any other bot), we do not send it to the mesh
-    if is_command or is_any_bot_command_detected:
-        if is_command:
-            logger.debug("Message is a command directed at this bot, not sending to mesh")
-        else:
-            logger.debug("Message is a bot command directed at another bot, not sending to mesh")
+    # If this is a command, we do not send it to the mesh
+    if is_command or is_bot_command_detected:
+        logger.debug("Message is a bot command, not sending to mesh")
         return
 
     # Connect to Meshtastic

--- a/src/mmrelay/matrix_utils.py
+++ b/src/mmrelay/matrix_utils.py
@@ -134,6 +134,34 @@ def bot_command(command, event):
         return False
 
 
+def is_any_bot_command(event):
+    """
+    Checks if the message is any bot command (directed at any bot),
+    to prevent relaying bot commands to Meshtastic regardless of target.
+
+    Returns True if the message appears to be a bot command directed at any bot.
+    """
+    full_message = event.body.strip()
+    content = event.source.get("content", {})
+    formatted_body = content.get("formatted_body", "")
+
+    # Remove HTML tags and extract the text content
+    text_content = re.sub(r"<[^>]+>", "", formatted_body).strip()
+
+    # Check for bot mention patterns followed by commands
+    # Patterns like: @bot:server.com: !command or @bot:server.com !command
+    bot_command_pattern = r"^@[^:]+:[^:\s]+[:\s]+!\w+"
+
+    if re.match(bot_command_pattern, full_message) or re.match(bot_command_pattern, text_content):
+        return True
+
+    # Check for simple !command at start of message (could be directed at any bot)
+    if full_message.startswith("!") or text_content.startswith("!"):
+        return True
+
+    return False
+
+
 async def connect_matrix(passed_config=None):
     """
     Establish a connection to the Matrix homeserver.
@@ -914,9 +942,16 @@ async def on_room_message(
         if is_command:
             break
 
-    # If this is a command, we do not send it to the mesh
-    if is_command:
-        logger.debug("Message is a command, not sending to mesh")
+    # Also check if this is any bot command (directed at any bot)
+    # to prevent relaying bot commands to Meshtastic regardless of target
+    is_any_bot_command_detected = is_any_bot_command(event)
+
+    # If this is a command (directed at us or any other bot), we do not send it to the mesh
+    if is_command or is_any_bot_command_detected:
+        if is_command:
+            logger.debug("Message is a command directed at this bot, not sending to mesh")
+        else:
+            logger.debug("Message is a bot command directed at another bot, not sending to mesh")
         return
 
     # Connect to Meshtastic

--- a/src/mmrelay/matrix_utils.py
+++ b/src/mmrelay/matrix_utils.py
@@ -101,8 +101,16 @@ matrix_client = None
 
 def bot_command(command, event):
     """
-    Checks if the given command is directed at the bot,
-    accounting for variations in different Matrix clients.
+    Determine if a given command string is directed at the bot in a Matrix message event.
+    
+    Checks for command invocation using both plain text and formatted message content, supporting variations such as direct bot mentions, display name references, and different Matrix client formats.
+    
+    Parameters:
+        command (str): The command string to check for (without the leading '!').
+        event: The Matrix event object containing the message.
+    
+    Returns:
+        bool: True if the command is directed at the bot, otherwise False.
     """
     full_message = event.body.strip()
     content = event.source.get("content", {})
@@ -136,10 +144,10 @@ def bot_command(command, event):
 
 def is_bot_command_message(event):
     """
-    Checks if the message is any command directed at this bot,
-    to prevent relaying bot commands to Meshtastic.
-
-    Returns True if the message appears to be a command directed at this bot.
+    Determine if a Matrix message event is a command directed at the bot.
+    
+    Returns:
+        bool: True if the message is a bot command, otherwise False.
     """
     full_message = event.body.strip()
     content = event.source.get("content", {})
@@ -167,11 +175,9 @@ def is_bot_command_message(event):
 
 async def connect_matrix(passed_config=None):
     """
-    Establish a connection to the Matrix homeserver.
-    Sets global matrix_client and detects the bot's display name.
-
-    Args:
-        passed_config: The configuration dictionary to use (will update global config)
+    Asynchronously establishes and configures a connection to the Matrix homeserver using the provided or global configuration.
+    
+    Initializes the global Matrix client, retrieves the bot's device ID and display name, and sets up connection parameters. Returns the initialized Matrix client instance, or `None` if configuration is missing.
     """
     global matrix_client, bot_user_name, matrix_homeserver, matrix_rooms, matrix_access_token, bot_user_id, config
 
@@ -647,9 +653,9 @@ async def on_room_message(
     event: Union[RoomMessageText, RoomMessageNotice, ReactionEvent, RoomMessageEmote],
 ) -> None:
     """
-    Handles incoming Matrix room messages, reactions, and replies, relaying them to Meshtastic as appropriate.
-
-    Processes events from Matrix rooms, including text messages, reactions, and replies. Relays supported messages to Meshtastic if broadcasting is enabled, applying message mapping for cross-referencing when reactions or replies are enabled. Prevents relaying of reactions to reactions and avoids processing messages from the bot itself or messages sent before the bot started. Integrates with plugins for command and message handling, and ensures that only supported messages are forwarded to Meshtastic.
+    Handles incoming Matrix room messages, reactions, and replies, relaying them to Meshtastic if appropriate.
+    
+    Processes Matrix events including text messages, reactions, and replies. Relays supported messages to Meshtastic channels when broadcasting is enabled, and manages message mapping for cross-referencing when reactions or replies are enabled. Prevents relaying of bot commands, reactions to reactions, messages from the bot itself, and messages sent before the bot started. Integrates with plugins for command and message handling, and ensures only supported messages are forwarded to Meshtastic. Handles special cases for remote meshnet messages and reactions, and manages message mapping storage and pruning as configured.
     """
     # Importing here to avoid circular imports and to keep logic consistent
     # Note: We do not call store_message_map directly here for inbound matrix->mesh messages.

--- a/src/mmrelay/meshtastic_utils.py
+++ b/src/mmrelay/meshtastic_utils.py
@@ -82,12 +82,12 @@ def _unsubscribe_from_meshtastic_events():
 
     if message_listener is not None:
         logger.debug("Unsubscribing from meshtastic.receive")
-        pub.unsubscribe(message_listener, "meshtastic.receive")
+        message_listener.unsubscribe()
         message_listener = None
 
     if connection_lost_listener is not None:
         logger.debug("Unsubscribing from meshtastic.connection.lost")
-        pub.unsubscribe(connection_lost_listener, "meshtastic.connection.lost")
+        connection_lost_listener.unsubscribe()
         connection_lost_listener = None
 
 

--- a/src/mmrelay/meshtastic_utils.py
+++ b/src/mmrelay/meshtastic_utils.py
@@ -56,10 +56,9 @@ connection_lost_listener = None
 
 def _subscribe_to_meshtastic_events():
     """
-    Subscribe to Meshtastic pubsub events and store listener objects.
-
-    This function stores the listener objects returned by pub.subscribe()
-    so they can be properly unsubscribed later to prevent duplicate handlers.
+    Subscribes to Meshtastic pubsub events and saves the listener objects globally.
+    
+    This enables later unsubscription to prevent duplicate event handling during reconnections.
     """
     global message_listener, connection_lost_listener
 
@@ -72,11 +71,9 @@ def _subscribe_to_meshtastic_events():
 
 def _unsubscribe_from_meshtastic_events():
     """
-    Unsubscribe from Meshtastic pubsub events to prevent duplicate handlers.
-
-    This is called before reconnecting to ensure we don't accumulate multiple
-    subscriptions to the same topics, which would cause messages to be processed
-    multiple times (once per subscription).
+    Unsubscribes from Meshtastic pubsub events to prevent duplicate event handling.
+    
+    Removes existing listeners for `"meshtastic.receive"` and `"meshtastic.connection.lost"` topics if present, ensuring that only a single set of handlers is active after reconnection or reconfiguration.
     """
     global message_listener, connection_lost_listener
 
@@ -93,11 +90,10 @@ def _unsubscribe_from_meshtastic_events():
 
 def is_running_as_service():
     """
-    Check if the application is running as a systemd service.
-    This is used to determine whether to show Rich progress indicators.
-
+    Determine if the application is running as a systemd service.
+    
     Returns:
-        bool: True if running as a service, False otherwise
+        bool: True if running as a systemd service, otherwise False.
     """
     # Check for INVOCATION_ID environment variable (set by systemd)
     if os.environ.get("INVOCATION_ID"):
@@ -128,14 +124,16 @@ def serial_port_exists(port_name):
 
 def connect_meshtastic(passed_config=None, force_connect=False):
     """
-    Establish a connection to the Meshtastic device.
-    Attempts a connection based on connection_type (serial/ble/network).
-    Retries until successful or shutting_down is set.
-    If already connected and not force_connect, returns the existing client.
-
-    Args:
-        passed_config: The configuration dictionary to use (will update global config)
-        force_connect: Whether to force a new connection even if one exists
+    Establishes and manages a connection to a Meshtastic device using the configured connection type (serial, BLE, or TCP).
+    
+    If a configuration is provided, updates the global configuration and Matrix room mappings. Handles reconnection logic, including closing any existing client, retrying with exponential backoff on failure, and supporting legacy connection types. Ensures only one connection attempt occurs at a time using a lock. Subscribes to Meshtastic message and connection lost events, preventing duplicate subscriptions. Returns the connected Meshtastic client instance, or `None` if unable to connect or if shutdown is in progress.
+    
+    Parameters:
+        passed_config (dict, optional): Configuration dictionary to use for the connection.
+        force_connect (bool, optional): If True, forces a new connection even if one already exists.
+    
+    Returns:
+        meshtastic_client: The connected Meshtastic client instance, or None on failure or shutdown.
     """
     global meshtastic_client, shutting_down, config, matrix_rooms
     if shutting_down:
@@ -274,10 +272,9 @@ def connect_meshtastic(passed_config=None, force_connect=False):
 
 def on_lost_meshtastic_connection(interface=None):
     """
-    Callback invoked when the Meshtastic connection is lost.
-    Initiates a reconnect sequence unless shutting_down is True.
-
-    Also cleans up pubsub subscriptions to prevent accumulation of duplicate handlers.
+    Handles loss of Meshtastic connection by initiating a reconnection sequence and cleaning up event subscriptions.
+    
+    If not already reconnecting or shutting down, this function unsubscribes from Meshtastic pubsub events, closes the current client, and schedules an asynchronous reconnection attempt.
     """
     global meshtastic_client, reconnecting, shutting_down, event_loop, reconnect_task
     with meshtastic_lock:

--- a/src/mmrelay/meshtastic_utils.py
+++ b/src/mmrelay/meshtastic_utils.py
@@ -47,6 +47,49 @@ reconnecting = False
 shutting_down = False
 reconnect_task = None  # To keep track of the reconnect task
 
+# Global variables for pubsub subscription management
+# These store the listener objects returned by pub.subscribe() so we can unsubscribe later
+# to prevent duplicate message handling during reconnections
+message_listener = None
+connection_lost_listener = None
+
+
+def _subscribe_to_meshtastic_events():
+    """
+    Subscribe to Meshtastic pubsub events and store listener objects.
+
+    This function stores the listener objects returned by pub.subscribe()
+    so they can be properly unsubscribed later to prevent duplicate handlers.
+    """
+    global message_listener, connection_lost_listener
+
+    logger.debug("Subscribing to Meshtastic pubsub events")
+    message_listener = pub.subscribe(on_meshtastic_message, "meshtastic.receive")
+    connection_lost_listener = pub.subscribe(
+        on_lost_meshtastic_connection, "meshtastic.connection.lost"
+    )
+
+
+def _unsubscribe_from_meshtastic_events():
+    """
+    Unsubscribe from Meshtastic pubsub events to prevent duplicate handlers.
+
+    This is called before reconnecting to ensure we don't accumulate multiple
+    subscriptions to the same topics, which would cause messages to be processed
+    multiple times (once per subscription).
+    """
+    global message_listener, connection_lost_listener
+
+    if message_listener is not None:
+        logger.debug("Unsubscribing from meshtastic.receive")
+        pub.unsubscribe(message_listener, "meshtastic.receive")
+        message_listener = None
+
+    if connection_lost_listener is not None:
+        logger.debug("Unsubscribing from meshtastic.connection.lost")
+        pub.unsubscribe(connection_lost_listener, "meshtastic.connection.lost")
+        connection_lost_listener = None
+
 
 def is_running_as_service():
     """
@@ -198,10 +241,11 @@ def connect_meshtastic(passed_config=None, force_connect=False):
                 )
 
                 # Subscribe to message and connection lost events
-                pub.subscribe(on_meshtastic_message, "meshtastic.receive")
-                pub.subscribe(
-                    on_lost_meshtastic_connection, "meshtastic.connection.lost"
-                )
+                # First, unsubscribe any existing listeners to prevent duplicates
+                _unsubscribe_from_meshtastic_events()
+
+                # Now subscribe with fresh listeners
+                _subscribe_to_meshtastic_events()
 
             except (
                 serial.SerialException,
@@ -232,6 +276,8 @@ def on_lost_meshtastic_connection(interface=None):
     """
     Callback invoked when the Meshtastic connection is lost.
     Initiates a reconnect sequence unless shutting_down is True.
+
+    Also cleans up pubsub subscriptions to prevent accumulation of duplicate handlers.
     """
     global meshtastic_client, reconnecting, shutting_down, event_loop, reconnect_task
     with meshtastic_lock:
@@ -245,6 +291,9 @@ def on_lost_meshtastic_connection(interface=None):
             return
         reconnecting = True
         logger.error("Lost connection. Reconnecting...")
+
+        # Clean up existing subscriptions to prevent duplicates during reconnection
+        _unsubscribe_from_meshtastic_events()
 
         if meshtastic_client:
             try:


### PR DESCRIPTION
## Problems Fixed

### TCP Reconnection Duplicate Messages
When TCP connection is lost and reconnects multiple times, messages get relayed multiple times (up to 12x after connection issues). Each reconnection creates duplicate pubsub subscriptions without cleaning up previous ones.

### Bot Command Relay Issue  
Bot commands directed at the relay were being incorrectly sent to Meshtastic instead of being processed as commands only.

### BLE Connection Stability
Uses temporary fork of meshtastic python library with BLE hanging fixes until upstream merge. The fork addresses connection freezing issues that require manual intervention.

## Solutions

### TCP Reconnection Fix
- Store pubsub listener objects for proper cleanup
- Unsubscribe existing listeners before reconnecting using `listener.unsubscribe()` method
- Clean up subscriptions during connection loss and application shutdown

### Bot Command Detection Fix
- Enhanced original `bot_command()` function to handle any command when `command=None`
- Maintains support for multiple Matrix clients with single, clean implementation
- Prevents relaying any bot commands to Meshtastic while preserving existing functionality

### Packaging and Dependencies
- Pin meshtastic dependency to specific commit hash with BLE fixes
- Proper file handling with context manager and UTF-8 encoding in setup.py
- Explicit package_data declaration for sample_config.yaml inclusion

## Files Modified
- `src/mmrelay/meshtastic_utils.py`: Pubsub subscription management and cleanup
- `src/mmrelay/main.py`: Added subscription cleanup to shutdown sequence  
- `src/mmrelay/matrix_utils.py`: Enhanced bot command detection logic
- `setup.py`: Dependency pinning, file handling, and package data configuration

## Technical Details
- Global variables track pubsub subscriptions for proper cleanup
- Helper functions manage subscription lifecycle
- Enhanced command detection prevents any bot command from reaching mesh
- Temporary meshtastic fork pinned to commit `19f5174a7ee3d166dceea317be09782d663263d5`
- Explicit package data ensures sample_config.yaml is included in built packages

This resolves duplicate message relay after connection instability, prevents bot commands from being sent to the mesh network, and improves overall stability for BLE connections.