### PR TITLE
feat: hide username prefix when bridging from matrix->meshtastic

### DIFF
--- a/src/mmrelay/tools/sample_config.yaml
+++ b/src/mmrelay/tools/sample_config.yaml
@@ -21,6 +21,7 @@ meshtastic:
   message_interactions: # Configure reactions and replies (both require message storage in database)
     reactions: false # Enable reaction relaying between platforms
     replies: false   # Enable reply relaying between platforms
+  prefix_enabled: true
 
   # Connection health monitoring configuration
   #health_check:


### PR DESCRIPTION
When using private bridging between my matrix room and meshtastic network, there is no need to add prefix before every message that is being sent to meshtastic