### PR TITLE
Fix PyPI Publishing and Release Issues

### DIFF
--- a/.github/workflows/package-windows.yml
+++ b/.github/workflows/package-windows.yml
@@ -62,14 +62,14 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: MMRelay_setup_${{ env.FILE_VERSION }}
-          path: MMRelay_setup_${{ env.FILE_VERSION }}.exe
+          path: scripts/MMRelay_setup_${{ env.FILE_VERSION }}.exe
 
       - name: Upload installer to GitHub Release
         if: github.event_name == 'release'
         uses: svenstaro/upload-release-action@v2
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
-          file: MMRelay_setup_${{ env.FILE_VERSION }}.exe
+          file: scripts/MMRelay_setup_${{ env.FILE_VERSION }}.exe
           asset_name: MMRelay_setup_${{ env.FILE_VERSION }}.exe
           tag: ${{ github.ref }}
           overwrite: true

--- a/README.md
+++ b/README.md
@@ -60,6 +60,8 @@ Docker provides isolated environment, easy deployment, automatic restarts, and v
 
 For detailed Docker setup instructions, see the [Docker Guide](DOCKER.md).
 
+> **Note**: Docker builds currently use a temporary fork of the meshtastic library with BLE hanging fixes. PyPI releases use the upstream library. This will be resolved when the fixes are merged upstream.
+
 ---
 
 ## Windows Installer

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,7 @@
-meshtastic
+# TEMPORARY: Using fork with BLE hanging fix until upstream merge
+# Commit: 33d23e9c28508a740da6567627e42d81552c9b58
+# For PyPI compatibility, setup.py uses upstream meshtastic>=2.6.4
+meshtastic @ git+https://github.com/jeremiah-k/meshtastic-python.git@33d23e9c28508a740da6567627e42d81552c9b58
 Pillow==11.3.0
 matrix-nio==0.25.2
 matplotlib==3.10.1

--- a/setup.py
+++ b/setup.py
@@ -25,9 +25,7 @@ setup(
     ],
     python_requires=">=3.8",
     install_requires=[
-        # TEMPORARY: Using fork with BLE hanging fix until upstream merge
-        # Commit: 33d23e9c28508a740da6567627e42d81552c9b58
-        "meshtastic @ git+https://github.com/jeremiah-k/meshtastic-python.git@33d23e9c28508a740da6567627e42d81552c9b58",
+        "meshtastic>=2.6.4",
         "Pillow==11.3.0",
         "matrix-nio==0.25.2",
         "matplotlib==3.10.1",


### PR DESCRIPTION
## Overview
Resolves critical issues preventing successful v1.1.0 release, including a PyPI publishing failure.

## Issues Fixed

### PyPI Publishing Failure
- **Problem**: PyPI rejected package due to direct git dependency: `meshtastic @ git+https://github.com/jeremiah-k/meshtastic-python.git@33d23e9c28508a740da6567627e42d81552c9b58`
- **Solution**: Use upstream `meshtastic>=2.6.4` in setup.py for PyPI compatibility
- **Compatibility**: Keep fork reference in requirements.txt for Docker/development builds with BLE hanging fixes

### Windows Installer
- **Problem**: GitHub Actions workflow looking for installer in wrong location
- **Solution**: Fixed paths to `scripts/MMRelay_setup_${{ env.FILE_VERSION }}.exe` in workflow

## Technical Implementation

### Dual Dependency Strategy
- **PyPI releases**: Use upstream `meshtastic>=2.6.4` (latest stable)
- **Docker/development**: Use fork with BLE hanging fixes via requirements.txt
- **Documentation**: Added note in README explaining temporary fork usage

### Benefits
- **PyPI compliance**: No direct git dependencies in published package
- **BLE stability**: Docker builds still get hanging fixes
- **Future-proof**: Easy transition when upstream merges fixes
- **Transparency**: Clear documentation of temporary workaround

## Files Modified
- `setup.py` - Changed to upstream meshtastic dependency
- `requirements.txt` - Added fork reference with explanatory comments
- `README.md` - Added note about Docker fork usage
- `.github/workflows/package-windows.yml` - Fixed installer artifact paths

## Testing
- Verified setup.py contains only PyPI-compatible dependencies
- Confirmed requirements.txt maintains BLE fixes for Docker builds
- Fixed Windows installer workflow to look in correct directory

This approach ensures successful PyPI publishing while maintaining BLE stability for Docker users until upstream fixes are merged.
