### PR TITLE
docs: reorganize documentation to reduce duplication and improve flow

### DIFF
--- a/DOCKER.md
+++ b/DOCKER.md
@@ -7,7 +7,7 @@ Simple Docker setup for Meshtastic Matrix Relay.
 **Option 1: One-step setup (recommended for first time):**
 
 ```bash
-make setup    # Copies config, .env, and docker-compose.yaml, then opens editor
+make setup    # Copy config, .env, and docker-compose.yaml, then opens editor
 make build    # Build Docker image
 make run      # Start container
 ```
@@ -15,7 +15,7 @@ make run      # Start container
 **Option 2: Manual steps:**
 
 ```bash
-make config   # Copy sample files (config.yaml, .env, docker-compose.yaml)
+make config   # Copy sample files and create directories
 make edit     # Edit config with your preferred editor
 make build    # Build Docker image
 make run      # Start container

--- a/README.md
+++ b/README.md
@@ -4,6 +4,21 @@
 
 A powerful and easy-to-use relay between Meshtastic devices and Matrix chat rooms, allowing seamless communication across platforms. This opens the door for bridging Meshtastic devices to [many other platforms](https://matrix.org/bridges/).
 
+## Features
+
+- Bidirectional message relay between Meshtastic devices and Matrix chat rooms, capable of supporting multiple meshnets
+- Supports serial, network, and **_BLE (now too!)_** connections for Meshtastic devices
+- Custom fields are embedded in Matrix messages for relaying messages between multiple meshnets
+- Truncates long messages to fit within Meshtastic's payload size
+- SQLite database to store node information for improved functionality
+- Customizable logging level for easy debugging
+- Configurable through a simple YAML file
+- Supports mapping multiple rooms and channels 1:1
+- Relays messages to/from an MQTT broker, if configured in the Meshtastic firmware
+- ✨️ _Bidirectional replies and reactions support_ ✨️ **NEW!!**
+
+_We would love to support [Matrix E2EE rooms](https://github.com/geoffwhittington/meshtastic-matrix-relay/issues/33), but this is currently not implemented._
+
 ## Documentation
 
 Visit our [Wiki](https://github.com/geoffwhittington/meshtastic-matrix-relay/wiki) for comprehensive guides and information.
@@ -35,42 +50,15 @@ MMRelay includes official Docker support for easy deployment and management:
 
 ```bash
 # Quick setup with Docker
-make config  # Creates config files and directories
+make setup   # Copy config and open editor (first time)
 make build   # Build the Docker image
 make run     # Start the container
-
-# View logs
-make logs
-
-# Stop the container
-make stop
+make logs    # View logs
 ```
 
-Docker provides:
+Docker provides isolated environment, easy deployment, automatic restarts, and volume persistence.
 
-- **Isolated environment** - No dependency conflicts
-- **Easy deployment** - Single command setup
-- **Automatic restarts** - Container restarts on failure
-- **Volume persistence** - Data and logs preserved across restarts
-
-For detailed Docker setup instructions, see the [Docker Guide](DOCKER.md) or [Installation Guide](docs/INSTRUCTIONS.md#docker).
-
----
-
-## Features
-
-- Bidirectional message relay between Meshtastic devices and Matrix chat rooms, capable of supporting multiple meshnets
-- Supports serial, network, and **_BLE (now too!)_** connections for Meshtastic devices
-- Custom fields are embedded in Matrix messages for relaying messages between multiple meshnets
-- Truncates long messages to fit within Meshtastic's payload size
-- SQLite database to store node information for improved functionality
-- Customizable logging level for easy debugging
-- Configurable through a simple YAML file
-- Supports mapping multiple rooms and channels 1:1
-- Relays messages to/from an MQTT broker, if configured in the Meshtastic firmware
-- ✨️ _Bidirectional replies and reactions support_ ✨️ **NEW!!**
-
-_We would love to support [Matrix E2EE rooms](https://github.com/geoffwhittington/meshtastic-matrix-relay/issues/33), but this is currently not implemented._
+For detailed Docker setup instructions, see the [Docker Guide](DOCKER.md).
 
 ---
 

--- a/docs/INSTRUCTIONS.md
+++ b/docs/INSTRUCTIONS.md
@@ -160,13 +160,7 @@ tail -f ~/.mmrelay/logs/mmrelay.log
 
 ## Docker
 
-MMRelay includes official Docker support for easy deployment and management. Docker provides several key benefits:
-
-- **Isolated environment** - No conflicts with system dependencies
-- **Automatic dependency management** - All required packages included
-- **Easy updates** - Simple container rebuilds for new versions
-- **Consistent deployment** - Same environment across different systems
-- **Quick setup** - Get running in minutes with minimal configuration
+MMRelay includes official Docker support for easy deployment and management. Docker provides isolated environment, automatic dependency management, easy updates, and consistent deployment across different systems.
 
 ### Quick Docker Setup
 
@@ -175,81 +169,14 @@ MMRelay includes official Docker support for easy deployment and management. Doc
 git clone https://github.com/geoffwhittington/meshtastic-matrix-relay.git
 cd meshtastic-matrix-relay
 
-# Set up configuration files and directories
-make config
-
-# Edit the configuration file
-nano ~/.mmrelay/config.yaml
-
-# Build and run the Docker container
-make build
-make run
-
-# View logs
-make logs
-
-# Stop the container
-make stop
+# Set up configuration and start
+make setup    # Copy config and open editor (first time)
+make build    # Build the Docker image
+make run      # Start the container
+make logs     # View logs
 ```
 
-### Docker Benefits
-
-- **Isolated Environment**: No dependency conflicts with your system
-- **Easy Deployment**: Single command setup and management
-- **Automatic Restarts**: Container restarts automatically on failure
-- **Volume Persistence**: Data and logs are preserved across container restarts
-- **Consistent Environment**: Same runtime environment across different systems
-
-### Docker Commands
-
-The included Makefile provides convenient commands for Docker management:
-
-```bash
-# Setup and configuration
-make config          # Create config files and directories
-make setup           # Alias for config
-
-# Building and running
-make build           # Build the Docker image
-make run             # Start the container in detached mode
-make rebuild         # Stop, rebuild (no cache), and restart
-
-# Monitoring and management
-make logs            # View container logs (follow mode)
-make status          # Show container status
-make stop            # Stop the container
-make restart         # Restart the container
-
-# Cleanup
-make clean           # Remove container and image
-```
-
-### Docker Configuration
-
-The Docker setup uses:
-
-- **Host networking** for Meshtastic device access (serial/BLE)
-- **Volume mounts** for configuration and data persistence:
-  - `~/.mmrelay/config.yaml` → `/app/config.yaml` (read-only)
-  - `~/.mmrelay/data/` → `/app/data/` (read-write)
-  - `~/.mmrelay/logs/` → `/app/logs/` (read-write)
-
-### Docker Compose
-
-For advanced users, you can also use docker-compose directly:
-
-```bash
-# Start with docker-compose
-docker compose up -d
-
-# View logs
-docker compose logs -f
-
-# Stop
-docker compose down
-```
-
-The `docker-compose.yaml` file is automatically created by `make config` and can be customized for your specific needs.
+For detailed Docker commands, configuration options, connection types, and troubleshooting, see the [Docker Guide](../DOCKER.md).
 
 ## Development
 


### PR DESCRIPTION
- Move Features section above Quick Start in README for better visibility
- Simplify Docker sections to reduce command duplication:
  - README: Basic Docker overview with essential commands
  - INSTRUCTIONS.md: Simplified Docker section referencing DOCKER.md
  - DOCKER.md: Authoritative source for all Docker commands and details
- Remove duplicate Features section from README
- Streamline Docker command presentation across all documentation
- Improve documentation flow and reduce maintenance burden