### PR TITLE
Add persistent plugin dependency installation tracking

### DIFF
--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -18,7 +18,7 @@ runtimes:
 # This is the section where you manage your linters. (https://docs.trunk.io/check/configuration)
 lint:
   enabled:
-    - renovate@43.139.6
+    - renovate@43.141.6
     - shellcheck@0.11.0
     - shfmt@3.6.0
     - mypy@1.20.2
@@ -29,13 +29,13 @@ lint:
     - actionlint@1.7.12
     - bandit@1.9.4
     - black@26.3.1
-    - checkov@3.2.524
+    - checkov@3.2.525
     - git-diff-check
     - isort@8.0.1
     - markdownlint@0.48.0
     - osv-scanner@2.3.5
     - prettier@3.8.3
-    - ruff@0.15.11
+    - ruff@0.15.12
     - trufflehog@3.95.2
     - yamllint@1.38.0
   definitions:

--- a/src/mmrelay/plugin_loader.py
+++ b/src/mmrelay/plugin_loader.py
@@ -867,7 +867,7 @@ def _requirements_install_target_identity() -> str:
     try:
         user_site = site.getusersitepackages()
     except AttributeError:
-        user_site = "unknown"
+        return "user:unknown"
     if isinstance(user_site, str):
         return f"user:{os.path.abspath(user_site)}"
     return "user:" + os.pathsep.join(os.path.abspath(path) for path in user_site)
@@ -936,8 +936,36 @@ def _effective_requirements_for_repo(
 
 
 def _requirements_hash(requirements: Sequence[str]) -> str:
+    """Hash all safe effective requirement lines, including pip option lines."""
     payload = "\n".join(requirements).encode(DEFAULT_TEXT_ENCODING)
     return hashlib.sha256(payload).hexdigest()
+
+
+def _installable_requirement_lines(requirements: Sequence[str]) -> list[str]:
+    return [
+        requirement for requirement in requirements if not requirement.startswith("-")
+    ]
+
+
+@contextmanager
+def _temporary_requirements_file(requirements: Sequence[str]) -> Iterator[str]:
+    with tempfile.NamedTemporaryFile(
+        mode="w", suffix=".txt", delete=False
+    ) as temp_file:
+        temp_path = temp_file.name
+        for entry in requirements:
+            temp_file.write(entry + "\n")
+
+    try:
+        yield temp_path
+    finally:
+        try:
+            os.unlink(temp_path)
+        except OSError:
+            logger.debug(
+                "Failed to clean up temporary requirements file: %s",
+                temp_path,
+            )
 
 
 def _install_requirements_for_repo(
@@ -983,6 +1011,7 @@ def _install_requirements_for_repo(
         safe_requirements = effective_requirements.allowed
         requirements_hash = _requirements_hash(safe_requirements)
         requirements_target = _requirements_install_target_identity()
+        packages = _installable_requirement_lines(safe_requirements)
 
         installed_packages = False
         handled_requirements = False
@@ -993,7 +1022,6 @@ def _install_requirements_for_repo(
                 repo_name,
                 install_target,
             )
-            packages = [r for r in safe_requirements if not r.startswith("-")]
             if not packages:
                 logger.info(
                     "Requirements in %s provided no installable packages; skipping pip install.",
@@ -1020,33 +1048,16 @@ def _install_requirements_for_repo(
                     os.fspath(install_target),
                 ]
 
-                with tempfile.NamedTemporaryFile(
-                    mode="w", suffix=".txt", delete=False
-                ) as temp_file:
-                    temp_path = temp_file.name
-                    for entry in safe_requirements:
-                        temp_file.write(entry + "\n")
-
-                try:
+                with _temporary_requirements_file(safe_requirements) as temp_path:
                     cmd.extend(["-r", temp_path])
                     _run(cmd, timeout=PIP_INSTALL_TIMEOUT_SECONDS)
                     installed_packages = True
                     handled_requirements = True
-                finally:
-                    try:
-                        os.unlink(temp_path)
-                    except OSError:
-                        logger.debug(
-                            "Failed to clean up temporary requirements file: %s",
-                            temp_path,
-                        )
         elif in_pipx:
             logger.info("Installing requirements for plugin %s with pipx", repo_name)
             pipx_path = shutil.which("pipx")
             if not pipx_path:
                 raise FileNotFoundError("pipx executable not found on PATH")
-            # Check if there are actual packages to install (not just flags)
-            packages = [r for r in safe_requirements if not r.startswith("-")]
             if packages:
                 if (
                     plugin_type == PLUGIN_TYPE_COMMUNITY
@@ -1056,16 +1067,7 @@ def _install_requirements_for_repo(
                         "Community plugin dependencies execute arbitrary code and are unsafe"
                     )
                     _community_dep_install_warning_logged = True
-                # Write safe requirements to a temporary file to handle hashed requirements
-                # and environment markers properly
-                with tempfile.NamedTemporaryFile(
-                    mode="w", suffix=".txt", delete=False
-                ) as temp_file:
-                    temp_path = temp_file.name
-                    for entry in safe_requirements:
-                        temp_file.write(entry + "\n")
-
-                try:
+                with _temporary_requirements_file(safe_requirements) as temp_path:
                     cmd = [
                         pipx_path,
                         "inject",
@@ -1076,15 +1078,6 @@ def _install_requirements_for_repo(
                     _run(cmd, timeout=PIP_INSTALL_TIMEOUT_SECONDS)
                     installed_packages = True
                     handled_requirements = True
-                finally:
-                    # Clean up the temporary file
-                    try:
-                        os.unlink(temp_path)
-                    except OSError:
-                        logger.debug(
-                            "Failed to clean up temporary requirements file: %s",
-                            temp_path,
-                        )
             else:
                 logger.info(
                     "No dependencies listed in %s; skipping pipx injection.",
@@ -1096,7 +1089,6 @@ def _install_requirements_for_repo(
                 "VIRTUAL_ENV" in os.environ
             )
             logger.info("Installing requirements for plugin %s with pip", repo_name)
-            packages = [r for r in safe_requirements if not r.startswith("-")]
             if not packages:
                 logger.info(
                     "Requirements in %s provided no installable packages; skipping pip install.",
@@ -1123,28 +1115,11 @@ def _install_requirements_for_repo(
                 if not in_venv:
                     cmd.append("--user")
 
-                # Write safe requirements to a temporary file to handle hashed requirements properly
-                with tempfile.NamedTemporaryFile(
-                    mode="w", suffix=".txt", delete=False
-                ) as temp_file:
-                    temp_path = temp_file.name
-                    for entry in safe_requirements:
-                        temp_file.write(entry + "\n")
-
-                try:
+                with _temporary_requirements_file(safe_requirements) as temp_path:
                     cmd.extend(["-r", temp_path])
                     _run(cmd, timeout=PIP_INSTALL_TIMEOUT_SECONDS)
                     installed_packages = True
                     handled_requirements = True
-                finally:
-                    # Clean up the temporary file
-                    try:
-                        os.unlink(temp_path)
-                    except OSError:
-                        logger.debug(
-                            "Failed to clean up temporary requirements file: %s",
-                            temp_path,
-                        )
 
         if installed_packages:
             logger.info("Successfully installed requirements for plugin %s", repo_name)

--- a/src/mmrelay/plugin_loader.py
+++ b/src/mmrelay/plugin_loader.py
@@ -10,6 +10,7 @@ import shutil
 import site
 import subprocess
 import sys
+import sysconfig
 import tempfile
 import threading
 import time
@@ -23,6 +24,7 @@ import mmrelay.paths as paths_module
 from mmrelay.config import (
     get_app_path,
 )
+from mmrelay.constants.app import PLUGINS_DIRNAME
 from mmrelay.constants.config import (
     CONFIG_SECTION_COMMUNITY_PLUGINS,
     CONFIG_SECTION_CUSTOM_PLUGINS,
@@ -106,6 +108,7 @@ _global_scheduler_stop_event: threading.Event | None = None
 
 # Plugin dependency directory (may not be set if base dir can't be resolved)
 _PLUGIN_DEPS_DIR: str | None = None
+PLUGIN_DEPS_DIRNAME: Final[str] = "deps"
 PLUGIN_REQUIREMENTS_FILENAME: Final[str] = "requirements.txt"
 PLUGIN_STATE_FILENAME: Final[str] = ".mmrelay-plugin-state.json"
 PLUGIN_STATE_LAST_INSTALLED_REQUIREMENTS_COMMIT: Final[str] = (
@@ -132,6 +135,13 @@ class EffectiveRequirements(NamedTuple):
 
     allowed: list[str]
     flagged: list[str]
+
+
+class RequirementsInstallTarget(NamedTuple):
+    """Dependency install target identity and preferred marker location."""
+
+    identity: str
+    marker_dir: str | None
 
 
 def _is_safe_plugin_name(name: str) -> bool:
@@ -201,12 +211,15 @@ def _get_plugin_root_dirs() -> list[str]:
     seen: set[str] = set()
 
     try:
-        home_dir = str(paths_module.get_home_dir())
-        if home_dir:
-            home_plugins = os.path.join(home_dir, "plugins")
-            if home_plugins not in seen:
-                roots.append(home_plugins)
-                seen.add(home_plugins)
+        try:
+            home_plugins = str(paths_module.get_plugins_dir())
+        except TypeError:
+            home_plugins = os.path.join(
+                str(paths_module.get_home_dir()), PLUGINS_DIRNAME
+            )
+        if home_plugins not in seen:
+            roots.append(home_plugins)
+            seen.add(home_plugins)
     except (OSError, RuntimeError, ValueError) as e:
         logger.warning("Could not determine primary plugin root: %s", e)
 
@@ -217,7 +230,7 @@ def _get_plugin_root_dirs() -> list[str]:
         legacy_dirs_list = []
 
     for legacy_root in legacy_dirs_list:
-        legacy_plugins = os.path.join(str(legacy_root), "plugins")
+        legacy_plugins = os.path.join(str(legacy_root), PLUGINS_DIRNAME)
         if legacy_plugins not in seen and os.path.exists(legacy_plugins):
             roots.append(legacy_plugins)
             seen.add(legacy_plugins)
@@ -247,7 +260,7 @@ def _get_legacy_plugin_roots() -> set[str]:
     If discovery of legacy bases fails, an empty set is returned and a warning is logged.
 
     Returns:
-        A set of path strings for legacy "plugins" directories; empty if discovery fails or none are found.
+        A set of path strings for legacy plugin directories; empty if discovery fails or none are found.
     """
     try:
         legacy_dirs = paths_module.get_legacy_dirs()
@@ -257,7 +270,7 @@ def _get_legacy_plugin_roots() -> set[str]:
 
     legacy_roots: set[str] = set()
     for legacy_root in legacy_dirs:
-        legacy_roots.add(os.path.join(str(legacy_root), "plugins"))
+        legacy_roots.add(os.path.join(str(legacy_root), PLUGINS_DIRNAME))
     return legacy_roots
 
 
@@ -275,7 +288,10 @@ else:
                 deps_root,
             )
             continue
-        deps_dir = os.path.join(deps_root, "deps")
+        if deps_root == str(paths_module.get_plugins_dir()):
+            deps_dir = str(paths_module.resolve_all_paths()["deps_dir"])
+        else:
+            deps_dir = os.path.join(deps_root, PLUGIN_DEPS_DIRNAME)
         try:
             os.makedirs(deps_dir, exist_ok=True)
         except (
@@ -819,14 +835,122 @@ def _requirements_marker_repo_identity(repo_path: str, repo_name: str) -> str:
     return hashlib.sha256(repo_identity.encode(DEFAULT_TEXT_ENCODING)).hexdigest()[:24]
 
 
+def _path_freshness_stamp(path: str | None) -> str:
+    if not path:
+        return "unavailable"
+    try:
+        return str(os.stat(path).st_mtime_ns)
+    except OSError:
+        return "missing"
+
+
+def _is_writable_directory(path: str | None) -> bool:
+    return bool(path and os.path.isdir(path) and os.access(path, os.W_OK))
+
+
+def _site_packages_for_prefix(prefix: str) -> str | None:
+    prefix_path = os.path.abspath(prefix)
+    candidates: list[str] = []
+
+    try:
+        site_packages = site.getsitepackages()
+        candidates.extend(path for path in site_packages if isinstance(path, str))
+    except AttributeError:
+        logger.debug("site.getsitepackages() not available in this environment.")
+
+    for scheme in ("venv", "posix_prefix"):
+        try:
+            purelib = sysconfig.get_path(
+                "purelib",
+                scheme=scheme,
+                vars={"base": prefix_path, "platbase": prefix_path},
+            )
+            if purelib:
+                candidates.append(purelib)
+        except (KeyError, AttributeError):
+            continue
+
+    for candidate in dict.fromkeys(candidates):
+        candidate_path = os.path.abspath(candidate)
+        if candidate_path == prefix_path or candidate_path.startswith(
+            prefix_path + os.sep
+        ):
+            return candidate_path
+
+    return None
+
+
+def _requirements_install_target() -> RequirementsInstallTarget:
+    if _PLUGIN_DEPS_DIR:
+        deps_dir = os.path.abspath(os.fspath(_PLUGIN_DEPS_DIR))
+        return RequirementsInstallTarget(
+            identity=f"target:{deps_dir}", marker_dir=deps_dir
+        )
+
+    prefix = os.path.abspath(sys.prefix)
+    if any(key in os.environ for key in PIPX_ENVIRONMENT_KEYS):
+        site_packages = _site_packages_for_prefix(prefix)
+        stamp_path = site_packages or prefix
+        identity = (
+            f"pipx:{prefix}:"
+            f"{os.path.abspath(site_packages) if site_packages else 'site-packages:unknown'}:"
+            f"{_path_freshness_stamp(stamp_path)}"
+        )
+        return RequirementsInstallTarget(
+            identity=identity,
+            marker_dir=site_packages if _is_writable_directory(site_packages) else None,
+        )
+
+    in_venv = (sys.prefix != getattr(sys, "base_prefix", sys.prefix)) or (
+        "VIRTUAL_ENV" in os.environ
+    )
+    if in_venv:
+        site_packages = _site_packages_for_prefix(prefix)
+        stamp_path = site_packages or prefix
+        identity = (
+            f"python:{prefix}:"
+            f"{os.path.abspath(site_packages) if site_packages else 'site-packages:unknown'}:"
+            f"{_path_freshness_stamp(stamp_path)}"
+        )
+        return RequirementsInstallTarget(
+            identity=identity,
+            marker_dir=site_packages if _is_writable_directory(site_packages) else None,
+        )
+
+    try:
+        user_site = site.getusersitepackages()
+    except AttributeError:
+        return RequirementsInstallTarget(identity="user:unknown", marker_dir=None)
+
+    if isinstance(user_site, str):
+        user_site_path = os.path.abspath(user_site)
+        return RequirementsInstallTarget(
+            identity=f"user:{user_site_path}:{_path_freshness_stamp(user_site_path)}",
+            marker_dir=(
+                user_site_path if _is_writable_directory(user_site_path) else None
+            ),
+        )
+
+    user_site_paths = [os.path.abspath(path) for path in user_site]
+    identity_parts = [
+        f"{path}:{_path_freshness_stamp(path)}" for path in user_site_paths
+    ]
+    marker_dir = next(
+        (path for path in user_site_paths if _is_writable_directory(path)), None
+    )
+    return RequirementsInstallTarget(
+        identity="user:" + os.pathsep.join(identity_parts),
+        marker_dir=marker_dir,
+    )
+
+
 def _requirements_install_marker_path(repo_path: str, repo_name: str) -> str:
     marker_name = (
         f"{PLUGIN_REQUIREMENTS_INSTALL_MARKER_PREFIX}-"
         f"{_requirements_marker_repo_identity(repo_path, repo_name)}.json"
     )
-    if _PLUGIN_DEPS_DIR:
-        return os.path.join(os.fspath(_PLUGIN_DEPS_DIR), marker_name)
-    return os.path.join(repo_path, marker_name)
+    marker_dir = _requirements_install_target().marker_dir or repo_path
+    return os.path.join(marker_dir, marker_name)
 
 
 def _write_requirements_install_marker(
@@ -836,41 +960,41 @@ def _write_requirements_install_marker(
     target: str,
 ) -> None:
     marker_path = _requirements_install_marker_path(repo_path, repo_name)
-    os.makedirs(os.path.dirname(marker_path), exist_ok=True)
-    with open(marker_path, "w", encoding=DEFAULT_TEXT_ENCODING) as marker_file:
-        json.dump(
-            {
-                "requirements_hash": requirements_hash,
-                "target": target,
-                "installed_at": datetime.now(timezone.utc).isoformat(),
-                "repo": repo_name,
-            },
-            marker_file,
-            sort_keys=True,
-        )
-        marker_file.write("\n")
+    marker_dir = os.path.dirname(marker_path)
+    tmp_path: str | None = None
+    try:
+        os.makedirs(marker_dir, exist_ok=True)
+        with tempfile.NamedTemporaryFile(
+            mode="w",
+            encoding=DEFAULT_TEXT_ENCODING,
+            delete=False,
+            dir=marker_dir,
+        ) as marker_file:
+            json.dump(
+                {
+                    "requirements_hash": requirements_hash,
+                    "target": target,
+                    "installed_at": datetime.now(timezone.utc).isoformat(),
+                    "repo": repo_name,
+                },
+                marker_file,
+                sort_keys=True,
+            )
+            marker_file.write("\n")
+            marker_file.flush()
+            os.fsync(marker_file.fileno())
+            tmp_path = marker_file.name
+        os.replace(tmp_path, marker_path)
+    finally:
+        if tmp_path and os.path.exists(tmp_path):
+            try:
+                os.unlink(tmp_path)
+            except OSError:
+                pass
 
 
 def _requirements_install_target_identity() -> str:
-    if _PLUGIN_DEPS_DIR:
-        return f"target:{os.path.abspath(os.fspath(_PLUGIN_DEPS_DIR))}"
-
-    if any(key in os.environ for key in PIPX_ENVIRONMENT_KEYS):
-        return "pipx:mmrelay"
-
-    in_venv = (sys.prefix != getattr(sys, "base_prefix", sys.prefix)) or (
-        "VIRTUAL_ENV" in os.environ
-    )
-    if in_venv:
-        return f"python:{os.path.abspath(sys.prefix)}"
-
-    try:
-        user_site = site.getusersitepackages()
-    except AttributeError:
-        return "user:unknown"
-    if isinstance(user_site, str):
-        return f"user:{os.path.abspath(user_site)}"
-    return "user:" + os.pathsep.join(os.path.abspath(path) for path in user_site)
+    return _requirements_install_target().identity
 
 
 def _requirements_install_target_valid(
@@ -1127,6 +1251,7 @@ def _install_requirements_for_repo(
         else:
             logger.info("No dependency installation run for plugin %s", repo_name)
         if handled_requirements:
+            requirements_target = _requirements_install_target_identity()
             _write_requirements_install_marker(
                 repo_path, repo_name, requirements_hash, requirements_target
             )
@@ -1164,7 +1289,7 @@ def _get_plugin_dirs(plugin_type: str) -> list[str]:
 
     legacy_roots = _get_legacy_plugin_roots()
     for root_dir in _get_plugin_root_dirs():
-        if os.path.basename(root_dir) == "plugins":
+        if os.path.basename(root_dir) == PLUGINS_DIRNAME:
             user_dir = os.path.join(root_dir, plugin_type)
         else:
             user_dir = root_dir
@@ -1185,7 +1310,7 @@ def _get_plugin_dirs(plugin_type: str) -> list[str]:
             logger.warning("Cannot create user plugin directory %s: %s", user_dir, e)
 
     # Check local directory (backward compatibility)
-    local_dir = os.path.join(get_app_path(), "plugins", plugin_type)
+    local_dir = os.path.join(get_app_path(), PLUGINS_DIRNAME, plugin_type)
     try:
         os.makedirs(local_dir, exist_ok=True)
         dirs.append(local_dir)
@@ -3380,6 +3505,17 @@ def load_plugins(passed_config: Any = None) -> list[Any]:
                             plugin_name,
                         )
                     else:
+                        requirements_path = os.path.join(
+                            repo_path, PLUGIN_REQUIREMENTS_FILENAME
+                        )
+                        if not os.path.isfile(requirements_path):
+                            logger.debug(
+                                "Skipping requirements install for community plugin %s; no %s found",
+                                plugin_name,
+                                PLUGIN_REQUIREMENTS_FILENAME,
+                            )
+                            ready_community_plugins.append(plugin_name)
+                            continue
                         state = _load_plugin_state(repo_path)
                         effective_requirements = _effective_requirements_for_repo(
                             repo_path, repo_name
@@ -3421,6 +3557,9 @@ def load_plugins(passed_config: Any = None) -> list[Any]:
                         elif _install_requirements_for_repo(
                             repo_path, repo_name, plugin_type=PLUGIN_TYPE_COMMUNITY
                         ):
+                            requirements_target = (
+                                _requirements_install_target_identity()
+                            )
                             state[PLUGIN_STATE_LAST_INSTALLED_REQUIREMENTS_COMMIT] = (
                                 pinned_sha
                             )

--- a/src/mmrelay/plugin_loader.py
+++ b/src/mmrelay/plugin_loader.py
@@ -120,11 +120,18 @@ PLUGIN_STATE_LAST_INSTALLED_REQUIREMENTS_TARGET: Final[str] = (
 PLUGIN_STATE_LAST_REQUIREMENTS_INSTALLED_AT: Final[str] = (
     "last_requirements_installed_at"
 )
-PLUGIN_REQUIREMENTS_INSTALL_MARKER_FILENAME: Final[str] = (
+PLUGIN_REQUIREMENTS_INSTALL_MARKER_PREFIX: Final[str] = (
     ".mmrelay-requirements-installed"
 )
 COMMUNITY_PLUGIN_UPDATE_CHECK_INTERVAL: Final[timedelta] = timedelta(hours=24)
 _community_dep_install_warning_logged = False
+
+
+class EffectiveRequirements(NamedTuple):
+    """Filtered plugin requirements used for both installs and state hashing."""
+
+    allowed: list[str]
+    flagged: list[str]
 
 
 def _is_safe_plugin_name(name: str) -> bool:
@@ -807,19 +814,41 @@ def _refresh_dependency_paths() -> None:
     importlib.invalidate_caches()
 
 
-def _requirements_install_marker_path(repo_path: str) -> str:
+def _requirements_marker_repo_identity(repo_path: str, repo_name: str) -> str:
+    repo_identity = f"{repo_name}:{os.path.abspath(repo_path)}"
+    return hashlib.sha256(repo_identity.encode(DEFAULT_TEXT_ENCODING)).hexdigest()[:24]
+
+
+def _requirements_install_marker_path(repo_path: str, repo_name: str) -> str:
+    marker_name = (
+        f"{PLUGIN_REQUIREMENTS_INSTALL_MARKER_PREFIX}-"
+        f"{_requirements_marker_repo_identity(repo_path, repo_name)}.json"
+    )
     if _PLUGIN_DEPS_DIR:
-        return os.path.join(
-            os.fspath(_PLUGIN_DEPS_DIR), PLUGIN_REQUIREMENTS_INSTALL_MARKER_FILENAME
-        )
-    return os.path.join(repo_path, PLUGIN_REQUIREMENTS_INSTALL_MARKER_FILENAME)
+        return os.path.join(os.fspath(_PLUGIN_DEPS_DIR), marker_name)
+    return os.path.join(repo_path, marker_name)
 
 
-def _write_requirements_install_marker(repo_path: str) -> None:
-    marker_path = _requirements_install_marker_path(repo_path)
+def _write_requirements_install_marker(
+    repo_path: str,
+    repo_name: str,
+    requirements_hash: str,
+    target: str,
+) -> None:
+    marker_path = _requirements_install_marker_path(repo_path, repo_name)
     os.makedirs(os.path.dirname(marker_path), exist_ok=True)
     with open(marker_path, "w", encoding=DEFAULT_TEXT_ENCODING) as marker_file:
-        marker_file.write(datetime.now(timezone.utc).isoformat() + "\n")
+        json.dump(
+            {
+                "requirements_hash": requirements_hash,
+                "target": target,
+                "installed_at": datetime.now(timezone.utc).isoformat(),
+                "repo": repo_name,
+            },
+            marker_file,
+            sort_keys=True,
+        )
+        marker_file.write("\n")
 
 
 def _requirements_install_target_identity() -> str:
@@ -844,22 +873,32 @@ def _requirements_install_target_identity() -> str:
     return "user:" + os.pathsep.join(os.path.abspath(path) for path in user_site)
 
 
-def _requirements_install_target_valid(repo_path: str) -> bool:
-    marker_exists = os.path.isfile(_requirements_install_marker_path(repo_path))
-    if _PLUGIN_DEPS_DIR:
-        deps_path = os.fspath(_PLUGIN_DEPS_DIR)
-        deps_has_content = False
-        if os.path.isdir(deps_path):
-            try:
-                with os.scandir(deps_path) as entries:
-                    deps_has_content = any(entries)
-            except OSError:
-                deps_has_content = False
-        return deps_has_content or marker_exists
-    return marker_exists
+def _requirements_install_target_valid(
+    repo_path: str,
+    repo_name: str,
+    requirements_hash: str,
+    target: str,
+) -> bool:
+    marker_path = _requirements_install_marker_path(repo_path, repo_name)
+    try:
+        with open(marker_path, encoding=DEFAULT_TEXT_ENCODING) as marker_file:
+            marker = json.load(marker_file)
+    except (OSError, json.JSONDecodeError):
+        return False
+
+    return (
+        isinstance(marker, dict)
+        and marker.get("requirements_hash") == requirements_hash
+        and marker.get("target") == target
+    )
 
 
-def _effective_requirements_for_repo(repo_path: str, repo_name: str) -> list[str]:
+def _effective_requirements_for_repo(
+    repo_path: str,
+    repo_name: str,
+    *,
+    log_flagged: bool = False,
+) -> EffectiveRequirements:
     requirements_path = os.path.join(repo_path, PLUGIN_REQUIREMENTS_FILENAME)
     requirements_lines = _collect_requirements(requirements_path)
     safe_requirements, flagged_requirements = _filter_risky_requirement_lines(
@@ -869,8 +908,21 @@ def _effective_requirements_for_repo(repo_path: str, repo_name: str) -> list[str
     allow_untrusted = bool(
         _get_security_settings().get("allow_untrusted_dependencies", False)
     )
-    if flagged_requirements and allow_untrusted:
-        safe_requirements.extend(flagged_requirements)
+    if flagged_requirements:
+        if allow_untrusted:
+            if log_flagged:
+                logger.warning(
+                    "Allowing %d flagged dependency entries for %s due to security.allow_untrusted_dependencies=True",
+                    len(flagged_requirements),
+                    repo_name,
+                )
+            safe_requirements.extend(flagged_requirements)
+        elif log_flagged:
+            logger.warning(
+                "Skipping %d flagged dependency entries for %s. Set security.allow_untrusted_dependencies=True to override.",
+                len(flagged_requirements),
+                repo_name,
+            )
 
     logger.debug(
         "Computed effective requirements for plugin %s: %d allowed, %d flagged",
@@ -878,7 +930,9 @@ def _effective_requirements_for_repo(repo_path: str, repo_name: str) -> list[str
         len(safe_requirements),
         len(flagged_requirements),
     )
-    return safe_requirements
+    return EffectiveRequirements(
+        allowed=safe_requirements, flagged=flagged_requirements
+    )
 
 
 def _requirements_hash(requirements: Sequence[str]) -> str:
@@ -894,11 +948,14 @@ def _install_requirements_for_repo(
     """
     Install dependencies listed in repo_path/requirements.txt for a community plugin and refresh import paths.
 
-    This function is a no-op if no requirements file exists. It installs allowed dependency
-    entries either into the application's pipx environment (when pipx is in use) or into
-    the current Python environment (using pip). After a successful installation the
-    interpreter import/search paths are refreshed so newly installed packages become
-    importable. Failures are logged and do not raise from this function.
+    This function is a no-op if no requirements file exists. When the persistent
+    plugin dependency directory is available, allowed dependency entries are
+    installed there with pip --target so they survive container restarts. If no
+    persistent dependency directory is configured, it falls back to pipx inject
+    when running under pipx, otherwise pip installs into the current environment
+    or the user site outside a virtual environment. After a successful install
+    the interpreter import/search paths are refreshed so newly installed packages
+    become importable. Failures are logged and do not raise from this function.
 
     Parameters:
         repo_path: Filesystem path to the plugin repository (looks for a requirements.txt file at this location).
@@ -920,33 +977,15 @@ def _install_requirements_for_repo(
             key in os.environ for key in PIPX_ENVIRONMENT_KEYS
         )
 
-        requirements_lines = _collect_requirements(requirements_path)
-        safe_requirements, flagged_requirements = _filter_risky_requirement_lines(
-            requirements_lines
+        effective_requirements = _effective_requirements_for_repo(
+            repo_path, repo_name, log_flagged=True
         )
-
-        # Check security configuration for handling flagged requirements
-        allow_untrusted = bool(
-            _get_security_settings().get("allow_untrusted_dependencies", False)
-        )
-
-        if flagged_requirements:
-            if allow_untrusted:
-                logger.warning(
-                    "Allowing %d flagged dependency entries for %s due to security.allow_untrusted_dependencies=True",
-                    len(flagged_requirements),
-                    repo_name,
-                )
-                # Include flagged requirements when allowed
-                safe_requirements.extend(flagged_requirements)
-            else:
-                logger.warning(
-                    "Skipping %d flagged dependency entries for %s. Set security.allow_untrusted_dependencies=True to override.",
-                    len(flagged_requirements),
-                    repo_name,
-                )
+        safe_requirements = effective_requirements.allowed
+        requirements_hash = _requirements_hash(safe_requirements)
+        requirements_target = _requirements_install_target_identity()
 
         installed_packages = False
+        handled_requirements = False
 
         if install_target is not None:
             logger.info(
@@ -960,6 +999,7 @@ def _install_requirements_for_repo(
                     "Requirements in %s provided no installable packages; skipping pip install.",
                     requirements_path,
                 )
+                handled_requirements = True
             else:
                 if (
                     plugin_type == PLUGIN_TYPE_COMMUNITY
@@ -991,6 +1031,7 @@ def _install_requirements_for_repo(
                     cmd.extend(["-r", temp_path])
                     _run(cmd, timeout=PIP_INSTALL_TIMEOUT_SECONDS)
                     installed_packages = True
+                    handled_requirements = True
                 finally:
                     try:
                         os.unlink(temp_path)
@@ -1034,6 +1075,7 @@ def _install_requirements_for_repo(
                     ]
                     _run(cmd, timeout=PIP_INSTALL_TIMEOUT_SECONDS)
                     installed_packages = True
+                    handled_requirements = True
                 finally:
                     # Clean up the temporary file
                     try:
@@ -1048,6 +1090,7 @@ def _install_requirements_for_repo(
                     "No dependencies listed in %s; skipping pipx injection.",
                     requirements_path,
                 )
+                handled_requirements = True
         else:
             in_venv = (sys.prefix != getattr(sys, "base_prefix", sys.prefix)) or (
                 "VIRTUAL_ENV" in os.environ
@@ -1059,6 +1102,7 @@ def _install_requirements_for_repo(
                     "Requirements in %s provided no installable packages; skipping pip install.",
                     requirements_path,
                 )
+                handled_requirements = True
             else:
                 if (
                     plugin_type == PLUGIN_TYPE_COMMUNITY
@@ -1091,6 +1135,7 @@ def _install_requirements_for_repo(
                     cmd.extend(["-r", temp_path])
                     _run(cmd, timeout=PIP_INSTALL_TIMEOUT_SECONDS)
                     installed_packages = True
+                    handled_requirements = True
                 finally:
                     # Clean up the temporary file
                     try:
@@ -1103,10 +1148,13 @@ def _install_requirements_for_repo(
 
         if installed_packages:
             logger.info("Successfully installed requirements for plugin %s", repo_name)
-            _write_requirements_install_marker(repo_path)
             _refresh_dependency_paths()
         else:
             logger.info("No dependency installation run for plugin %s", repo_name)
+        if handled_requirements:
+            _write_requirements_install_marker(
+                repo_path, repo_name, requirements_hash, requirements_target
+            )
         return True
     except (
         OSError,
@@ -3358,8 +3406,11 @@ def load_plugins(passed_config: Any = None) -> list[Any]:
                         )
                     else:
                         state = _load_plugin_state(repo_path)
+                        effective_requirements = _effective_requirements_for_repo(
+                            repo_path, repo_name
+                        )
                         requirements_hash = _requirements_hash(
-                            _effective_requirements_for_repo(repo_path, repo_name)
+                            effective_requirements.allowed
                         )
                         requirements_target = _requirements_install_target_identity()
                         last_installed_commit = state.get(
@@ -3378,7 +3429,12 @@ def load_plugins(passed_config: Any = None) -> list[Any]:
                             and last_installed_hash == requirements_hash
                             and isinstance(last_installed_target, str)
                             and last_installed_target == requirements_target
-                            and _requirements_install_target_valid(repo_path)
+                            and _requirements_install_target_valid(
+                                repo_path,
+                                repo_name,
+                                requirements_hash,
+                                requirements_target,
+                            )
                         ):
                             logger.debug(
                                 "Skipping requirements install for community plugin %s; already installed for commit %s, requirements hash %s, target %s",

--- a/src/mmrelay/plugin_loader.py
+++ b/src/mmrelay/plugin_loader.py
@@ -274,6 +274,22 @@ def _get_legacy_plugin_roots() -> set[str]:
     return legacy_roots
 
 
+def _resolve_plugin_deps_dir_for_root(deps_root: str) -> str:
+    """Resolve the dependency directory for a plugin root using paths.py when possible."""
+    try:
+        primary_plugins_dir = os.path.abspath(str(paths_module.get_plugins_dir()))
+        resolved_deps_dir = os.path.abspath(
+            str(paths_module.resolve_all_paths()["deps_dir"])
+        )
+    except (KeyError, OSError, RuntimeError, TypeError, ValueError) as exc:
+        logger.debug("Could not resolve canonical deps dir: %s", exc)
+        return os.path.join(deps_root, PLUGIN_DEPS_DIRNAME)
+
+    if os.path.abspath(deps_root) == primary_plugins_dir:
+        return resolved_deps_dir
+    return os.path.join(deps_root, PLUGIN_DEPS_DIRNAME)
+
+
 try:
     deps_roots = _get_plugin_root_dirs()
 except (OSError, RuntimeError, ValueError) as exc:  # pragma: no cover
@@ -288,10 +304,7 @@ else:
                 deps_root,
             )
             continue
-        if deps_root == str(paths_module.get_plugins_dir()):
-            deps_dir = str(paths_module.resolve_all_paths()["deps_dir"])
-        else:
-            deps_dir = os.path.join(deps_root, PLUGIN_DEPS_DIRNAME)
+        deps_dir = _resolve_plugin_deps_dir_for_root(deps_root)
         try:
             os.makedirs(deps_dir, exist_ok=True)
         except (
@@ -835,15 +848,6 @@ def _requirements_marker_repo_identity(repo_path: str, repo_name: str) -> str:
     return hashlib.sha256(repo_identity.encode(DEFAULT_TEXT_ENCODING)).hexdigest()[:24]
 
 
-def _path_freshness_stamp(path: str | None) -> str:
-    if not path:
-        return "unavailable"
-    try:
-        return str(os.stat(path).st_mtime_ns)
-    except OSError:
-        return "missing"
-
-
 def _is_writable_directory(path: str | None) -> bool:
     return bool(path and os.path.isdir(path) and os.access(path, os.W_OK))
 
@@ -858,7 +862,8 @@ def _site_packages_for_prefix(prefix: str) -> str | None:
     except AttributeError:
         logger.debug("site.getsitepackages() not available in this environment.")
 
-    for scheme in ("venv", "posix_prefix"):
+    schemes = ("venv", "nt") if sys.platform == "win32" else ("venv", "posix_prefix")
+    for scheme in schemes:
         try:
             purelib = sysconfig.get_path(
                 "purelib",
@@ -872,9 +877,7 @@ def _site_packages_for_prefix(prefix: str) -> str | None:
 
     for candidate in dict.fromkeys(candidates):
         candidate_path = os.path.abspath(candidate)
-        if candidate_path == prefix_path or candidate_path.startswith(
-            prefix_path + os.sep
-        ):
+        if _is_path_contained(prefix_path, candidate_path):
             return candidate_path
 
     return None
@@ -890,11 +893,9 @@ def _requirements_install_target() -> RequirementsInstallTarget:
     prefix = os.path.abspath(sys.prefix)
     if any(key in os.environ for key in PIPX_ENVIRONMENT_KEYS):
         site_packages = _site_packages_for_prefix(prefix)
-        stamp_path = site_packages or prefix
         identity = (
             f"pipx:{prefix}:"
-            f"{os.path.abspath(site_packages) if site_packages else 'site-packages:unknown'}:"
-            f"{_path_freshness_stamp(stamp_path)}"
+            f"{os.path.abspath(site_packages) if site_packages else 'site-packages:unknown'}"
         )
         return RequirementsInstallTarget(
             identity=identity,
@@ -906,11 +907,9 @@ def _requirements_install_target() -> RequirementsInstallTarget:
     )
     if in_venv:
         site_packages = _site_packages_for_prefix(prefix)
-        stamp_path = site_packages or prefix
         identity = (
             f"python:{prefix}:"
-            f"{os.path.abspath(site_packages) if site_packages else 'site-packages:unknown'}:"
-            f"{_path_freshness_stamp(stamp_path)}"
+            f"{os.path.abspath(site_packages) if site_packages else 'site-packages:unknown'}"
         )
         return RequirementsInstallTarget(
             identity=identity,
@@ -925,21 +924,18 @@ def _requirements_install_target() -> RequirementsInstallTarget:
     if isinstance(user_site, str):
         user_site_path = os.path.abspath(user_site)
         return RequirementsInstallTarget(
-            identity=f"user:{user_site_path}:{_path_freshness_stamp(user_site_path)}",
+            identity=f"user:{user_site_path}",
             marker_dir=(
                 user_site_path if _is_writable_directory(user_site_path) else None
             ),
         )
 
     user_site_paths = [os.path.abspath(path) for path in user_site]
-    identity_parts = [
-        f"{path}:{_path_freshness_stamp(path)}" for path in user_site_paths
-    ]
     marker_dir = next(
         (path for path in user_site_paths if _is_writable_directory(path)), None
     )
     return RequirementsInstallTarget(
-        identity="user:" + os.pathsep.join(identity_parts),
+        identity="user:" + os.pathsep.join(user_site_paths),
         marker_dir=marker_dir,
     )
 
@@ -3533,28 +3529,36 @@ def load_plugins(passed_config: Any = None) -> list[Any]:
                         last_installed_target = state.get(
                             PLUGIN_STATE_LAST_INSTALLED_REQUIREMENTS_TARGET
                         )
-                        if (
+                        state_matches_requirements = (
                             isinstance(last_installed_commit, str)
                             and last_installed_commit == pinned_sha
                             and isinstance(last_installed_hash, str)
                             and last_installed_hash == requirements_hash
                             and isinstance(last_installed_target, str)
                             and last_installed_target == requirements_target
-                            and _requirements_install_target_valid(
+                        )
+                        if state_matches_requirements:
+                            if _requirements_install_target_valid(
                                 repo_path,
                                 repo_name,
                                 requirements_hash,
                                 requirements_target,
-                            )
-                        ):
+                            ):
+                                logger.debug(
+                                    "Skipping requirements install for community plugin %s; already installed for commit %s, requirements hash %s, target %s",
+                                    plugin_name,
+                                    pinned_sha,
+                                    requirements_hash,
+                                    requirements_target,
+                                )
+                                ready_community_plugins.append(plugin_name)
+                                continue
                             logger.debug(
-                                "Skipping requirements install for community plugin %s; already installed for commit %s, requirements hash %s, target %s",
+                                "Reinstalling requirements for community plugin %s; install state matches but marker validation failed for target %s",
                                 plugin_name,
-                                pinned_sha,
-                                requirements_hash,
                                 requirements_target,
                             )
-                        elif _install_requirements_for_repo(
+                        if _install_requirements_for_repo(
                             repo_path, repo_name, plugin_type=PLUGIN_TYPE_COMMUNITY
                         ):
                             requirements_target = (

--- a/src/mmrelay/plugin_loader.py
+++ b/src/mmrelay/plugin_loader.py
@@ -14,7 +14,7 @@ import sysconfig
 import tempfile
 import threading
 import time
-from contextlib import contextmanager
+from contextlib import contextmanager, suppress
 from datetime import datetime, timedelta, timezone
 from types import ModuleType
 from typing import Any, Final, Iterator, NamedTuple, NoReturn, Sequence, cast
@@ -983,10 +983,8 @@ def _write_requirements_install_marker(
         os.replace(tmp_path, marker_path)
     finally:
         if tmp_path and os.path.exists(tmp_path):
-            try:
+            with suppress(OSError):
                 os.unlink(tmp_path)
-            except OSError:
-                pass
 
 
 def _requirements_install_target_identity() -> str:
@@ -1092,7 +1090,31 @@ def _temporary_requirements_file(requirements: Sequence[str]) -> Iterator[str]:
             )
 
 
+def _merge_dependency_directory(source_dir: str, destination_dir: str) -> None:
+    os.makedirs(destination_dir, exist_ok=True)
+    for item_name in os.listdir(source_dir):
+        source_path = os.path.join(source_dir, item_name)
+        destination_path = os.path.join(destination_dir, item_name)
+        _replace_dependency_target_item(source_path, destination_path)
+    shutil.rmtree(source_dir)
+
+
+def _is_namespace_package_directory(path: str) -> bool:
+    return not os.path.exists(os.path.join(path, "__init__.py"))
+
+
 def _replace_dependency_target_item(source_path: str, destination_path: str) -> None:
+    if (
+        os.path.isdir(source_path)
+        and not os.path.islink(source_path)
+        and os.path.isdir(destination_path)
+        and not os.path.islink(destination_path)
+        and _is_namespace_package_directory(source_path)
+        and _is_namespace_package_directory(destination_path)
+    ):
+        _merge_dependency_directory(source_path, destination_path)
+        return
+
     if os.path.lexists(destination_path):
         if os.path.isdir(destination_path) and not os.path.islink(destination_path):
             shutil.rmtree(destination_path)
@@ -1108,7 +1130,8 @@ def _normalize_distribution_name(distribution_name: str) -> str:
 def _metadata_distribution_key(item_name: str, item_path: str) -> str | None:
     for suffix in (".dist-info", ".egg-info"):
         if item_name.endswith(suffix):
-            metadata_path = os.path.join(item_path, "METADATA")
+            metadata_filename = "PKG-INFO" if suffix == ".egg-info" else "METADATA"
+            metadata_path = os.path.join(item_path, metadata_filename)
             try:
                 with open(
                     metadata_path, encoding=DEFAULT_TEXT_ENCODING
@@ -1159,6 +1182,8 @@ def _install_requirements_for_repo(
     repo_path: str,
     repo_name: str,
     plugin_type: str = PLUGIN_TYPE_CUSTOM,
+    *,
+    requirements_target: str | None = None,
 ) -> bool:
     """
     Install dependencies listed in repo_path/requirements.txt for a community plugin and refresh import paths.
@@ -1323,7 +1348,9 @@ def _install_requirements_for_repo(
         else:
             logger.info("No dependency installation run for plugin %s", repo_name)
         if handled_requirements:
-            requirements_target = _requirements_install_target_identity()
+            requirements_target = (
+                requirements_target or _requirements_install_target_identity()
+            )
             _write_requirements_install_marker(
                 repo_path, repo_name, requirements_hash, requirements_target
             )
@@ -3635,11 +3662,11 @@ def load_plugins(passed_config: Any = None) -> list[Any]:
                                 requirements_target,
                             )
                         if _install_requirements_for_repo(
-                            repo_path, repo_name, plugin_type=PLUGIN_TYPE_COMMUNITY
+                            repo_path,
+                            repo_name,
+                            plugin_type=PLUGIN_TYPE_COMMUNITY,
+                            requirements_target=requirements_target,
                         ):
-                            requirements_target = (
-                                _requirements_install_target_identity()
-                            )
                             state[PLUGIN_STATE_LAST_INSTALLED_REQUIREMENTS_COMMIT] = (
                                 pinned_sha
                             )

--- a/src/mmrelay/plugin_loader.py
+++ b/src/mmrelay/plugin_loader.py
@@ -1100,7 +1100,19 @@ def _merge_dependency_directory(source_dir: str, destination_dir: str) -> None:
 
 
 def _is_namespace_package_directory(path: str) -> bool:
-    return not os.path.exists(os.path.join(path, "__init__.py"))
+    if not os.path.isdir(path) or os.path.islink(path):
+        return False
+    init_path = os.path.join(path, "__init__.py")
+    if not os.path.exists(init_path):
+        return True
+    try:
+        with open(init_path, encoding=DEFAULT_TEXT_ENCODING) as init_file:
+            content = init_file.read()
+    except (OSError, UnicodeDecodeError):
+        return False
+    has_pkgutil = "pkgutil" in content and "extend_path" in content
+    has_pkg_resources = "pkg_resources" in content and "declare_namespace" in content
+    return has_pkgutil or has_pkg_resources
 
 
 def _replace_dependency_target_item(source_path: str, destination_path: str) -> None:

--- a/src/mmrelay/plugin_loader.py
+++ b/src/mmrelay/plugin_loader.py
@@ -111,8 +111,17 @@ PLUGIN_STATE_FILENAME: Final[str] = ".mmrelay-plugin-state.json"
 PLUGIN_STATE_LAST_INSTALLED_REQUIREMENTS_COMMIT: Final[str] = (
     "last_installed_requirements_commit"
 )
+PLUGIN_STATE_LAST_INSTALLED_REQUIREMENTS_HASH: Final[str] = (
+    "last_installed_requirements_hash"
+)
+PLUGIN_STATE_LAST_INSTALLED_REQUIREMENTS_TARGET: Final[str] = (
+    "last_installed_requirements_target"
+)
 PLUGIN_STATE_LAST_REQUIREMENTS_INSTALLED_AT: Final[str] = (
     "last_requirements_installed_at"
+)
+PLUGIN_REQUIREMENTS_INSTALL_MARKER_FILENAME: Final[str] = (
+    ".mmrelay-requirements-installed"
 )
 COMMUNITY_PLUGIN_UPDATE_CHECK_INTERVAL: Final[timedelta] = timedelta(hours=24)
 _community_dep_install_warning_logged = False
@@ -798,6 +807,85 @@ def _refresh_dependency_paths() -> None:
     importlib.invalidate_caches()
 
 
+def _requirements_install_marker_path(repo_path: str) -> str:
+    if _PLUGIN_DEPS_DIR:
+        return os.path.join(
+            os.fspath(_PLUGIN_DEPS_DIR), PLUGIN_REQUIREMENTS_INSTALL_MARKER_FILENAME
+        )
+    return os.path.join(repo_path, PLUGIN_REQUIREMENTS_INSTALL_MARKER_FILENAME)
+
+
+def _write_requirements_install_marker(repo_path: str) -> None:
+    marker_path = _requirements_install_marker_path(repo_path)
+    os.makedirs(os.path.dirname(marker_path), exist_ok=True)
+    with open(marker_path, "w", encoding=DEFAULT_TEXT_ENCODING) as marker_file:
+        marker_file.write(datetime.now(timezone.utc).isoformat() + "\n")
+
+
+def _requirements_install_target_identity() -> str:
+    if _PLUGIN_DEPS_DIR:
+        return f"target:{os.path.abspath(os.fspath(_PLUGIN_DEPS_DIR))}"
+
+    if any(key in os.environ for key in PIPX_ENVIRONMENT_KEYS):
+        return "pipx:mmrelay"
+
+    in_venv = (sys.prefix != getattr(sys, "base_prefix", sys.prefix)) or (
+        "VIRTUAL_ENV" in os.environ
+    )
+    if in_venv:
+        return f"python:{os.path.abspath(sys.prefix)}"
+
+    try:
+        user_site = site.getusersitepackages()
+    except AttributeError:
+        user_site = "unknown"
+    if isinstance(user_site, str):
+        return f"user:{os.path.abspath(user_site)}"
+    return "user:" + os.pathsep.join(os.path.abspath(path) for path in user_site)
+
+
+def _requirements_install_target_valid(repo_path: str) -> bool:
+    marker_exists = os.path.isfile(_requirements_install_marker_path(repo_path))
+    if _PLUGIN_DEPS_DIR:
+        deps_path = os.fspath(_PLUGIN_DEPS_DIR)
+        deps_has_content = False
+        if os.path.isdir(deps_path):
+            try:
+                with os.scandir(deps_path) as entries:
+                    deps_has_content = any(entries)
+            except OSError:
+                deps_has_content = False
+        return deps_has_content or marker_exists
+    return marker_exists
+
+
+def _effective_requirements_for_repo(repo_path: str, repo_name: str) -> list[str]:
+    requirements_path = os.path.join(repo_path, PLUGIN_REQUIREMENTS_FILENAME)
+    requirements_lines = _collect_requirements(requirements_path)
+    safe_requirements, flagged_requirements = _filter_risky_requirement_lines(
+        requirements_lines
+    )
+
+    allow_untrusted = bool(
+        _get_security_settings().get("allow_untrusted_dependencies", False)
+    )
+    if flagged_requirements and allow_untrusted:
+        safe_requirements.extend(flagged_requirements)
+
+    logger.debug(
+        "Computed effective requirements for plugin %s: %d allowed, %d flagged",
+        repo_name,
+        len(safe_requirements),
+        len(flagged_requirements),
+    )
+    return safe_requirements
+
+
+def _requirements_hash(requirements: Sequence[str]) -> str:
+    payload = "\n".join(requirements).encode(DEFAULT_TEXT_ENCODING)
+    return hashlib.sha256(payload).hexdigest()
+
+
 def _install_requirements_for_repo(
     repo_path: str,
     repo_name: str,
@@ -827,12 +915,12 @@ def _install_requirements_for_repo(
 
     global _community_dep_install_warning_logged
     try:
-        in_pipx = any(key in os.environ for key in PIPX_ENVIRONMENT_KEYS)
+        install_target = _PLUGIN_DEPS_DIR
+        in_pipx = install_target is None and any(
+            key in os.environ for key in PIPX_ENVIRONMENT_KEYS
+        )
 
-        # Collect requirements as full lines to preserve PEP 508 compliance
-        # (version specifiers, environment markers, etc.)
         requirements_lines = _collect_requirements(requirements_path)
-
         safe_requirements, flagged_requirements = _filter_risky_requirement_lines(
             requirements_lines
         )
@@ -860,7 +948,58 @@ def _install_requirements_for_repo(
 
         installed_packages = False
 
-        if in_pipx:
+        if install_target is not None:
+            logger.info(
+                "Installing requirements for plugin %s into persistent dependency directory %s",
+                repo_name,
+                install_target,
+            )
+            packages = [r for r in safe_requirements if not r.startswith("-")]
+            if not packages:
+                logger.info(
+                    "Requirements in %s provided no installable packages; skipping pip install.",
+                    requirements_path,
+                )
+            else:
+                if (
+                    plugin_type == PLUGIN_TYPE_COMMUNITY
+                    and not _community_dep_install_warning_logged
+                ):
+                    logger.warning(
+                        "Community plugin dependencies execute arbitrary code and are unsafe"
+                    )
+                    _community_dep_install_warning_logged = True
+                cmd = [
+                    sys.executable,
+                    "-m",
+                    "pip",
+                    "install",
+                    "--disable-pip-version-check",
+                    "--no-input",
+                    "--target",
+                    os.fspath(install_target),
+                ]
+
+                with tempfile.NamedTemporaryFile(
+                    mode="w", suffix=".txt", delete=False
+                ) as temp_file:
+                    temp_path = temp_file.name
+                    for entry in safe_requirements:
+                        temp_file.write(entry + "\n")
+
+                try:
+                    cmd.extend(["-r", temp_path])
+                    _run(cmd, timeout=PIP_INSTALL_TIMEOUT_SECONDS)
+                    installed_packages = True
+                finally:
+                    try:
+                        os.unlink(temp_path)
+                    except OSError:
+                        logger.debug(
+                            "Failed to clean up temporary requirements file: %s",
+                            temp_path,
+                        )
+        elif in_pipx:
             logger.info("Installing requirements for plugin %s with pipx", repo_name)
             pipx_path = shutil.which("pipx")
             if not pipx_path:
@@ -964,6 +1103,7 @@ def _install_requirements_for_repo(
 
         if installed_packages:
             logger.info("Successfully installed requirements for plugin %s", repo_name)
+            _write_requirements_install_marker(repo_path)
             _refresh_dependency_paths()
         else:
             logger.info("No dependency installation run for plugin %s", repo_name)
@@ -3218,23 +3358,46 @@ def load_plugins(passed_config: Any = None) -> list[Any]:
                         )
                     else:
                         state = _load_plugin_state(repo_path)
+                        requirements_hash = _requirements_hash(
+                            _effective_requirements_for_repo(repo_path, repo_name)
+                        )
+                        requirements_target = _requirements_install_target_identity()
                         last_installed_commit = state.get(
                             PLUGIN_STATE_LAST_INSTALLED_REQUIREMENTS_COMMIT
+                        )
+                        last_installed_hash = state.get(
+                            PLUGIN_STATE_LAST_INSTALLED_REQUIREMENTS_HASH
+                        )
+                        last_installed_target = state.get(
+                            PLUGIN_STATE_LAST_INSTALLED_REQUIREMENTS_TARGET
                         )
                         if (
                             isinstance(last_installed_commit, str)
                             and last_installed_commit == pinned_sha
+                            and isinstance(last_installed_hash, str)
+                            and last_installed_hash == requirements_hash
+                            and isinstance(last_installed_target, str)
+                            and last_installed_target == requirements_target
+                            and _requirements_install_target_valid(repo_path)
                         ):
                             logger.debug(
-                                "Skipping requirements install for community plugin %s; already installed for commit %s",
+                                "Skipping requirements install for community plugin %s; already installed for commit %s, requirements hash %s, target %s",
                                 plugin_name,
                                 pinned_sha,
+                                requirements_hash,
+                                requirements_target,
                             )
                         elif _install_requirements_for_repo(
                             repo_path, repo_name, plugin_type=PLUGIN_TYPE_COMMUNITY
                         ):
                             state[PLUGIN_STATE_LAST_INSTALLED_REQUIREMENTS_COMMIT] = (
                                 pinned_sha
+                            )
+                            state[PLUGIN_STATE_LAST_INSTALLED_REQUIREMENTS_HASH] = (
+                                requirements_hash
+                            )
+                            state[PLUGIN_STATE_LAST_INSTALLED_REQUIREMENTS_TARGET] = (
+                                requirements_target
                             )
                             state[PLUGIN_STATE_LAST_REQUIREMENTS_INSTALLED_AT] = (
                                 datetime.now(timezone.utc).isoformat()

--- a/src/mmrelay/plugin_loader.py
+++ b/src/mmrelay/plugin_loader.py
@@ -1010,6 +1010,7 @@ def _requirements_install_target_valid(
         isinstance(marker, dict)
         and marker.get("requirements_hash") == requirements_hash
         and marker.get("target") == target
+        and marker.get("repo") == repo_name
     )
 
 
@@ -1070,7 +1071,10 @@ def _installable_requirement_lines(requirements: Sequence[str]) -> list[str]:
 @contextmanager
 def _temporary_requirements_file(requirements: Sequence[str]) -> Iterator[str]:
     with tempfile.NamedTemporaryFile(
-        mode="w", suffix=".txt", delete=False
+        mode="w",
+        suffix=".txt",
+        encoding=DEFAULT_TEXT_ENCODING,
+        delete=False,
     ) as temp_file:
         temp_path = temp_file.name
         for entry in requirements:
@@ -1086,6 +1090,69 @@ def _temporary_requirements_file(requirements: Sequence[str]) -> Iterator[str]:
                 "Failed to clean up temporary requirements file: %s",
                 temp_path,
             )
+
+
+def _replace_dependency_target_item(source_path: str, destination_path: str) -> None:
+    if os.path.lexists(destination_path):
+        if os.path.isdir(destination_path) and not os.path.islink(destination_path):
+            shutil.rmtree(destination_path)
+        else:
+            os.unlink(destination_path)
+    shutil.move(source_path, destination_path)
+
+
+def _normalize_distribution_name(distribution_name: str) -> str:
+    return re.sub(r"[-_.]+", "-", distribution_name).lower()
+
+
+def _metadata_distribution_key(item_name: str, item_path: str) -> str | None:
+    for suffix in (".dist-info", ".egg-info"):
+        if item_name.endswith(suffix):
+            metadata_path = os.path.join(item_path, "METADATA")
+            try:
+                with open(
+                    metadata_path, encoding=DEFAULT_TEXT_ENCODING
+                ) as metadata_file:
+                    for line in metadata_file:
+                        if line.lower().startswith("name:"):
+                            _, _, distribution_name = line.partition(":")
+                            return _normalize_distribution_name(
+                                distribution_name.strip()
+                            )
+            except OSError:
+                pass
+            metadata_name = item_name[: -len(suffix)]
+            distribution_name = metadata_name.split("-", 1)[0]
+            return _normalize_distribution_name(distribution_name)
+    return None
+
+
+def _remove_stale_dependency_metadata(
+    target_dir: str, staged_item_name: str, staged_item_path: str
+) -> None:
+    staged_key = _metadata_distribution_key(staged_item_name, staged_item_path)
+    if not staged_key:
+        return
+
+    for existing_name in os.listdir(target_dir):
+        if existing_name == staged_item_name:
+            continue
+        existing_path = os.path.join(target_dir, existing_name)
+        if _metadata_distribution_key(existing_name, existing_path) != staged_key:
+            continue
+        if os.path.isdir(existing_path) and not os.path.islink(existing_path):
+            shutil.rmtree(existing_path)
+        else:
+            os.unlink(existing_path)
+
+
+def _merge_staged_dependency_target(staged_dir: str, target_dir: str) -> None:
+    os.makedirs(target_dir, exist_ok=True)
+    for item_name in os.listdir(staged_dir):
+        source_path = os.path.join(staged_dir, item_name)
+        destination_path = os.path.join(target_dir, item_name)
+        _remove_stale_dependency_metadata(target_dir, item_name, source_path)
+        _replace_dependency_target_item(source_path, destination_path)
 
 
 def _install_requirements_for_repo(
@@ -1130,7 +1197,6 @@ def _install_requirements_for_repo(
         )
         safe_requirements = effective_requirements.allowed
         requirements_hash = _requirements_hash(safe_requirements)
-        requirements_target = _requirements_install_target_identity()
         packages = _installable_requirement_lines(safe_requirements)
 
         installed_packages = False
@@ -1164,15 +1230,25 @@ def _install_requirements_for_repo(
                     "install",
                     "--disable-pip-version-check",
                     "--no-input",
-                    "--target",
-                    os.fspath(install_target),
                 ]
 
-                with _temporary_requirements_file(safe_requirements) as temp_path:
-                    cmd.extend(["-r", temp_path])
-                    _run(cmd, timeout=PIP_INSTALL_TIMEOUT_SECONDS)
+                target_dir = os.path.abspath(os.fspath(install_target))
+                staging_parent = os.path.dirname(target_dir) or None
+                if staging_parent:
+                    os.makedirs(staging_parent, exist_ok=True)
+                staged_dir = tempfile.mkdtemp(
+                    prefix=".mmrelay-deps-install-", dir=staging_parent
+                )
+                try:
+                    cmd.extend(["--target", staged_dir])
+                    with _temporary_requirements_file(safe_requirements) as temp_path:
+                        cmd.extend(["-r", temp_path])
+                        _run(cmd, timeout=PIP_INSTALL_TIMEOUT_SECONDS)
+                    _merge_staged_dependency_target(staged_dir, target_dir)
                     installed_packages = True
                     handled_requirements = True
+                finally:
+                    shutil.rmtree(staged_dir, ignore_errors=True)
         elif in_pipx:
             logger.info("Installing requirements for plugin %s with pipx", repo_name)
             pipx_path = shutil.which("pipx")

--- a/src/mmrelay/plugin_loader.py
+++ b/src/mmrelay/plugin_loader.py
@@ -1388,13 +1388,13 @@ def _get_plugin_dirs(plugin_type: str) -> list[str]:
     """
     Compute ordered plugin directories for the given plugin type.
 
-    Prefers per-root user plugin directories (created if missing) for each discovered plugin root and includes the local application `plugins/<type>` directory for backward compatibility; any directory that cannot be created or accessed is omitted.
+    Prefers per-root user plugin directories (created if missing) for each discovered plugin root and includes an existing local application `plugins/<type>` directory for backward compatibility.
 
     Parameters:
         plugin_type (str): Plugin category, e.g. "custom" or "community".
 
     Returns:
-        list[str]: Ordered list of filesystem paths to plugin directories (per-root user dirs first, then the local app directory).
+        list[str]: Ordered list of filesystem paths to plugin directories (per-root user dirs first, then an existing local app directory).
     """
     dirs = []
 
@@ -1420,14 +1420,11 @@ def _get_plugin_dirs(plugin_type: str) -> list[str]:
         except (OSError, PermissionError) as e:
             logger.warning("Cannot create user plugin directory %s: %s", user_dir, e)
 
-    # Check local directory (backward compatibility)
+    # Check local directory (backward compatibility). This path is part of the
+    # installed application package, so never try to create runtime data there.
     local_dir = os.path.join(get_app_path(), PLUGINS_DIRNAME, plugin_type)
-    try:
-        os.makedirs(local_dir, exist_ok=True)
+    if os.path.isdir(local_dir):
         dirs.append(local_dir)
-    except (OSError, PermissionError):
-        # Skip local directory if we can't create it (e.g., in Docker)
-        logger.debug(f"Cannot create local plugin directory {local_dir}, skipping")
 
     return dirs
 

--- a/tests/test_meshtastic_connection.py
+++ b/tests/test_meshtastic_connection.py
@@ -764,7 +764,7 @@ class TestConnectMeshtasticTimeoutBranches:
     def test_timeout_infinite_retries_exceeds_max(self, monkeypatch):
         from mmrelay.meshtastic.connection import _connect_meshtastic_impl
 
-        ble_address = self._configure_ble()
+        self._configure_ble()
         mu.config["meshtastic"]["retries"] = mu.INFINITE_RETRIES
         for attr_name in (
             "BLEConnectionTimeoutError",
@@ -1027,7 +1027,7 @@ class TestConnectMeshtasticExceptionBranches:
     def test_exception_handler_non_duplicate_error_retries(self, monkeypatch):
         from mmrelay.meshtastic.connection import _connect_meshtastic_impl
 
-        ble_address = self._configure_ble()
+        self._configure_ble()
         mu.config["meshtastic"]["retries"] = 3
         for attr_name in (
             "BLEConnectionTimeoutError",

--- a/tests/test_meshtastic_utils_coverage.py
+++ b/tests/test_meshtastic_utils_coverage.py
@@ -2009,7 +2009,6 @@ class TestBleInterfaceImport:
     def test_gating_module_import_exception_sets_none(self):
         """Test that a non-ModuleNotFoundError during gating import sets module to None."""
         import importlib
-        import sys
 
         import mmrelay.meshtastic_utils as mu_module
         from mmrelay.constants.network import (
@@ -2049,7 +2048,6 @@ class TestBleInterfaceImport:
     def test_gating_module_import_success_sets_callable(self):
         """Test successful gating import sets _ble_gate_reset_callable."""
         import importlib
-        import sys
         import types
 
         import mmrelay.meshtastic_utils as mu_module

--- a/tests/test_plugin_loader.py
+++ b/tests/test_plugin_loader.py
@@ -247,9 +247,8 @@ class TestPluginLoader(BaseGitTest):
     @patch("mmrelay.paths.get_home_dir")
     @patch("mmrelay.paths.get_legacy_dirs")
     @patch("mmrelay.plugin_loader.get_app_path")
-    @patch("os.makedirs")
     def test_get_custom_plugin_dirs(
-        self, _mock_makedirs, mock_get_app_path, mock_get_legacy_dirs, mock_get_home_dir
+        self, mock_get_app_path, mock_get_legacy_dirs, mock_get_home_dir
     ):
         """
         Test that custom plugin directories are discovered and created as expected.
@@ -272,15 +271,12 @@ class TestPluginLoader(BaseGitTest):
                 os.path.join(temp_app_dir, "plugins", "custom"),
             ]
             self.assertEqual(dirs, expected_dirs)
-        # Should be called twice: once for user dir, once for local dir
-        self.assertEqual(_mock_makedirs.call_count, 2)
 
     @patch("mmrelay.paths.get_home_dir")
     @patch("mmrelay.paths.get_legacy_dirs")
     @patch("mmrelay.plugin_loader.get_app_path")
-    @patch("os.makedirs")
     def test_get_community_plugin_dirs(
-        self, _mock_makedirs, mock_get_app_path, mock_get_legacy_dirs, mock_get_home_dir
+        self, mock_get_app_path, mock_get_legacy_dirs, mock_get_home_dir
     ):
         """
         Test that community plugin directory discovery returns correct directories and creates them if they do not exist.
@@ -301,8 +297,6 @@ class TestPluginLoader(BaseGitTest):
                 os.path.join(temp_app_dir, "plugins", "community"),
             ]
             self.assertEqual(dirs, expected_dirs)
-        # Should be called twice: once for user dir, once for local dir
-        self.assertEqual(_mock_makedirs.call_count, 2)
 
     def test_load_plugins_from_directory_empty(self):
         """
@@ -1773,25 +1767,18 @@ class Plugin:
 
     @patch("mmrelay.plugin_loader.clone_or_update_repo")
     @patch("mmrelay.plugin_loader._install_requirements_for_repo")
-    @patch(
-        "mmrelay.plugin_loader._resolve_local_head_commit",
-        return_value="0123456789abcdef0123456789abcdef01234567",
-    )
     @patch("mmrelay.plugin_loader.load_plugins_from_directory")
     @patch("mmrelay.plugin_loader.get_community_plugin_dirs")
     @patch("mmrelay.plugin_loader.get_custom_plugin_dirs")
     @patch("mmrelay.plugin_loader.start_global_scheduler")
-    @patch("mmrelay.plugin_loader._check_commit_pin_for_upstream_updates")
     @patch("mmrelay.plugin_loader.logger")
     def test_load_plugins_opted_in_no_requirements_file_skips_cache_work(
         self,
         mock_logger,
-        _mock_update_check,
         mock_start_scheduler,
         mock_get_custom_dirs,
         mock_get_community_dirs,
         mock_load_from_dir,
-        _mock_resolve_local_head_commit,
         mock_install_reqs,
         mock_clone_repo,
     ):
@@ -1816,7 +1803,14 @@ class Plugin:
         mock_clone_repo.return_value = True
         mock_load_from_dir.return_value = []
 
-        load_plugins(config)
+        with (
+            patch("mmrelay.plugin_loader._check_commit_pin_for_upstream_updates"),
+            patch(
+                "mmrelay.plugin_loader._resolve_local_head_commit",
+                return_value="0123456789abcdef0123456789abcdef01234567",
+            ),
+        ):
+            load_plugins(config)
 
         mock_install_reqs.assert_not_called()
         self.assertEqual(pl._load_plugin_state(repo_path), {})
@@ -1833,23 +1827,16 @@ class Plugin:
 
     @patch("mmrelay.plugin_loader.clone_or_update_repo")
     @patch("mmrelay.plugin_loader._install_requirements_for_repo")
-    @patch(
-        "mmrelay.plugin_loader._resolve_local_head_commit",
-        return_value="0123456789abcdef0123456789abcdef01234567",
-    )
     @patch("mmrelay.plugin_loader.load_plugins_from_directory")
     @patch("mmrelay.plugin_loader.get_community_plugin_dirs")
     @patch("mmrelay.plugin_loader.get_custom_plugin_dirs")
     @patch("mmrelay.plugin_loader.start_global_scheduler")
-    @patch("mmrelay.plugin_loader._check_commit_pin_for_upstream_updates")
     def test_load_plugins_opted_in_commit_unchanged_skips_dependency_install(
         self,
-        _mock_update_check,
         mock_start_scheduler,
         mock_get_custom_dirs,
         mock_get_community_dirs,
         mock_load_from_dir,
-        _mock_resolve_local_head_commit,
         mock_install_reqs,
         mock_clone_repo,
     ):
@@ -1890,7 +1877,14 @@ class Plugin:
         mock_clone_repo.return_value = True
         mock_load_from_dir.return_value = []
 
-        with patch.object(pl, "_PLUGIN_DEPS_DIR", deps_dir):
+        with (
+            patch.object(pl, "_PLUGIN_DEPS_DIR", deps_dir),
+            patch("mmrelay.plugin_loader._check_commit_pin_for_upstream_updates"),
+            patch(
+                "mmrelay.plugin_loader._resolve_local_head_commit",
+                return_value="0123456789abcdef0123456789abcdef01234567",
+            ),
+        ):
             load_plugins(config)
 
         mock_install_reqs.assert_not_called()
@@ -1898,23 +1892,16 @@ class Plugin:
 
     @patch("mmrelay.plugin_loader.clone_or_update_repo")
     @patch("mmrelay.plugin_loader._install_requirements_for_repo", return_value=True)
-    @patch(
-        "mmrelay.plugin_loader._resolve_local_head_commit",
-        return_value="0123456789abcdef0123456789abcdef01234567",
-    )
     @patch("mmrelay.plugin_loader.load_plugins_from_directory")
     @patch("mmrelay.plugin_loader.get_community_plugin_dirs")
     @patch("mmrelay.plugin_loader.get_custom_plugin_dirs")
     @patch("mmrelay.plugin_loader.start_global_scheduler")
-    @patch("mmrelay.plugin_loader._check_commit_pin_for_upstream_updates")
     def test_load_plugins_matching_commit_empty_deps_reinstalls_requirements(
         self,
-        _mock_update_check,
         mock_start_scheduler,
         mock_get_custom_dirs,
         mock_get_community_dirs,
         mock_load_from_dir,
-        _mock_resolve_local_head_commit,
         mock_install_reqs,
         mock_clone_repo,
     ):
@@ -1955,6 +1942,11 @@ class Plugin:
         with (
             patch.object(pl, "_PLUGIN_DEPS_DIR", deps_dir),
             patch("mmrelay.plugin_loader.logger") as mock_logger,
+            patch("mmrelay.plugin_loader._check_commit_pin_for_upstream_updates"),
+            patch(
+                "mmrelay.plugin_loader._resolve_local_head_commit",
+                return_value="0123456789abcdef0123456789abcdef01234567",
+            ),
         ):
             load_plugins(config)
 
@@ -2124,23 +2116,16 @@ class Plugin:
 
     @patch("mmrelay.plugin_loader.clone_or_update_repo")
     @patch("mmrelay.plugin_loader._install_requirements_for_repo", return_value=False)
-    @patch(
-        "mmrelay.plugin_loader._resolve_local_head_commit",
-        return_value="0123456789abcdef0123456789abcdef01234567",
-    )
     @patch("mmrelay.plugin_loader.load_plugins_from_directory")
     @patch("mmrelay.plugin_loader.get_community_plugin_dirs")
     @patch("mmrelay.plugin_loader.get_custom_plugin_dirs")
     @patch("mmrelay.plugin_loader.start_global_scheduler")
-    @patch("mmrelay.plugin_loader._check_commit_pin_for_upstream_updates")
     def test_load_plugins_failed_requirements_install_does_not_update_state(
         self,
-        _mock_update_check,
         mock_start_scheduler,
         mock_get_custom_dirs,
         mock_get_community_dirs,
         mock_load_from_dir,
-        _mock_resolve_local_head_commit,
         mock_install_reqs,
         mock_clone_repo,
     ):
@@ -2167,7 +2152,14 @@ class Plugin:
         mock_clone_repo.return_value = True
         mock_load_from_dir.return_value = []
 
-        with patch.object(pl, "_PLUGIN_DEPS_DIR", deps_dir):
+        with (
+            patch.object(pl, "_PLUGIN_DEPS_DIR", deps_dir),
+            patch("mmrelay.plugin_loader._check_commit_pin_for_upstream_updates"),
+            patch(
+                "mmrelay.plugin_loader._resolve_local_head_commit",
+                return_value="0123456789abcdef0123456789abcdef01234567",
+            ),
+        ):
             load_plugins(config)
 
         mock_install_reqs.assert_called_once()
@@ -2324,11 +2316,9 @@ class Plugin:
 
     @patch("mmrelay.plugin_loader._run_git")
     @patch("mmrelay.plugin_loader._is_repo_url_allowed")
-    @patch("mmrelay.plugin_loader.logger")
     @patch("os.path.isdir")
-    @patch("os.makedirs")
     def test_clone_or_update_repo_new_repo_commit(
-        self, _mock_makedirs, mock_isdir, _mock_logger, mock_is_allowed, mock_run_git
+        self, mock_isdir, mock_is_allowed, mock_run_git
     ):
         """Test cloning a new repository with commit ref."""
 
@@ -2355,9 +2345,10 @@ class Plugin:
 
         mock_run_git.side_effect = mock_git_func
 
-        result = clone_or_update_repo(
-            "https://github.com/user/repo.git", ref, self.temp_plugins_dir
-        )
+        with patch("os.makedirs"):
+            result = clone_or_update_repo(
+                "https://github.com/user/repo.git", ref, self.temp_plugins_dir
+            )
 
         self.assertTrue(result)
 
@@ -2402,10 +2393,9 @@ class Plugin:
 
     @patch("mmrelay.plugin_loader._run_git")
     @patch("mmrelay.plugin_loader._is_repo_url_allowed")
-    @patch("mmrelay.plugin_loader.logger")
     @patch("os.path.isdir")
     def test_clone_or_update_repo_existing_repo_commit(
-        self, mock_isdir, _mock_logger, mock_is_allowed, mock_run_git
+        self, mock_isdir, mock_is_allowed, mock_run_git
     ):
         """Test updating an existing repository to a specific commit."""
 
@@ -2507,10 +2497,9 @@ class Plugin:
 
     @patch("mmrelay.plugin_loader._run_git")
     @patch("mmrelay.plugin_loader._is_repo_url_allowed")
-    @patch("mmrelay.plugin_loader.logger")
     @patch("os.path.isdir")
     def test_clone_or_update_repo_commit_fetch_specific_fails_fallback(
-        self, mock_isdir, _mock_logger, mock_is_allowed, mock_run_git
+        self, mock_isdir, mock_is_allowed, mock_run_git
     ):
         """Test that when specific commit fetch fails, it falls back to fetching all."""
 
@@ -2585,10 +2574,9 @@ class Plugin:
 
     @patch("mmrelay.plugin_loader._run_git")
     @patch("mmrelay.plugin_loader._is_repo_url_allowed")
-    @patch("mmrelay.plugin_loader.logger")
     @patch("os.path.isdir")
     def test_clone_or_update_repo_commit_fetch_success_no_fallback(
-        self, mock_isdir, _mock_logger, mock_is_allowed, mock_run_git
+        self, mock_isdir, mock_is_allowed, mock_run_git
     ):
         """Test successful commit fetch without fallback."""
 
@@ -2648,10 +2636,9 @@ class Plugin:
 
     @patch("mmrelay.plugin_loader._run_git")
     @patch("mmrelay.plugin_loader._is_repo_url_allowed")
-    @patch("mmrelay.plugin_loader.logger")
     @patch("os.path.isdir")
     def test_clone_or_update_repo_commit_fetch_fallback_success(
-        self, mock_isdir, _mock_logger, mock_is_allowed, mock_run_git
+        self, mock_isdir, mock_is_allowed, mock_run_git
     ):
         """Test commit fetch that fails specific but succeeds with fallback."""
         mock_is_allowed.return_value = True
@@ -2793,18 +2780,17 @@ class Plugin:
         ]
         self.assertTrue(len(warning_calls) > 0)
 
+    @patch("os.makedirs")
     @patch("mmrelay.plugin_loader._run_git")
     @patch("mmrelay.plugin_loader._is_repo_url_allowed")
     @patch("mmrelay.plugin_loader.logger")
     @patch("os.path.isdir")
-    @patch("os.makedirs")
     def test_clone_or_update_repo_logger_exception_on_error(
-        self, _mock_makedirs, mock_isdir, mock_logger, mock_is_allowed, mock_run_git
+        self, mock_isdir, mock_logger, mock_is_allowed, mock_run_git, _mock_makedirs
     ):
         """Test that logger.exception is called for repository update errors."""
         mock_is_allowed.return_value = True
         mock_isdir.return_value = False  # Repo doesn't exist, will try to clone
-        _mock_makedirs.return_value = None
         ref = {"type": "commit", "value": "1234abcd"}
 
         # Configure mock to fail on git clone
@@ -3060,8 +3046,7 @@ class TestURLValidation(unittest.TestCase):
         result = _host_in_allowlist(None, ["github.com"])  # type: ignore[arg-type]
         self.assertFalse(result)
 
-    @patch("mmrelay.plugin_loader.logger")
-    def test_repo_url_rejected_for_dash_prefix(self, _mock_logger):
+    def test_repo_url_rejected_for_dash_prefix(self):
         """Test that URLs starting with dash are rejected."""
         self.pl.config = {}
         result = _is_repo_url_allowed("-evil-option")
@@ -3077,43 +3062,42 @@ class TestURLValidation(unittest.TestCase):
             "file:// repositories are disabled for security reasons."
         )
 
-    @patch("mmrelay.plugin_loader.logger")
-    def test_repo_url_allows_file_scheme_with_opt_in(self, _mock_logger):
+    def test_repo_url_allows_file_scheme_with_opt_in(self):
         """Test that file:// URLs are allowed when local paths are enabled."""
         self.pl.config = {"security": {"allow_local_plugin_paths": True}}
         result = _is_repo_url_allowed("file:///local/path")
         self.assertTrue(result)
 
     @patch("mmrelay.plugin_loader.logger")
-    def test_repo_url_rejected_for_unsupported_scheme(self, _mock_logger):
+    def test_repo_url_rejected_for_unsupported_scheme(self, mock_logger):
         """Test that unsupported schemes are rejected."""
         self.pl.config = {}
         result = _is_repo_url_allowed("ftp://github.com/user/repo.git")
         self.assertFalse(result)
-        _mock_logger.error.assert_called_with(
+        mock_logger.error.assert_called_with(
             "Unsupported repository scheme '%s' for %s",
             "ftp",
             "ftp://github.com/user/repo.git",
         )
 
     @patch("mmrelay.plugin_loader.logger")
-    def test_repo_url_local_path_nonexistent(self, _mock_logger):
+    def test_repo_url_local_path_nonexistent(self, mock_logger):
         """Test local path validation when path doesn't exist."""
         self.pl.config = {"security": {"allow_local_plugin_paths": True}}
         with patch("os.path.exists", return_value=False):
             result = _is_repo_url_allowed("/nonexistent/path")
             self.assertFalse(result)
-        _mock_logger.error.assert_called_with(
+        mock_logger.error.assert_called_with(
             "Local repository path does not exist: %s", "/nonexistent/path"
         )
 
     @patch("mmrelay.plugin_loader.logger")
-    def test_repo_url_local_path_disabled(self, _mock_logger):
+    def test_repo_url_local_path_disabled(self, mock_logger):
         """Test local path validation when local paths are disabled."""
         self.pl.config = {}
         result = _is_repo_url_allowed("/local/path")
         self.assertFalse(result)
-        _mock_logger.error.assert_called_with(
+        mock_logger.error.assert_called_with(
             "Invalid repository '%s'. Local paths are disabled, and remote URLs must include a scheme (e.g., 'https://').",
             "/local/path",
         )
@@ -3439,10 +3423,7 @@ class TestGitOperations(BaseGitTest):
         )
 
     @patch("mmrelay.plugin_loader._is_repo_url_allowed")
-    @patch("mmrelay.plugin_loader.logger")
-    def test_clone_or_update_repo_invalid_url_empty(
-        self, _mock_logger, mock_is_allowed
-    ):
+    def test_clone_or_update_repo_invalid_url_empty(self, mock_is_allowed):
         """Test clone with empty URL."""
         mock_is_allowed.return_value = False
         ref = {"type": "branch", "value": "main"}
@@ -3451,10 +3432,7 @@ class TestGitOperations(BaseGitTest):
         self.assertFalse(result)
 
     @patch("mmrelay.plugin_loader._is_repo_url_allowed")
-    @patch("mmrelay.plugin_loader.logger")
-    def test_clone_or_update_repo_invalid_url_whitespace(
-        self, _mock_logger, mock_is_allowed
-    ):
+    def test_clone_or_update_repo_invalid_url_whitespace(self, mock_is_allowed):
         """Test clone with whitespace-only URL."""
         mock_is_allowed.return_value = False
         ref = {"type": "branch", "value": "main"}
@@ -3462,11 +3440,8 @@ class TestGitOperations(BaseGitTest):
             result = clone_or_update_repo("   ", ref, tmpdir)
         self.assertFalse(result)
 
-    @patch("mmrelay.plugin_loader._is_repo_url_allowed", return_value=True)
     @patch("mmrelay.plugin_loader._run_git")
-    def test_clone_or_update_repo_pull_current_branch_fails(
-        self, mock_run_git, _mock_is_allowed
-    ):
+    def test_clone_or_update_repo_pull_current_branch_fails(self, mock_run_git):
         """Test that clone_or_update_repo handles checkout failure on default branches."""
         mock_run_git.side_effect = [
             None,  # fetch
@@ -3516,11 +3491,8 @@ class TestGitOperations(BaseGitTest):
             ]
             self.assertEqual(mock_run_git.call_args_list, expected_calls)
 
-    @patch("mmrelay.plugin_loader._is_repo_url_allowed", return_value=True)
     @patch("mmrelay.plugin_loader._run_git")
-    def test_clone_or_update_repo_checkout_and_pull_branch(
-        self, mock_run_git, _mock_is_allowed
-    ):
+    def test_clone_or_update_repo_checkout_and_pull_branch(self, mock_run_git):
         """Test that clone_or_update_repo handles checkout and pull for a different branch."""
 
         # Mock successful fetch, checkout and pull
@@ -3540,11 +3512,8 @@ class TestGitOperations(BaseGitTest):
             result = clone_or_update_repo(repo_url, ref, plugins_dir)
             self.assertTrue(result)
 
-    @patch("mmrelay.plugin_loader._is_repo_url_allowed", return_value=True)
     @patch("mmrelay.plugin_loader._run_git")
-    def test_clone_or_update_repo_branch_pull_failure_force_syncs(
-        self, mock_run_git, _mock_is_allowed
-    ):
+    def test_clone_or_update_repo_branch_pull_failure_force_syncs(self, mock_run_git):
         """Branch pull failures should fallback to a force-sync against origin."""
         mock_run_git.side_effect = [
             None,  # initial fetch in update flow
@@ -3599,11 +3568,8 @@ class TestGitOperations(BaseGitTest):
             ]
             self.assertEqual(mock_run_git.call_args_list, expected_calls)
 
-    @patch("mmrelay.plugin_loader._is_repo_url_allowed", return_value=True)
     @patch("mmrelay.plugin_loader._run_git")
-    def test_clone_or_update_repo_checkout_and_pull_tag(
-        self, mock_run_git, _mock_is_allowed
-    ):
+    def test_clone_or_update_repo_checkout_and_pull_tag(self, mock_run_git):
         """Test that clone_or_update_repo handles checkout and pull for a tag."""
 
         def mock_run_git_side_effect(*args, **_kwargs):
@@ -3645,11 +3611,8 @@ class TestGitOperations(BaseGitTest):
             result = clone_or_update_repo(repo_url, ref, plugins_dir)
             self.assertTrue(result)
 
-    @patch("mmrelay.plugin_loader._is_repo_url_allowed", return_value=True)
     @patch("mmrelay.plugin_loader._run_git")
-    def test_clone_or_update_repo_checkout_fails_fallback(
-        self, mock_run_git, _mock_is_allowed
-    ):
+    def test_clone_or_update_repo_checkout_fails_fallback(self, mock_run_git):
         """Test that clone_or_update_repo handles checkout failure and tries fallback."""
         mock_run_git.side_effect = [
             None,  # fetch
@@ -3838,20 +3801,18 @@ class TestGitOperations(BaseGitTest):
         )
 
     @patch("mmrelay.plugin_loader.logger")
-    @patch(
-        "mmrelay.plugin_loader._run_git",
-        side_effect=subprocess.CalledProcessError(1, "git"),
-    )
-    def test_fallback_to_default_branches_logs_warning_when_all_fail(
-        self, _mock_run_git, mock_logger
-    ):
+    def test_fallback_to_default_branches_logs_warning_when_all_fail(self, mock_logger):
         """Default branch fallback should warn when no branch can be checked out."""
-        result = pl._fallback_to_default_branches(
-            self.temp_repo_path,
-            list(DEFAULT_BRANCHES),
-            "v1.0.0",
-            "repo",
-        )
+        with patch(
+            "mmrelay.plugin_loader._run_git",
+            side_effect=subprocess.CalledProcessError(1, "git"),
+        ):
+            result = pl._fallback_to_default_branches(
+                self.temp_repo_path,
+                list(DEFAULT_BRANCHES),
+                "v1.0.0",
+                "repo",
+            )
 
         self.assertFalse(result)
         mock_logger.warning.assert_called_with(
@@ -3859,19 +3820,19 @@ class TestGitOperations(BaseGitTest):
         )
 
     @patch("mmrelay.plugin_loader.logger")
-    @patch("mmrelay.plugin_loader._run_git", side_effect=FileNotFoundError())
     def test_update_existing_repo_to_branch_or_tag_handles_missing_git_binary(
-        self, _mock_run_git, mock_logger
+        self, mock_logger
     ):
         """Missing git during remote fetch should be logged and return False."""
-        result = pl._update_existing_repo_to_branch_or_tag(
-            self.temp_repo_path,
-            "branch",
-            "main",
-            "repo",
-            False,
-            list(DEFAULT_BRANCHES),
-        )
+        with patch("mmrelay.plugin_loader._run_git", side_effect=FileNotFoundError()):
+            result = pl._update_existing_repo_to_branch_or_tag(
+                self.temp_repo_path,
+                "branch",
+                "main",
+                "repo",
+                False,
+                list(DEFAULT_BRANCHES),
+            )
         self.assertFalse(result)
         mock_logger.exception.assert_called_with(
             "Error updating repository %s; git not found.",
@@ -3982,89 +3943,93 @@ class TestGitOperations(BaseGitTest):
             mock_run_git.call_args_list,
         )
 
-    @patch("mmrelay.plugin_loader.os.path.isdir", return_value=False)
     @patch("mmrelay.plugin_loader._run_git")
     def test_clone_new_repo_to_branch_or_tag_tag_returns_when_commit_matches(
-        self, mock_run_git, _mock_isdir
+        self, mock_run_git
     ):
         """Tag clones should return early when cloned HEAD already equals tag commit."""
+        with patch("mmrelay.plugin_loader.os.path.isdir", return_value=False):
 
-        def _side_effect(cmd, *args, **kwargs):
-            if cmd[:3] == ["git", "clone", "--filter=blob:none"]:
+            def _side_effect(cmd, *args, **kwargs):
+                if cmd[:3] == ["git", "clone", "--filter=blob:none"]:
+                    return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+                if cmd[-2:] == ["rev-parse", "HEAD"]:
+                    return subprocess.CompletedProcess(
+                        cmd, 0, stdout="abc123\n", stderr=""
+                    )
+                if cmd[-1] == "v2.0.0^{commit}":
+                    return subprocess.CompletedProcess(
+                        cmd, 0, stdout="abc123\n", stderr=""
+                    )
                 return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
-            if cmd[-2:] == ["rev-parse", "HEAD"]:
-                return subprocess.CompletedProcess(cmd, 0, stdout="abc123\n", stderr="")
-            if cmd[-1] == "v2.0.0^{commit}":
-                return subprocess.CompletedProcess(cmd, 0, stdout="abc123\n", stderr="")
-            return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
 
-        mock_run_git.side_effect = _side_effect
+            mock_run_git.side_effect = _side_effect
 
-        result = pl._clone_new_repo_to_branch_or_tag(
-            "https://github.com/user/repo.git",
-            self.temp_repo_path,
-            "tag",
-            "v2.0.0",
-            "repo",
-            self.temp_plugins_dir,
-            False,
-        )
+            result = pl._clone_new_repo_to_branch_or_tag(
+                "https://github.com/user/repo.git",
+                self.temp_repo_path,
+                "tag",
+                "v2.0.0",
+                "repo",
+                self.temp_plugins_dir,
+                False,
+            )
 
-        self.assertTrue(result)
-        self.assertNotIn(
-            call(
-                [
-                    "git",
-                    "-C",
-                    self.temp_repo_path,
-                    "fetch",
-                    "origin",
-                    "refs/tags/v2.0.0",
-                ],
-                timeout=TEST_GIT_TIMEOUT,
-            ),
-            mock_run_git.call_args_list,
-        )
+            self.assertTrue(result)
+            self.assertNotIn(
+                call(
+                    [
+                        "git",
+                        "-C",
+                        self.temp_repo_path,
+                        "fetch",
+                        "origin",
+                        "refs/tags/v2.0.0",
+                    ],
+                    timeout=TEST_GIT_TIMEOUT,
+                ),
+                mock_run_git.call_args_list,
+            )
 
     @patch("mmrelay.plugin_loader.logger")
     @patch("mmrelay.plugin_loader._run_git")
-    @patch("mmrelay.plugin_loader.os.path.isdir", return_value=True)
     def test_clone_or_update_repo_validated_handles_update_exception(
-        self, _mock_isdir, mock_run_git, mock_logger
+        self, mock_run_git, mock_logger
     ):
         """Validated update path should catch and log raised git errors."""
-        mock_run_git.side_effect = FileNotFoundError("git")
+        with patch("mmrelay.plugin_loader.os.path.isdir", return_value=True):
+            mock_run_git.side_effect = FileNotFoundError("git")
 
-        result = pl._clone_or_update_repo_validated(
-            "https://github.com/user/repo.git",
-            "commit",
-            "deadbeef",
-            "repo",
-            self.temp_plugins_dir,
-        )
+            result = pl._clone_or_update_repo_validated(
+                "https://github.com/user/repo.git",
+                "commit",
+                "deadbeef",
+                "repo",
+                self.temp_plugins_dir,
+            )
 
-        self.assertFalse(result)
-        mock_logger.exception.assert_called_once()
+            self.assertFalse(result)
+            mock_logger.exception.assert_called_once()
 
     @patch("mmrelay.plugin_loader.logger")
     @patch("mmrelay.plugin_loader._run_git")
-    @patch("mmrelay.plugin_loader.os.path.isdir", return_value=False)
     def test_clone_or_update_repo_validated_handles_clone_exception(
-        self, _mock_isdir, mock_run_git, mock_logger
+        self, mock_run_git, mock_logger
     ):
         """Validated clone path should catch and log raised git errors."""
-        mock_run_git.side_effect = FileNotFoundError("git")
+        with patch("mmrelay.plugin_loader.os.path.isdir", return_value=False):
+            mock_run_git.side_effect = FileNotFoundError("git")
 
-        result = pl._clone_or_update_repo_validated(
-            "https://github.com/user/repo.git",
-            "commit",
-            "deadbeef",
-            "repo",
-            self.temp_plugins_dir,
-        )
+            result = pl._clone_or_update_repo_validated(
+                "https://github.com/user/repo.git",
+                "commit",
+                "deadbeef",
+                "repo",
+                self.temp_plugins_dir,
+            )
 
-        self.assertFalse(result)
-        mock_logger.exception.assert_called_once()
+            self.assertFalse(result)
+            mock_logger.exception.assert_called_once()
 
     def test_load_plugins_from_directory_auto_install_uses_pipx_inject(self):
         """Missing deps should use pipx inject when running inside pipx."""
@@ -4637,18 +4602,16 @@ class TestCleanPythonCache(unittest.TestCase):
 class TestPluginDirectories(unittest.TestCase):
     """Test cases for plugin directory discovery and creation."""
 
-    @patch("os.makedirs")
     @patch("mmrelay.paths.get_home_dir")
     @patch("mmrelay.paths.get_legacy_dirs")
     @patch("mmrelay.plugin_loader.get_app_path")
-    @patch("mmrelay.plugin_loader.logger")
+    @patch("os.makedirs")
     def test_get_plugin_dirs_user_dir_success(
         self,
-        _mock_logger,
+        mock_makedirs,
         mock_get_app_path,
         mock_get_legacy_dirs,
         mock_get_home_dir,
-        _mock_makedirs,
     ):
         """Test successful user directory creation."""
         from mmrelay.plugin_loader import _get_plugin_dirs
@@ -4669,7 +4632,7 @@ class TestPluginDirectories(unittest.TestCase):
     @patch("os.makedirs")
     def test_get_plugin_dirs_user_dir_permission_error(
         self,
-        _mock_makedirs,
+        mock_makedirs,
         mock_logger,
         mock_get_app_path,
         mock_get_legacy_dirs,
@@ -4681,7 +4644,7 @@ class TestPluginDirectories(unittest.TestCase):
         mock_get_home_dir.return_value = "/user/base"
         mock_get_legacy_dirs.return_value = []
         mock_get_app_path.return_value = "/app/path"
-        _mock_makedirs.side_effect = [
+        mock_makedirs.side_effect = [
             PermissionError("Permission denied"),
             None,  # Second call succeeds
         ]
@@ -4700,7 +4663,7 @@ class TestPluginDirectories(unittest.TestCase):
     @patch("os.makedirs")
     def test_get_plugin_dirs_local_dir_os_error(
         self,
-        _mock_makedirs,
+        mock_makedirs,
         mock_logger,
         mock_get_app_path,
         mock_get_legacy_dirs,
@@ -4712,7 +4675,7 @@ class TestPluginDirectories(unittest.TestCase):
         mock_get_home_dir.return_value = "/user/base"
         mock_get_legacy_dirs.return_value = []
         mock_get_app_path.return_value = "/app/path"
-        _mock_makedirs.side_effect = [
+        mock_makedirs.side_effect = [
             None,  # User dir succeeds
             OSError("Disk full"),
         ]
@@ -5483,6 +5446,136 @@ class TestDependencyInstallation(BaseGitTest):
         )
         self.assertTrue(os.path.exists(os.path.join(self.deps_dir, "zope", "proxy")))
 
+    def test_install_plugin_requirements_pkgutil_namespace_keeps_siblings(self):
+        """pkgutil.extend_path namespace dirs should merge and keep existing subpackages."""
+        existing_ns = os.path.join(self.deps_dir, "google", "cloud")
+        os.makedirs(existing_ns)
+        with open(os.path.join(self.deps_dir, "google", "__init__.py"), "w") as handle:
+            handle.write(
+                "__path__ = __import__('pkgutil').extend_path(__path__, __name__)\n"
+            )
+        with open(os.path.join(existing_ns, "__init__.py"), "w") as handle:
+            handle.write("cloud = True\n")
+
+        staged_targets: list[str] = []
+
+        def fake_run(cmd, **_kwargs):
+            staged_target = cmd[cmd.index("--target") + 1]
+            staged_targets.append(staged_target)
+            staged_ns = os.path.join(staged_target, "google", "ads")
+            os.makedirs(staged_ns)
+            with open(
+                os.path.join(staged_target, "google", "__init__.py"), "w"
+            ) as handle:
+                handle.write(
+                    "__path__ = __import__('pkgutil').extend_path(__path__, __name__)\n"
+                )
+            with open(os.path.join(staged_ns, "__init__.py"), "w") as handle:
+                handle.write("ads = True\n")
+            dist_info = os.path.join(staged_target, "google_ads-1.0.dist-info")
+            os.makedirs(dist_info)
+            with open(os.path.join(dist_info, "METADATA"), "w") as handle:
+                handle.write("Name: google-ads\n")
+
+        with (
+            patch("mmrelay.plugin_loader._run", side_effect=fake_run),
+            patch("mmrelay.plugin_loader._refresh_dependency_paths") as mock_refresh,
+            patch.object(pl, "_PLUGIN_DEPS_DIR", self.deps_dir),
+        ):
+            result = _install_requirements_for_repo(self.repo_path, "test-plugin")
+
+        self.assertTrue(result)
+        mock_refresh.assert_called_once()
+        self.assertTrue(os.path.exists(os.path.join(self.deps_dir, "google", "cloud")))
+        self.assertTrue(os.path.exists(os.path.join(self.deps_dir, "google", "ads")))
+
+    def test_install_plugin_requirements_pkg_resources_namespace_keeps_siblings(self):
+        """pkg_resources.declare_namespace dirs should merge and keep existing subpackages."""
+        existing_ns = os.path.join(self.deps_dir, "zope", "event")
+        os.makedirs(existing_ns)
+        with open(os.path.join(self.deps_dir, "zope", "__init__.py"), "w") as handle:
+            handle.write("__import__('pkg_resources').declare_namespace(__name__)\n")
+        with open(os.path.join(existing_ns, "__init__.py"), "w") as handle:
+            handle.write("event = True\n")
+
+        staged_targets: list[str] = []
+
+        def fake_run(cmd, **_kwargs):
+            staged_target = cmd[cmd.index("--target") + 1]
+            staged_targets.append(staged_target)
+            staged_ns = os.path.join(staged_target, "zope", "proxy")
+            os.makedirs(staged_ns)
+            with open(
+                os.path.join(staged_target, "zope", "__init__.py"), "w"
+            ) as handle:
+                handle.write(
+                    "__import__('pkg_resources').declare_namespace(__name__)\n"
+                )
+            with open(os.path.join(staged_ns, "__init__.py"), "w") as handle:
+                handle.write("proxy = True\n")
+            dist_info = os.path.join(staged_target, "zope_proxy-5.2.dist-info")
+            os.makedirs(dist_info)
+            with open(os.path.join(dist_info, "METADATA"), "w") as handle:
+                handle.write("Name: zope.proxy\n")
+
+        with (
+            patch("mmrelay.plugin_loader._run", side_effect=fake_run),
+            patch("mmrelay.plugin_loader._refresh_dependency_paths") as mock_refresh,
+            patch.object(pl, "_PLUGIN_DEPS_DIR", self.deps_dir),
+        ):
+            result = _install_requirements_for_repo(self.repo_path, "test-plugin")
+
+        self.assertTrue(result)
+        mock_refresh.assert_called_once()
+        self.assertTrue(os.path.exists(os.path.join(self.deps_dir, "zope", "event")))
+        self.assertTrue(os.path.exists(os.path.join(self.deps_dir, "zope", "proxy")))
+
+    def test_install_plugin_requirements_regular_package_replaces_stale_files(self):
+        """Regular packages with normal __init__.py should be replaced, removing stale files."""
+        package_dir = os.path.join(self.deps_dir, "requests")
+        os.makedirs(package_dir)
+        with open(os.path.join(package_dir, "__init__.py"), "w") as handle:
+            handle.write("old = True\n")
+        with open(os.path.join(package_dir, "stale_module.py"), "w") as handle:
+            handle.write("stale = True\n")
+
+        staged_targets: list[str] = []
+
+        def fake_run(cmd, **_kwargs):
+            staged_target = cmd[cmd.index("--target") + 1]
+            staged_targets.append(staged_target)
+            os.makedirs(os.path.join(staged_target, "requests"))
+            with open(
+                os.path.join(staged_target, "requests", "__init__.py"), "w"
+            ) as handle:
+                handle.write("new = True\n")
+            dist_info = os.path.join(staged_target, "requests-2.28.0.dist-info")
+            os.makedirs(dist_info)
+            with open(os.path.join(dist_info, "METADATA"), "w") as handle:
+                handle.write("Name: requests\n")
+
+        with (
+            patch("mmrelay.plugin_loader._run", side_effect=fake_run),
+            patch("mmrelay.plugin_loader._refresh_dependency_paths") as mock_refresh,
+            patch.object(pl, "_PLUGIN_DEPS_DIR", self.deps_dir),
+        ):
+            result = _install_requirements_for_repo(self.repo_path, "test-plugin")
+
+        self.assertTrue(result)
+        mock_refresh.assert_called_once()
+        self.assertEqual(
+            sorted(os.listdir(os.path.join(self.deps_dir, "requests"))),
+            ["__init__.py"],
+        )
+        with open(
+            os.path.join(self.deps_dir, "requests", "__init__.py"),
+            encoding="utf-8",
+        ) as handle:
+            self.assertEqual(handle.read(), "new = True\n")
+        self.assertFalse(
+            os.path.exists(os.path.join(self.deps_dir, "requests", "stale_module.py"))
+        )
+
     def test_install_plugin_requirements_failed_staged_target_leaves_deps_unchanged(
         self,
     ):
@@ -5928,10 +6021,9 @@ class TestDependencyInstallation(BaseGitTest):
     @patch("mmrelay.plugin_loader._run_git")
     @patch("mmrelay.plugin_loader._is_repo_url_allowed")
     @patch("mmrelay.plugin_loader.logger")
-    @patch("os.makedirs")
     @patch("os.path.isdir")
     def test_clone_or_update_repo_commit_ref_type_validation(
-        self, mock_isdir, _mock_makedirs, mock_logger, mock_is_allowed, mock_run_git
+        self, mock_isdir, mock_logger, mock_is_allowed, mock_run_git
     ):
         """Test that 'commit' is accepted as a valid ref type."""
         mock_is_allowed.return_value = True
@@ -6082,9 +6174,8 @@ class TestDependencyInstallation(BaseGitTest):
         )
 
     @patch("mmrelay.plugin_loader._run_git")
-    @patch("mmrelay.plugin_loader.logger")
     def test_clone_new_repo_to_branch_or_tag_default_branch_fallback(
-        self, _mock_logger, mock_run_git
+        self, mock_run_git
     ):
         """Test _clone_new_repo_to_branch_or_tag with default branch fallback."""
         # First call fails, second succeeds
@@ -6133,9 +6224,8 @@ class TestDependencyInstallation(BaseGitTest):
         )
 
     @patch("mmrelay.plugin_loader._run_git")
-    @patch("mmrelay.plugin_loader.logger")
     def test_clone_new_repo_to_branch_or_tag_default_branch_final_fallback(
-        self, _mock_logger, mock_run_git
+        self, mock_run_git
     ):
         """Test _clone_new_repo_to_branch_or_tag with final fallback to default branch."""
         # Both main and master fail, fallback to clone without branch
@@ -6258,10 +6348,7 @@ class TestDependencyInstallation(BaseGitTest):
         )
 
     @patch("mmrelay.plugin_loader._run_git")
-    @patch("mmrelay.plugin_loader.logger")
-    def test_clone_new_repo_to_branch_or_tag_tag_fetch_fallback(
-        self, _mock_logger, mock_run_git
-    ):
+    def test_clone_new_repo_to_branch_or_tag_tag_fetch_fallback(self, mock_run_git):
         """Test _clone_new_repo_to_branch_or_tag with tag fetch fallback."""
         # Clone succeeds, rev-parse succeed but don't match, then fetch and checkout succeed
         mock_run_git.side_effect = [
@@ -6297,10 +6384,7 @@ class TestDependencyInstallation(BaseGitTest):
         )
 
     @patch("mmrelay.plugin_loader._run_git")
-    @patch("mmrelay.plugin_loader.logger")
-    def test_clone_new_repo_to_branch_or_tag_tag_fetch_fallback_alt(
-        self, _mock_logger, mock_run_git
-    ):
+    def test_clone_new_repo_to_branch_or_tag_tag_fetch_fallback_alt(self, mock_run_git):
         """Test _clone_new_repo_to_branch_or_tag with alternative tag fetch."""
         # Clone succeeds, rev-parse succeed but don't match, first fetch fails, alternative fetch succeeds, checkout succeeds
         mock_run_git.side_effect = [
@@ -6339,10 +6423,7 @@ class TestDependencyInstallation(BaseGitTest):
         )
 
     @patch("mmrelay.plugin_loader._run_git")
-    @patch("mmrelay.plugin_loader.logger")
-    def test_clone_new_repo_to_branch_or_tag_tag_as_branch_fallback(
-        self, _mock_logger, mock_run_git
-    ):
+    def test_clone_new_repo_to_branch_or_tag_tag_as_branch_fallback(self, mock_run_git):
         """Test _clone_new_repo_to_branch_or_tag with tag as branch fallback."""
         mock_run_git.side_effect = [
             subprocess.CalledProcessError(1, "git"),  # clone --branch fails
@@ -6882,6 +6963,70 @@ class TestExecPluginModuleThreadSafety(unittest.TestCase):
             self.assertIs(sys.modules.get(mod_name), previous)
         finally:
             sys.modules.pop(mod_name, None)
+
+
+class TestIsNamespacePackageDirectory(unittest.TestCase):
+    """Tests for _is_namespace_package_directory detection logic."""
+
+    def setUp(self):
+        self.temp_dir = tempfile.mkdtemp()
+        self.addCleanup(lambda: shutil.rmtree(self.temp_dir, ignore_errors=True))
+
+    def test_implicit_namespace_no_init_py(self):
+        """Directory without __init__.py should be detected as implicit namespace."""
+        ns_dir = os.path.join(self.temp_dir, "mypackage")
+        os.makedirs(ns_dir)
+        self.assertTrue(pl._is_namespace_package_directory(ns_dir))
+
+    def test_pkgutil_namespace(self):
+        """Directory with pkgutil.extend_path in __init__.py should be namespace."""
+        ns_dir = os.path.join(self.temp_dir, "google")
+        os.makedirs(ns_dir)
+        with open(os.path.join(ns_dir, "__init__.py"), "w") as f:
+            f.write(
+                "__path__ = __import__('pkgutil').extend_path(__path__, __name__)\n"
+            )
+        self.assertTrue(pl._is_namespace_package_directory(ns_dir))
+
+    def test_pkg_resources_namespace(self):
+        """Directory with pkg_resources.declare_namespace should be namespace."""
+        ns_dir = os.path.join(self.temp_dir, "zope")
+        os.makedirs(ns_dir)
+        with open(os.path.join(ns_dir, "__init__.py"), "w") as f:
+            f.write("__import__('pkg_resources').declare_namespace(__name__)\n")
+        self.assertTrue(pl._is_namespace_package_directory(ns_dir))
+
+    def test_regular_package_not_namespace(self):
+        """Directory with normal __init__.py should NOT be detected as namespace."""
+        pkg_dir = os.path.join(self.temp_dir, "requests")
+        os.makedirs(pkg_dir)
+        with open(os.path.join(pkg_dir, "__init__.py"), "w") as f:
+            f.write("__version__ = '2.28.0'\n")
+        self.assertFalse(pl._is_namespace_package_directory(pkg_dir))
+
+    def test_symlink_not_namespace(self):
+        """Symlinked directory should not be treated as namespace package."""
+        real_dir = os.path.join(self.temp_dir, "real")
+        link_dir = os.path.join(self.temp_dir, "link")
+        os.makedirs(real_dir)
+        os.symlink(real_dir, link_dir)
+        self.assertFalse(pl._is_namespace_package_directory(link_dir))
+
+    def test_nonexistent_path_not_namespace(self):
+        """Non-existent path should not be treated as namespace package."""
+        self.assertFalse(
+            pl._is_namespace_package_directory(os.path.join(self.temp_dir, "nope"))
+        )
+
+    def test_unreadable_init_py_fails_safe(self):
+        """Unreadable __init__.py should fail safe (return False)."""
+        pkg_dir = os.path.join(self.temp_dir, "badpkg")
+        os.makedirs(pkg_dir)
+        init_path = os.path.join(pkg_dir, "__init__.py")
+        with open(init_path, "w") as f:
+            f.write("some content\n")
+        with patch("builtins.open", side_effect=OSError("permission denied")):
+            self.assertFalse(pl._is_namespace_package_directory(pkg_dir))
 
 
 if __name__ == "__main__":

--- a/tests/test_plugin_loader.py
+++ b/tests/test_plugin_loader.py
@@ -4670,6 +4670,7 @@ class TestDependencyInstallation(BaseGitTest):
         with (
             patch.dict(os.environ, {"VIRTUAL_ENV": "/venv"}, clear=True),
             patch.object(pl, "_PLUGIN_DEPS_DIR", self.deps_dir),
+            patch("mmrelay.plugin_loader._refresh_dependency_paths"),
             patch("mmrelay.plugin_loader._write_requirements_install_marker"),
         ):
             _install_requirements_for_repo(self.repo_path, "test-plugin")
@@ -4684,9 +4685,11 @@ class TestDependencyInstallation(BaseGitTest):
             "--disable-pip-version-check",
             "--no-input",
             "--target",
-            self.deps_dir,
         ]
-        assert called_cmd[:8] == expected_base
+        assert called_cmd[:7] == expected_base
+        target_path = called_cmd[called_cmd.index("--target") + 1]
+        assert target_path != self.deps_dir
+        assert os.path.dirname(target_path) == os.path.dirname(self.deps_dir)
         assert "-r" in called_cmd
         assert called_cmd[called_cmd.index("-r") + 1] == temp_req
         mock_run.assert_called_once_with(called_cmd, timeout=600)
@@ -4720,6 +4723,7 @@ class TestDependencyInstallation(BaseGitTest):
         with (
             patch.dict(os.environ, {"PIPX_HOME": "/pipx/home"}, clear=True),
             patch.object(pl, "_PLUGIN_DEPS_DIR", None),
+            patch("mmrelay.plugin_loader._refresh_dependency_paths"),
         ):
             _install_requirements_for_repo(self.repo_path, "test-plugin")
 
@@ -4756,6 +4760,7 @@ class TestDependencyInstallation(BaseGitTest):
             patch("sys.base_prefix", "/fake/prefix"),
             patch("shutil.which", return_value=None),
             patch.object(pl, "_PLUGIN_DEPS_DIR", None),
+            patch("mmrelay.plugin_loader._refresh_dependency_paths"),
             patch(
                 "mmrelay.plugin_loader.tempfile.NamedTemporaryFile"
             ) as mock_temp_file,
@@ -4817,7 +4822,9 @@ class TestDependencyInstallation(BaseGitTest):
             ],
         )
         self.assertIn("--target", cmd)
-        self.assertEqual(cmd[cmd.index("--target") + 1], self.deps_dir)
+        target_path = cmd[cmd.index("--target") + 1]
+        self.assertNotEqual(target_path, self.deps_dir)
+        self.assertEqual(os.path.dirname(target_path), os.path.dirname(self.deps_dir))
         self.assertNotIn("--user", cmd)
         self.assertNotIn("inject", cmd)
 
@@ -4835,7 +4842,9 @@ class TestDependencyInstallation(BaseGitTest):
         cmd = mock_run.call_args.args[0]
         self.assertEqual(cmd[:4], [sys.executable, "-m", "pip", "install"])
         self.assertIn("--target", cmd)
-        self.assertEqual(cmd[cmd.index("--target") + 1], self.deps_dir)
+        target_path = cmd[cmd.index("--target") + 1]
+        self.assertNotEqual(target_path, self.deps_dir)
+        self.assertEqual(os.path.dirname(target_path), os.path.dirname(self.deps_dir))
         self.assertNotIn("inject", cmd)
         mock_which.assert_not_called()
 
@@ -4845,6 +4854,7 @@ class TestDependencyInstallation(BaseGitTest):
             patch("mmrelay.plugin_loader._run") as mock_run,
             patch.object(pl, "_PLUGIN_DEPS_DIR", None),
             patch("shutil.which", return_value="/usr/bin/pipx"),
+            patch("mmrelay.plugin_loader._refresh_dependency_paths"),
             patch.dict(os.environ, {"PIPX_HOME": "/pipx/home"}, clear=True),
         ):
             _install_requirements_for_repo(self.repo_path, "test-plugin")
@@ -4861,6 +4871,7 @@ class TestDependencyInstallation(BaseGitTest):
             patch.object(pl, "_PLUGIN_DEPS_DIR", None),
             patch("sys.prefix", "/fake/prefix"),
             patch("sys.base_prefix", "/fake/prefix"),
+            patch("mmrelay.plugin_loader._refresh_dependency_paths"),
             patch.dict(os.environ, {}, clear=True),
         ):
             _install_requirements_for_repo(self.repo_path, "test-plugin")
@@ -5065,12 +5076,21 @@ class TestDependencyInstallation(BaseGitTest):
 
     def test_temporary_requirements_file_cleans_up_after_success(self):
         """Temporary requirements helper should remove the file after normal use."""
-        with pl._temporary_requirements_file(["requests==2.28.0"]) as temp_path:
+        with (
+            patch(
+                "mmrelay.plugin_loader.tempfile.NamedTemporaryFile",
+                wraps=tempfile.NamedTemporaryFile,
+            ) as mock_temp_file,
+            pl._temporary_requirements_file(["requests==2.28.0"]) as temp_path,
+        ):
             self.assertTrue(os.path.exists(temp_path))
             with open(temp_path, encoding="utf-8") as temp_file:
                 self.assertEqual(temp_file.read(), "requests==2.28.0\n")
 
         self.assertFalse(os.path.exists(temp_path))
+        self.assertEqual(
+            mock_temp_file.call_args.kwargs["encoding"], pl.DEFAULT_TEXT_ENCODING
+        )
 
     def test_temporary_requirements_file_cleans_up_after_failure(self):
         """Temporary requirements helper should remove the file when callers fail."""
@@ -5128,6 +5148,27 @@ class TestDependencyInstallation(BaseGitTest):
                 )
             )
 
+    def test_requirements_install_target_valid_marker_repo_mismatch_is_invalid(self):
+        """A marker with a mismatched repo payload should not validate."""
+        with patch.object(pl, "_PLUGIN_DEPS_DIR", self.deps_dir):
+            marker_path = pl._requirements_install_marker_path(
+                self.repo_path, "test-plugin"
+            )
+            with open(marker_path, "w", encoding="utf-8") as marker_file:
+                json.dump(
+                    {
+                        "requirements_hash": "hash",
+                        "target": "target",
+                        "repo": "other-plugin",
+                    },
+                    marker_file,
+                )
+            self.assertFalse(
+                pl._requirements_install_target_valid(
+                    self.repo_path, "test-plugin", "hash", "target"
+                )
+            )
+
     def test_requirements_install_target_valid_unrelated_deps_file_is_invalid(self):
         """Unrelated files in the shared deps dir should not validate a plugin."""
         with open(os.path.join(self.deps_dir, "unrelated.txt"), "w") as handle:
@@ -5161,6 +5202,115 @@ class TestDependencyInstallation(BaseGitTest):
         self.assertEqual(marker["requirements_hash"], requirements_hash)
         self.assertEqual(marker["target"], target)
         self.assertEqual(marker["repo"], "test-plugin")
+
+    def test_install_plugin_requirements_stages_target_and_replaces_matching_items(
+        self,
+    ):
+        """Persistent installs should merge staged outputs without deleting unrelated deps."""
+        package_dir = os.path.join(self.deps_dir, "requests")
+        dist_info_dir = os.path.join(self.deps_dir, "requests-2.27.0.dist-info")
+        unrelated_dir = os.path.join(self.deps_dir, "unrelated")
+        os.makedirs(package_dir)
+        os.makedirs(dist_info_dir)
+        os.makedirs(unrelated_dir)
+        with open(os.path.join(package_dir, "__init__.py"), "w") as handle:
+            handle.write("old = True\n")
+        with open(os.path.join(dist_info_dir, "METADATA"), "w") as handle:
+            handle.write("old metadata\n")
+        with open(os.path.join(unrelated_dir, "keep.txt"), "w") as handle:
+            handle.write("keep\n")
+
+        staged_targets: list[str] = []
+
+        def fake_run(cmd, **_kwargs):
+            staged_target = cmd[cmd.index("--target") + 1]
+            staged_targets.append(staged_target)
+            os.makedirs(os.path.join(staged_target, "requests"))
+            os.makedirs(os.path.join(staged_target, "requests-2.28.0.dist-info"))
+            with open(
+                os.path.join(staged_target, "requests", "__init__.py"), "w"
+            ) as handle:
+                handle.write("new = True\n")
+            with open(
+                os.path.join(staged_target, "requests-2.28.0.dist-info", "METADATA"),
+                "w",
+            ) as handle:
+                handle.write("new metadata\n")
+
+        with (
+            patch("mmrelay.plugin_loader._run", side_effect=fake_run) as mock_run,
+            patch("mmrelay.plugin_loader._refresh_dependency_paths"),
+            patch.object(pl, "_PLUGIN_DEPS_DIR", self.deps_dir),
+        ):
+            result = _install_requirements_for_repo(self.repo_path, "test-plugin")
+
+        self.assertTrue(result)
+        mock_run.assert_called_once()
+        self.assertEqual(len(staged_targets), 1)
+        self.assertNotEqual(staged_targets[0], self.deps_dir)
+        self.assertFalse(os.path.exists(staged_targets[0]))
+        self.assertEqual(
+            os.listdir(os.path.join(self.deps_dir, "requests")),
+            ["__init__.py"],
+        )
+        with open(
+            os.path.join(self.deps_dir, "requests", "__init__.py"),
+            encoding="utf-8",
+        ) as handle:
+            self.assertEqual(handle.read(), "new = True\n")
+        self.assertFalse(os.path.exists(dist_info_dir))
+        self.assertTrue(
+            os.path.exists(os.path.join(self.deps_dir, "requests-2.28.0.dist-info"))
+        )
+        self.assertTrue(os.path.exists(os.path.join(unrelated_dir, "keep.txt")))
+
+    def test_install_plugin_requirements_failed_staged_target_leaves_deps_unchanged(
+        self,
+    ):
+        """Failed persistent installs should not merge staged outputs or write markers."""
+        package_dir = os.path.join(self.deps_dir, "requests")
+        unrelated_dir = os.path.join(self.deps_dir, "unrelated")
+        os.makedirs(package_dir)
+        os.makedirs(unrelated_dir)
+        with open(os.path.join(package_dir, "__init__.py"), "w") as handle:
+            handle.write("old = True\n")
+        with open(os.path.join(unrelated_dir, "keep.txt"), "w") as handle:
+            handle.write("keep\n")
+
+        staged_targets: list[str] = []
+
+        def fake_run(cmd, **_kwargs):
+            staged_target = cmd[cmd.index("--target") + 1]
+            staged_targets.append(staged_target)
+            os.makedirs(os.path.join(staged_target, "requests"))
+            with open(
+                os.path.join(staged_target, "requests", "__init__.py"), "w"
+            ) as handle:
+                handle.write("new = True\n")
+            raise subprocess.CalledProcessError(1, cmd)
+
+        with (
+            patch("mmrelay.plugin_loader._run", side_effect=fake_run),
+            patch("mmrelay.plugin_loader._refresh_dependency_paths") as mock_refresh,
+            patch.object(pl, "_PLUGIN_DEPS_DIR", self.deps_dir),
+        ):
+            result = _install_requirements_for_repo(self.repo_path, "test-plugin")
+
+        self.assertFalse(result)
+        self.assertEqual(len(staged_targets), 1)
+        self.assertFalse(os.path.exists(staged_targets[0]))
+        with open(
+            os.path.join(self.deps_dir, "requests", "__init__.py"),
+            encoding="utf-8",
+        ) as handle:
+            self.assertEqual(handle.read(), "old = True\n")
+        self.assertTrue(os.path.exists(os.path.join(unrelated_dir, "keep.txt")))
+        with patch.object(pl, "_PLUGIN_DEPS_DIR", self.deps_dir):
+            marker_path = pl._requirements_install_marker_path(
+                self.repo_path, "test-plugin"
+            )
+        self.assertFalse(os.path.exists(marker_path))
+        mock_refresh.assert_not_called()
 
     def test_install_plugin_requirements_no_packages_writes_marker(self):
         """No-installable-package requirements should still mark successful handling."""

--- a/tests/test_plugin_loader.py
+++ b/tests/test_plugin_loader.py
@@ -263,6 +263,7 @@ class TestPluginLoader(BaseGitTest):
         # Use a temporary directory instead of hardcoded path
         with tempfile.TemporaryDirectory() as temp_app_dir:
             mock_get_app_path.return_value = temp_app_dir
+            os.makedirs(os.path.join(temp_app_dir, "plugins", "custom"))
 
             dirs = get_custom_plugin_dirs()
 
@@ -289,6 +290,7 @@ class TestPluginLoader(BaseGitTest):
         # Use a temporary directory instead of hardcoded path
         with tempfile.TemporaryDirectory() as temp_app_dir:
             mock_get_app_path.return_value = temp_app_dir
+            os.makedirs(os.path.join(temp_app_dir, "plugins", "community"))
 
             dirs = get_community_plugin_dirs()
 
@@ -4605,10 +4607,12 @@ class TestPluginDirectories(unittest.TestCase):
     @patch("mmrelay.paths.get_home_dir")
     @patch("mmrelay.paths.get_legacy_dirs")
     @patch("mmrelay.plugin_loader.get_app_path")
+    @patch("os.path.isdir")
     @patch("os.makedirs")
     def test_get_plugin_dirs_user_dir_success(
         self,
         mock_makedirs,
+        mock_isdir,
         mock_get_app_path,
         mock_get_legacy_dirs,
         mock_get_home_dir,
@@ -4619,21 +4623,27 @@ class TestPluginDirectories(unittest.TestCase):
         mock_get_home_dir.return_value = "/user/base"
         mock_get_legacy_dirs.return_value = []
         mock_get_app_path.return_value = "/app/path"
+        mock_isdir.return_value = True
 
         dirs = _get_plugin_dirs("custom")
 
         self.assertIn("/user/base/plugins/custom", dirs)
         self.assertIn("/app/path/plugins/custom", dirs)
+        mock_makedirs.assert_called_once_with(
+            "/user/base/plugins/custom", exist_ok=True
+        )
 
     @patch("mmrelay.paths.get_home_dir")
     @patch("mmrelay.paths.get_legacy_dirs")
     @patch("mmrelay.plugin_loader.get_app_path")
+    @patch("os.path.isdir")
     @patch("mmrelay.plugin_loader.logger")
     @patch("os.makedirs")
     def test_get_plugin_dirs_user_dir_permission_error(
         self,
         mock_makedirs,
         mock_logger,
+        mock_isdir,
         mock_get_app_path,
         mock_get_legacy_dirs,
         mock_get_home_dir,
@@ -4644,10 +4654,8 @@ class TestPluginDirectories(unittest.TestCase):
         mock_get_home_dir.return_value = "/user/base"
         mock_get_legacy_dirs.return_value = []
         mock_get_app_path.return_value = "/app/path"
-        mock_makedirs.side_effect = [
-            PermissionError("Permission denied"),
-            None,  # Second call succeeds
-        ]
+        mock_isdir.return_value = True
+        mock_makedirs.side_effect = PermissionError("Permission denied")
 
         dirs = _get_plugin_dirs("custom")
 
@@ -4659,33 +4667,69 @@ class TestPluginDirectories(unittest.TestCase):
     @patch("mmrelay.paths.get_home_dir")
     @patch("mmrelay.paths.get_legacy_dirs")
     @patch("mmrelay.plugin_loader.get_app_path")
+    @patch("os.path.isdir")
     @patch("mmrelay.plugin_loader.logger")
     @patch("os.makedirs")
-    def test_get_plugin_dirs_local_dir_os_error(
+    def test_get_plugin_dirs_missing_local_dir_is_skipped_without_noise(
         self,
         mock_makedirs,
         mock_logger,
+        mock_isdir,
         mock_get_app_path,
         mock_get_legacy_dirs,
         mock_get_home_dir,
     ):
-        """Test handling of OS error in local directory."""
+        """Missing package-local fallback directories should be skipped quietly."""
         from mmrelay.plugin_loader import _get_plugin_dirs
 
         mock_get_home_dir.return_value = "/user/base"
         mock_get_legacy_dirs.return_value = []
         mock_get_app_path.return_value = "/app/path"
-        mock_makedirs.side_effect = [
-            None,  # User dir succeeds
-            OSError("Disk full"),
-        ]
+        mock_isdir.return_value = False
 
         dirs = _get_plugin_dirs("custom")
 
-        # Should only include user directory since local dir failed
         self.assertEqual(len(dirs), 1)
         self.assertIn("/user/base/plugins/custom", dirs)
-        mock_logger.debug.assert_called()
+        mock_makedirs.assert_called_once_with(
+            "/user/base/plugins/custom", exist_ok=True
+        )
+        mock_logger.warning.assert_not_called()
+        mock_logger.debug.assert_not_called()
+
+    @patch("mmrelay.paths.get_home_dir")
+    @patch("mmrelay.paths.get_legacy_dirs")
+    @patch("mmrelay.plugin_loader.get_app_path")
+    @patch("os.path.isdir")
+    @patch("os.makedirs")
+    def test_get_plugin_dirs_existing_local_dir_is_included(
+        self,
+        mock_makedirs,
+        mock_isdir,
+        mock_get_app_path,
+        mock_get_legacy_dirs,
+        mock_get_home_dir,
+    ):
+        """Existing package-local fallback directories should still be searched."""
+        from mmrelay.plugin_loader import _get_plugin_dirs
+
+        mock_get_home_dir.return_value = "/user/base"
+        mock_get_legacy_dirs.return_value = []
+        mock_get_app_path.return_value = "/app/path"
+        mock_isdir.return_value = True
+
+        dirs = _get_plugin_dirs("community")
+
+        self.assertEqual(
+            dirs,
+            [
+                "/user/base/plugins/community",
+                "/app/path/plugins/community",
+            ],
+        )
+        mock_makedirs.assert_called_once_with(
+            "/user/base/plugins/community", exist_ok=True
+        )
 
 
 class TestDependencyInstallation(BaseGitTest):

--- a/tests/test_plugin_loader.py
+++ b/tests/test_plugin_loader.py
@@ -1770,9 +1770,6 @@ class Plugin:
 
     @patch("mmrelay.plugin_loader.clone_or_update_repo")
     @patch("mmrelay.plugin_loader._install_requirements_for_repo")
-    @patch("mmrelay.plugin_loader._requirements_install_target_identity")
-    @patch("mmrelay.plugin_loader._requirements_hash")
-    @patch("mmrelay.plugin_loader._effective_requirements_for_repo")
     @patch(
         "mmrelay.plugin_loader._resolve_local_head_commit",
         return_value="0123456789abcdef0123456789abcdef01234567",
@@ -1792,16 +1789,13 @@ class Plugin:
         mock_get_community_dirs,
         mock_load_from_dir,
         _mock_resolve_local_head_commit,
-        mock_effective_requirements,
-        mock_requirements_hash,
-        mock_target_identity,
         mock_install_reqs,
         mock_clone_repo,
     ):
         """No requirements.txt should not compute install state or churn cache."""
         pl.plugins_loaded = False
         pl.sorted_active_plugins = []
-        self._community_repo_path()
+        repo_path = self._community_repo_path()
         config = {
             "community-plugins": {
                 "commit-plugin": {
@@ -1821,10 +1815,12 @@ class Plugin:
 
         load_plugins(config)
 
-        mock_effective_requirements.assert_not_called()
-        mock_requirements_hash.assert_not_called()
-        mock_target_identity.assert_not_called()
         mock_install_reqs.assert_not_called()
+        self.assertEqual(pl._load_plugin_state(repo_path), {})
+        self.assertFalse(
+            os.path.exists(pl._requirements_install_marker_path(repo_path, "repo"))
+        )
+        mock_load_from_dir.assert_called()
         mock_logger.debug.assert_any_call(
             "Skipping requirements install for community plugin %s; no %s found",
             "commit-plugin",
@@ -1953,7 +1949,10 @@ class Plugin:
         mock_clone_repo.return_value = True
         mock_load_from_dir.return_value = []
 
-        with patch.object(pl, "_PLUGIN_DEPS_DIR", deps_dir):
+        with (
+            patch.object(pl, "_PLUGIN_DEPS_DIR", deps_dir),
+            patch("mmrelay.plugin_loader.logger") as mock_logger,
+        ):
             load_plugins(config)
 
         mock_install_reqs.assert_called_once_with(
@@ -1968,6 +1967,11 @@ class Plugin:
         )
         self.assertEqual(
             saved_state.get(pl.PLUGIN_STATE_LAST_INSTALLED_REQUIREMENTS_TARGET),
+            requirements_target,
+        )
+        mock_logger.debug.assert_any_call(
+            "Reinstalling requirements for community plugin %s; install state matches but marker validation failed for target %s",
+            "commit-plugin",
             requirements_target,
         )
         mock_start_scheduler.assert_called_once()
@@ -4878,7 +4882,7 @@ class TestDependencyInstallation(BaseGitTest):
             self.assertEqual(pl._requirements_install_target_identity(), "user:unknown")
 
     def test_requirements_install_target_pipx_uses_site_packages_marker_dir(self):
-        """pipx fallback target should include site-packages freshness."""
+        """pipx fallback target should use site-packages as marker location."""
         site_packages = os.path.join(self.temp_dir, "pipx-venv", "site-packages")
         os.makedirs(site_packages)
         with (
@@ -4894,11 +4898,10 @@ class TestDependencyInstallation(BaseGitTest):
 
         self.assertTrue(target.identity.startswith("pipx:"))
         self.assertIn(os.path.abspath(site_packages), target.identity)
-        self.assertIn(str(os.stat(site_packages).st_mtime_ns), target.identity)
         self.assertEqual(target.marker_dir, site_packages)
 
     def test_requirements_install_target_venv_uses_site_packages_marker_dir(self):
-        """venv fallback target should include site-packages freshness."""
+        """venv fallback target should use site-packages as marker location."""
         site_packages = os.path.join(self.temp_dir, "venv", "site-packages")
         os.makedirs(site_packages)
         with (
@@ -4915,11 +4918,10 @@ class TestDependencyInstallation(BaseGitTest):
 
         self.assertTrue(target.identity.startswith("python:"))
         self.assertIn(os.path.abspath(site_packages), target.identity)
-        self.assertIn(str(os.stat(site_packages).st_mtime_ns), target.identity)
         self.assertEqual(target.marker_dir, site_packages)
 
     def test_requirements_install_target_user_uses_user_site_marker_dir(self):
-        """user fallback target should include user-site freshness."""
+        """user fallback target should use user-site as marker location."""
         user_site = os.path.join(self.temp_dir, "user-site")
         os.makedirs(user_site)
         with (
@@ -4934,8 +4936,116 @@ class TestDependencyInstallation(BaseGitTest):
         self.assertTrue(
             target.identity.startswith(f"user:{os.path.abspath(user_site)}")
         )
-        self.assertIn(str(os.stat(user_site).st_mtime_ns), target.identity)
         self.assertEqual(target.marker_dir, user_site)
+
+    def test_requirements_install_target_identity_stable_after_marker_write(self):
+        """Writing a colocated marker should not change the target identity."""
+        user_site = os.path.join(self.temp_dir, "user-site")
+        os.makedirs(user_site)
+        with (
+            patch.object(pl, "_PLUGIN_DEPS_DIR", None),
+            patch.dict(os.environ, {}, clear=True),
+            patch("sys.prefix", "/fake/prefix"),
+            patch("sys.base_prefix", "/fake/prefix"),
+            patch("site.getusersitepackages", return_value=user_site),
+        ):
+            before = pl._requirements_install_target_identity()
+            pl._write_requirements_install_marker(
+                self.repo_path, "test-plugin", "hash", before
+            )
+            after = pl._requirements_install_target_identity()
+
+        self.assertEqual(after, before)
+
+    def test_requirements_install_marker_path_falls_back_to_repo_when_unwritable(self):
+        """Marker should fall back to repo path when install marker dir is unavailable."""
+        with (
+            patch.object(pl, "_PLUGIN_DEPS_DIR", None),
+            patch.dict(os.environ, {}, clear=True),
+            patch("sys.prefix", "/fake/prefix"),
+            patch("sys.base_prefix", "/fake/prefix"),
+            patch("site.getusersitepackages", return_value="/missing/user-site"),
+        ):
+            marker_path = pl._requirements_install_marker_path(
+                self.repo_path, "test-plugin"
+            )
+
+        self.assertTrue(marker_path.startswith(self.repo_path + os.sep))
+
+    def test_site_packages_for_prefix_uses_posix_prefix_scheme(self):
+        """site-packages discovery should include the POSIX prefix scheme."""
+        prefix = os.path.join(self.temp_dir, "venv")
+        site_packages = os.path.join(prefix, "lib", "python3.12", "site-packages")
+        os.makedirs(site_packages)
+
+        def fake_get_path(name, scheme, **_kwargs):
+            if name == "purelib" and scheme == "posix_prefix":
+                return site_packages
+            return None
+
+        with (
+            patch("sys.platform", "linux"),
+            patch("site.getsitepackages", return_value=[]),
+            patch(
+                "mmrelay.plugin_loader.sysconfig.get_path",
+                side_effect=fake_get_path,
+            ),
+        ):
+            self.assertEqual(pl._site_packages_for_prefix(prefix), site_packages)
+
+    def test_site_packages_for_prefix_uses_windows_nt_scheme(self):
+        """site-packages discovery should include the Windows nt scheme."""
+        prefix = os.path.join(self.temp_dir, "venv")
+        site_packages = os.path.join(prefix, "Lib", "site-packages")
+        os.makedirs(site_packages)
+
+        def fake_get_path(name, scheme, **_kwargs):
+            if name == "purelib" and scheme == "nt":
+                return site_packages
+            return None
+
+        with (
+            patch("sys.platform", "win32"),
+            patch("site.getsitepackages", return_value=[]),
+            patch(
+                "mmrelay.plugin_loader.sysconfig.get_path",
+                side_effect=fake_get_path,
+            ),
+        ):
+            self.assertEqual(pl._site_packages_for_prefix(prefix), site_packages)
+
+    def test_resolve_plugin_deps_dir_uses_paths_module_for_primary_root(self):
+        """Canonical deps dir should come from paths.py for the primary plugin root."""
+        plugin_root = os.path.join(self.temp_dir, "plugins")
+        canonical_deps = os.path.join(self.temp_dir, "canonical-deps")
+
+        with (
+            patch(
+                "mmrelay.plugin_loader.paths_module.get_plugins_dir",
+                return_value=plugin_root,
+            ),
+            patch(
+                "mmrelay.plugin_loader.paths_module.resolve_all_paths",
+                return_value={"deps_dir": canonical_deps},
+            ),
+        ):
+            self.assertEqual(
+                pl._resolve_plugin_deps_dir_for_root(plugin_root),
+                os.path.abspath(canonical_deps),
+            )
+
+    def test_resolve_plugin_deps_dir_falls_back_when_paths_module_fails(self):
+        """Deps dir setup should fall back safely if paths.py resolution fails."""
+        plugin_root = os.path.join(self.temp_dir, "plugins")
+
+        with patch(
+            "mmrelay.plugin_loader.paths_module.get_plugins_dir",
+            side_effect=RuntimeError("boom"),
+        ):
+            self.assertEqual(
+                pl._resolve_plugin_deps_dir_for_root(plugin_root),
+                os.path.join(plugin_root, pl.PLUGIN_DEPS_DIRNAME),
+            )
 
     def test_requirements_hash_includes_safe_pip_options(self):
         """Requirement state hash covers all safe effective lines, including options."""

--- a/tests/test_plugin_loader.py
+++ b/tests/test_plugin_loader.py
@@ -13,6 +13,7 @@ Tests the plugin discovery, loading, and management functionality including:
 
 import hashlib
 import importlib
+import json
 import os
 import shutil
 import subprocess  # nosec B404 - Used for controlled test environment operations
@@ -1763,7 +1764,7 @@ class Plugin:
     )
     @patch(
         "mmrelay.plugin_loader._effective_requirements_for_repo",
-        return_value=["requests==2.28.0"],
+        return_value=pl.EffectiveRequirements(["requests==2.28.0"], []),
     )
     @patch(
         "mmrelay.plugin_loader._load_plugin_state",
@@ -1835,7 +1836,10 @@ class Plugin:
         )
         mock_target_identity.assert_called_once()
         mock_target_valid.assert_called_once_with(
-            os.path.join(self.community_dir, "repo")
+            os.path.join(self.community_dir, "repo"),
+            "repo",
+            pl._requirements_hash(["requests==2.28.0"]),
+            "target:/plugins/deps",
         )
         mock_save_state.assert_not_called()
         mock_start_scheduler.assert_called_once()
@@ -1852,7 +1856,7 @@ class Plugin:
     )
     @patch(
         "mmrelay.plugin_loader._effective_requirements_for_repo",
-        return_value=["requests==2.28.0"],
+        return_value=pl.EffectiveRequirements(["requests==2.28.0"], []),
     )
     @patch(
         "mmrelay.plugin_loader._load_plugin_state",
@@ -1913,7 +1917,10 @@ class Plugin:
 
         mock_update_check.assert_called_once()
         mock_target_valid.assert_called_once_with(
-            os.path.join(self.community_dir, "repo")
+            os.path.join(self.community_dir, "repo"),
+            "repo",
+            pl._requirements_hash(["requests==2.28.0"]),
+            "target:/plugins/deps",
         )
         mock_install_reqs.assert_called_once_with(
             os.path.join(self.community_dir, "repo"),
@@ -1940,7 +1947,7 @@ class Plugin:
     )
     @patch(
         "mmrelay.plugin_loader._effective_requirements_for_repo",
-        return_value=["requests==2.28.0"],
+        return_value=pl.EffectiveRequirements(["requests==2.28.0"], []),
     )
     @patch("mmrelay.plugin_loader._load_plugin_state", return_value={})
     @patch(
@@ -4607,7 +4614,7 @@ class TestDependencyInstallation(BaseGitTest):
 
     @patch("mmrelay.plugin_loader.logger")
     @patch("mmrelay.plugin_loader._run")
-    @patch("mmrelay.plugin_loader._filter_risky_requirements")
+    @patch("mmrelay.plugin_loader._filter_risky_requirement_lines")
     @patch("mmrelay.plugin_loader._collect_requirements")
     @patch("shutil.which", return_value=None)
     @patch("mmrelay.plugin_loader.tempfile.NamedTemporaryFile")
@@ -4624,7 +4631,7 @@ class TestDependencyInstallation(BaseGitTest):
     ):
         """Test dependency installation with pip in virtual environment."""
         mock_collect.return_value = ["requests==2.28.0"]
-        mock_filter.return_value = (["requests==2.28.0"], [], False)
+        mock_filter.return_value = (["requests==2.28.0"], [])
 
         # Mock the temporary file
         mock_file = mock_temp_file.return_value.__enter__.return_value
@@ -4659,7 +4666,7 @@ class TestDependencyInstallation(BaseGitTest):
 
     @patch("mmrelay.plugin_loader.logger")
     @patch("mmrelay.plugin_loader._run")
-    @patch("mmrelay.plugin_loader._filter_risky_requirements")
+    @patch("mmrelay.plugin_loader._filter_risky_requirement_lines")
     @patch("mmrelay.plugin_loader._collect_requirements")
     @patch("shutil.which", return_value="/usr/bin/pipx")
     def test_install_plugin_requirements_pipx_injection(
@@ -4679,7 +4686,6 @@ class TestDependencyInstallation(BaseGitTest):
         mock_filter.return_value = (
             ["requests==2.28.0", "--extra-index-url", "https://pypi.org/simple"],
             [],
-            False,
         )
         with (
             patch.dict(os.environ, {"PIPX_HOME": "/pipx/home"}),
@@ -4712,7 +4718,9 @@ class TestDependencyInstallation(BaseGitTest):
         with (
             patch("mmrelay.plugin_loader.logger"),
             patch("mmrelay.plugin_loader._run") as mock_run,
-            patch("mmrelay.plugin_loader._filter_risky_requirements") as mock_filter,
+            patch(
+                "mmrelay.plugin_loader._filter_risky_requirement_lines"
+            ) as mock_filter,
             patch("mmrelay.plugin_loader._collect_requirements") as mock_collect,
             patch("sys.prefix", "/fake/prefix"),
             patch("sys.base_prefix", "/fake/prefix"),
@@ -4724,7 +4732,7 @@ class TestDependencyInstallation(BaseGitTest):
             patch("mmrelay.plugin_loader.os.unlink"),
         ):
             mock_collect.return_value = ["requests==2.28.0"]
-            mock_filter.return_value = (["requests==2.28.0"], [], False)
+            mock_filter.return_value = (["requests==2.28.0"], [])
 
             # Mock temporary file
             mock_file = mock_temp_file.return_value.__enter__.return_value
@@ -4834,17 +4842,127 @@ class TestDependencyInstallation(BaseGitTest):
     def test_requirements_install_target_valid_empty_deps_dir_is_invalid(self):
         """An empty persistent deps dir should not satisfy cached install state."""
         with patch.object(pl, "_PLUGIN_DEPS_DIR", self.deps_dir):
-            self.assertFalse(pl._requirements_install_target_valid(self.repo_path))
+            self.assertFalse(
+                pl._requirements_install_target_valid(
+                    self.repo_path, "test-plugin", "hash", "target"
+                )
+            )
 
     def test_requirements_install_target_valid_deps_dir_marker_is_valid(self):
         """A marker in the persistent deps dir should satisfy cached install state."""
         with patch.object(pl, "_PLUGIN_DEPS_DIR", self.deps_dir):
-            pl._write_requirements_install_marker(self.repo_path)
-            self.assertTrue(pl._requirements_install_target_valid(self.repo_path))
+            pl._write_requirements_install_marker(
+                self.repo_path, "test-plugin", "hash", "target"
+            )
+            self.assertTrue(
+                pl._requirements_install_target_valid(
+                    self.repo_path, "test-plugin", "hash", "target"
+                )
+            )
+
+    def test_requirements_install_target_valid_marker_hash_mismatch_is_invalid(self):
+        """A stale marker with a different requirements hash should not validate."""
+        with patch.object(pl, "_PLUGIN_DEPS_DIR", self.deps_dir):
+            pl._write_requirements_install_marker(
+                self.repo_path, "test-plugin", "old-hash", "target"
+            )
+            self.assertFalse(
+                pl._requirements_install_target_valid(
+                    self.repo_path, "test-plugin", "new-hash", "target"
+                )
+            )
+
+    def test_requirements_install_target_valid_marker_target_mismatch_is_invalid(self):
+        """A marker for a different install target should not validate."""
+        with patch.object(pl, "_PLUGIN_DEPS_DIR", self.deps_dir):
+            pl._write_requirements_install_marker(
+                self.repo_path, "test-plugin", "hash", "old-target"
+            )
+            self.assertFalse(
+                pl._requirements_install_target_valid(
+                    self.repo_path, "test-plugin", "hash", "new-target"
+                )
+            )
+
+    def test_requirements_install_target_valid_unrelated_deps_file_is_invalid(self):
+        """Unrelated files in the shared deps dir should not validate a plugin."""
+        with open(os.path.join(self.deps_dir, "unrelated.txt"), "w") as handle:
+            handle.write("not a marker\n")
+
+        with patch.object(pl, "_PLUGIN_DEPS_DIR", self.deps_dir):
+            self.assertFalse(
+                pl._requirements_install_target_valid(
+                    self.repo_path, "test-plugin", "hash", "target"
+                )
+            )
+
+    def test_install_plugin_requirements_success_writes_marker(self):
+        """Successful installs should write a per-plugin marker with hash and target."""
+        with (
+            patch("mmrelay.plugin_loader._run"),
+            patch("mmrelay.plugin_loader._refresh_dependency_paths"),
+            patch.object(pl, "_PLUGIN_DEPS_DIR", self.deps_dir),
+        ):
+            result = _install_requirements_for_repo(self.repo_path, "test-plugin")
+
+        self.assertTrue(result)
+        requirements_hash = pl._requirements_hash(["requests==2.28.0"])
+        target = f"target:{os.path.abspath(self.deps_dir)}"
+        with patch.object(pl, "_PLUGIN_DEPS_DIR", self.deps_dir):
+            marker_path = pl._requirements_install_marker_path(
+                self.repo_path, "test-plugin"
+            )
+        with open(marker_path, encoding="utf-8") as marker_file:
+            marker = json.load(marker_file)
+        self.assertEqual(marker["requirements_hash"], requirements_hash)
+        self.assertEqual(marker["target"], target)
+        self.assertEqual(marker["repo"], "test-plugin")
+
+    def test_install_plugin_requirements_no_packages_writes_marker(self):
+        """No-installable-package requirements should still mark successful handling."""
+        with open(self.requirements_path, "w") as f:
+            f.write("--extra-index-url https://pypi.org/simple\n")
+
+        with (
+            patch("mmrelay.plugin_loader._run") as mock_run,
+            patch.object(pl, "_PLUGIN_DEPS_DIR", self.deps_dir),
+        ):
+            result = _install_requirements_for_repo(self.repo_path, "test-plugin")
+
+        self.assertTrue(result)
+        mock_run.assert_not_called()
+        requirements_hash = pl._requirements_hash([])
+        with patch.object(pl, "_PLUGIN_DEPS_DIR", self.deps_dir):
+            self.assertTrue(
+                pl._requirements_install_target_valid(
+                    self.repo_path,
+                    "test-plugin",
+                    requirements_hash,
+                    f"target:{os.path.abspath(self.deps_dir)}",
+                )
+            )
+
+    def test_install_plugin_requirements_failure_writes_no_marker(self):
+        """Failed installs should not write a marker."""
+        with (
+            patch(
+                "mmrelay.plugin_loader._run",
+                side_effect=subprocess.CalledProcessError(1, "pip"),
+            ),
+            patch.object(pl, "_PLUGIN_DEPS_DIR", self.deps_dir),
+        ):
+            result = _install_requirements_for_repo(self.repo_path, "test-plugin")
+
+        self.assertFalse(result)
+        with patch.object(pl, "_PLUGIN_DEPS_DIR", self.deps_dir):
+            marker_path = pl._requirements_install_marker_path(
+                self.repo_path, "test-plugin"
+            )
+        self.assertFalse(os.path.exists(marker_path))
 
     @patch("mmrelay.plugin_loader.logger")
     @patch("mmrelay.plugin_loader._run")
-    @patch("mmrelay.plugin_loader._filter_risky_requirements")
+    @patch("mmrelay.plugin_loader._filter_risky_requirement_lines")
     @patch("mmrelay.plugin_loader._collect_requirements")
     def test_install_plugin_requirements_with_flagged_deps(
         self,
@@ -4861,7 +4979,6 @@ class TestDependencyInstallation(BaseGitTest):
         mock_filter.return_value = (
             ["requests==2.28.0"],
             ["git+https://github.com/user/repo.git"],
-            False,
         )
         _install_requirements_for_repo(self.repo_path, "test-plugin")
         mock_logger.warning.assert_called_with(
@@ -4873,7 +4990,7 @@ class TestDependencyInstallation(BaseGitTest):
 
     @patch("mmrelay.plugin_loader.logger")
     @patch("mmrelay.plugin_loader._run")
-    @patch("mmrelay.plugin_loader._filter_risky_requirements")
+    @patch("mmrelay.plugin_loader._filter_risky_requirement_lines")
     @patch("mmrelay.plugin_loader._collect_requirements")
     def test_install_plugin_requirements_installation_error(
         self,
@@ -4884,7 +5001,7 @@ class TestDependencyInstallation(BaseGitTest):
     ):
         """Test handling of installation errors."""
         mock_collect.return_value = ["requests==2.28.0"]
-        mock_filter.return_value = (["requests==2.28.0"], [], False)
+        mock_filter.return_value = (["requests==2.28.0"], [])
         mock_run.side_effect = subprocess.CalledProcessError(1, "pip")
         _install_requirements_for_repo(self.repo_path, "test-plugin")
         mock_logger.exception.assert_called()
@@ -4894,7 +5011,9 @@ class TestDependencyInstallation(BaseGitTest):
         with (
             patch("mmrelay.plugin_loader.logger"),
             patch("mmrelay.plugin_loader._run") as mock_run,
-            patch("mmrelay.plugin_loader._filter_risky_requirements") as mock_filter,
+            patch(
+                "mmrelay.plugin_loader._filter_risky_requirement_lines"
+            ) as mock_filter,
             patch("mmrelay.plugin_loader._collect_requirements") as mock_collect,
             patch("sys.prefix", "/fake/prefix"),
             patch("sys.base_prefix", "/fake/prefix"),
@@ -4906,7 +5025,7 @@ class TestDependencyInstallation(BaseGitTest):
             patch("mmrelay.plugin_loader.os.unlink"),
         ):
             mock_collect.return_value = ["requests==2.28.0"]
-            mock_filter.return_value = (["requests==2.28.0"], [], False)
+            mock_filter.return_value = (["requests==2.28.0"], [])
 
             # Mock temporary file
             mock_file = mock_temp_file.return_value.__enter__.return_value
@@ -4937,7 +5056,7 @@ class TestDependencyInstallation(BaseGitTest):
 
     @patch("mmrelay.plugin_loader.logger")
     @patch("mmrelay.plugin_loader._run")
-    @patch("mmrelay.plugin_loader._filter_risky_requirements")
+    @patch("mmrelay.plugin_loader._filter_risky_requirement_lines")
     @patch("mmrelay.plugin_loader._collect_requirements")
     @patch("shutil.which", return_value="/usr/bin/pipx")
     def test_install_plugin_requirements_pipx_inject_fails(
@@ -4950,7 +5069,7 @@ class TestDependencyInstallation(BaseGitTest):
     ):
         """Test handling of pipx inject failure."""
         mock_collect.return_value = ["requests==2.28.0"]
-        mock_filter.return_value = (["requests==2.28.0"], [], False)
+        mock_filter.return_value = (["requests==2.28.0"], [])
         mock_run.side_effect = subprocess.CalledProcessError(1, "pipx")
 
         with (
@@ -4968,7 +5087,7 @@ class TestDependencyInstallation(BaseGitTest):
 
     @patch("mmrelay.plugin_loader.logger")
     @patch("mmrelay.plugin_loader._run")
-    @patch("mmrelay.plugin_loader._filter_risky_requirements")
+    @patch("mmrelay.plugin_loader._filter_risky_requirement_lines")
     @patch("mmrelay.plugin_loader._collect_requirements")
     def test_install_plugin_requirements_pipx_no_packages(
         self, mock_collect, mock_filter, mock_run, mock_logger
@@ -4978,7 +5097,6 @@ class TestDependencyInstallation(BaseGitTest):
         mock_filter.return_value = (
             ["--extra-index-url https://pypi.org/simple"],
             [],
-            False,
         )
 
         with open(self.requirements_path, "w") as f:
@@ -5000,7 +5118,7 @@ class TestDependencyInstallation(BaseGitTest):
 
     @patch("mmrelay.plugin_loader.logger")
     @patch("mmrelay.plugin_loader._run")
-    @patch("mmrelay.plugin_loader._filter_risky_requirements")
+    @patch("mmrelay.plugin_loader._filter_risky_requirement_lines")
     @patch("mmrelay.plugin_loader._collect_requirements")
     def test_install_plugin_requirements_allow_untrusted(
         self, mock_collect, mock_filter, mock_run, mock_logger
@@ -5013,7 +5131,6 @@ class TestDependencyInstallation(BaseGitTest):
         mock_filter.return_value = (
             ["requests==2.28.0"],
             ["git+https://github.com/user/repo.git"],
-            True,
         )
 
         with open(self.requirements_path, "w") as f:

--- a/tests/test_plugin_loader.py
+++ b/tests/test_plugin_loader.py
@@ -4839,6 +4839,53 @@ class TestDependencyInstallation(BaseGitTest):
         self.assertIn("--user", cmd)
         self.assertNotIn("--target", cmd)
 
+    def test_requirements_install_target_identity_unknown_user_site_is_stable(self):
+        """Missing user-site support should not produce cwd-dependent target IDs."""
+        with (
+            patch.object(pl, "_PLUGIN_DEPS_DIR", None),
+            patch.dict(os.environ, {}, clear=True),
+            patch("sys.prefix", "/fake/prefix"),
+            patch("sys.base_prefix", "/fake/prefix"),
+            patch("site.getusersitepackages", side_effect=AttributeError),
+        ):
+            self.assertEqual(pl._requirements_install_target_identity(), "user:unknown")
+
+    def test_requirements_hash_includes_safe_pip_options(self):
+        """Requirement state hash covers all safe effective lines, including options."""
+        requirements = ["--pre", "requests==2.28.0"]
+        self.assertEqual(
+            pl._requirements_hash(requirements),
+            hashlib.sha256("--pre\nrequests==2.28.0".encode("utf-8")).hexdigest(),
+        )
+
+    def test_installable_requirement_lines_filters_option_lines(self):
+        """Install execution only runs when non-option requirement lines are present."""
+        self.assertEqual(
+            pl._installable_requirement_lines(["--pre", "requests==2.28.0"]),
+            ["requests==2.28.0"],
+        )
+        self.assertEqual(pl._installable_requirement_lines(["--pre"]), [])
+
+    def test_temporary_requirements_file_cleans_up_after_success(self):
+        """Temporary requirements helper should remove the file after normal use."""
+        with pl._temporary_requirements_file(["requests==2.28.0"]) as temp_path:
+            self.assertTrue(os.path.exists(temp_path))
+            with open(temp_path, encoding="utf-8") as temp_file:
+                self.assertEqual(temp_file.read(), "requests==2.28.0\n")
+
+        self.assertFalse(os.path.exists(temp_path))
+
+    def test_temporary_requirements_file_cleans_up_after_failure(self):
+        """Temporary requirements helper should remove the file when callers fail."""
+        temp_path = None
+        with self.assertRaises(RuntimeError):
+            with pl._temporary_requirements_file(["requests==2.28.0"]) as path:
+                temp_path = path
+                raise RuntimeError("boom")
+
+        self.assertIsNotNone(temp_path)
+        self.assertFalse(os.path.exists(temp_path))
+
     def test_requirements_install_target_valid_empty_deps_dir_is_invalid(self):
         """An empty persistent deps dir should not satisfy cached install state."""
         with patch.object(pl, "_PLUGIN_DEPS_DIR", self.deps_dir):
@@ -4921,7 +4968,7 @@ class TestDependencyInstallation(BaseGitTest):
     def test_install_plugin_requirements_no_packages_writes_marker(self):
         """No-installable-package requirements should still mark successful handling."""
         with open(self.requirements_path, "w") as f:
-            f.write("--extra-index-url https://pypi.org/simple\n")
+            f.write("--pre\n")
 
         with (
             patch("mmrelay.plugin_loader._run") as mock_run,
@@ -4931,7 +4978,7 @@ class TestDependencyInstallation(BaseGitTest):
 
         self.assertTrue(result)
         mock_run.assert_not_called()
-        requirements_hash = pl._requirements_hash([])
+        requirements_hash = pl._requirements_hash(["--pre"])
         with patch.object(pl, "_PLUGIN_DEPS_DIR", self.deps_dir):
             self.assertTrue(
                 pl._requirements_install_target_valid(

--- a/tests/test_plugin_loader.py
+++ b/tests/test_plugin_loader.py
@@ -1566,6 +1566,7 @@ class Plugin:
             os.path.join(self.community_dir, "repo"),
             "repo",
             plugin_type=pl.PLUGIN_TYPE_COMMUNITY,
+            requirements_target=ANY,
         )
         saved_state = mock_save_state.call_args.args[1]
         self.assertEqual(
@@ -1633,6 +1634,7 @@ class Plugin:
             os.path.join(self.community_dir, "repo"),
             "repo",
             plugin_type=pl.PLUGIN_TYPE_COMMUNITY,
+            requirements_target=ANY,
         )
         saved_state = mock_save_state.call_args.args[1]
         self.assertEqual(
@@ -1705,6 +1707,7 @@ class Plugin:
             os.path.join(self.community_dir, "repo"),
             "repo",
             plugin_type=pl.PLUGIN_TYPE_COMMUNITY,
+            requirements_target=ANY,
         )
         saved_state = mock_save_state.call_args.args[1]
         self.assertEqual(
@@ -1959,6 +1962,7 @@ class Plugin:
             repo_path,
             "repo",
             plugin_type=pl.PLUGIN_TYPE_COMMUNITY,
+            requirements_target=requirements_target,
         )
         saved_state = pl._load_plugin_state(repo_path)
         self.assertEqual(
@@ -1975,6 +1979,148 @@ class Plugin:
             requirements_target,
         )
         mock_start_scheduler.assert_called_once()
+
+    def test_load_plugins_matching_commit_stale_hash_reinstalls_requirements(self):
+        """Matching commit should reinstall when saved requirements hash is stale."""
+        pl.plugins_loaded = False
+        pl.sorted_active_plugins = []
+        repo_path = self._write_community_requirements()
+        deps_dir = os.path.join(self.test_dir, "plugins", "deps")
+        os.makedirs(deps_dir, exist_ok=True)
+        current_hash = pl._requirements_hash(["requests==2.28.0"])
+        with patch.object(pl, "_PLUGIN_DEPS_DIR", deps_dir):
+            current_target = pl._requirements_install_target_identity()
+            pl._write_requirements_install_marker(
+                repo_path, "repo", current_hash, current_target
+            )
+        pl._save_plugin_state(
+            repo_path,
+            {
+                pl.PLUGIN_STATE_LAST_INSTALLED_REQUIREMENTS_COMMIT: "0123456789abcdef0123456789abcdef01234567",
+                pl.PLUGIN_STATE_LAST_INSTALLED_REQUIREMENTS_HASH: "stale-hash",
+                pl.PLUGIN_STATE_LAST_INSTALLED_REQUIREMENTS_TARGET: current_target,
+            },
+        )
+        config = {
+            "community-plugins": {
+                "commit-plugin": {
+                    "active": True,
+                    "repository": "https://github.com/user/repo.git",
+                    "commit": "0123456789abcdef0123456789abcdef01234567",
+                    "install_requirements": True,
+                }
+            },
+            "plugins": {},
+        }
+
+        with (
+            patch("mmrelay.plugin_loader.get_custom_plugin_dirs", return_value=[]),
+            patch(
+                "mmrelay.plugin_loader.get_community_plugin_dirs",
+                return_value=[self.community_dir],
+            ),
+            patch("mmrelay.plugin_loader.clone_or_update_repo", return_value=True),
+            patch(
+                "mmrelay.plugin_loader._resolve_local_head_commit",
+                return_value="0123456789abcdef0123456789abcdef01234567",
+            ),
+            patch("mmrelay.plugin_loader.load_plugins_from_directory", return_value=[]),
+            patch("mmrelay.plugin_loader.start_global_scheduler"),
+            patch("mmrelay.plugin_loader._check_commit_pin_for_upstream_updates"),
+            patch(
+                "mmrelay.plugin_loader._install_requirements_for_repo",
+                return_value=True,
+            ) as mock_install_reqs,
+            patch.object(pl, "_PLUGIN_DEPS_DIR", deps_dir),
+        ):
+            load_plugins(config)
+
+        mock_install_reqs.assert_called_once_with(
+            repo_path,
+            "repo",
+            plugin_type=pl.PLUGIN_TYPE_COMMUNITY,
+            requirements_target=current_target,
+        )
+        saved_state = pl._load_plugin_state(repo_path)
+        self.assertEqual(
+            saved_state[pl.PLUGIN_STATE_LAST_INSTALLED_REQUIREMENTS_HASH],
+            current_hash,
+        )
+        self.assertEqual(
+            saved_state[pl.PLUGIN_STATE_LAST_INSTALLED_REQUIREMENTS_TARGET],
+            current_target,
+        )
+
+    def test_load_plugins_matching_commit_stale_target_reinstalls_requirements(self):
+        """Matching commit should reinstall when saved target identity is stale."""
+        pl.plugins_loaded = False
+        pl.sorted_active_plugins = []
+        repo_path = self._write_community_requirements()
+        deps_dir = os.path.join(self.test_dir, "plugins", "deps")
+        os.makedirs(deps_dir, exist_ok=True)
+        current_hash = pl._requirements_hash(["requests==2.28.0"])
+        with patch.object(pl, "_PLUGIN_DEPS_DIR", deps_dir):
+            current_target = pl._requirements_install_target_identity()
+            pl._write_requirements_install_marker(
+                repo_path, "repo", current_hash, current_target
+            )
+        pl._save_plugin_state(
+            repo_path,
+            {
+                pl.PLUGIN_STATE_LAST_INSTALLED_REQUIREMENTS_COMMIT: "0123456789abcdef0123456789abcdef01234567",
+                pl.PLUGIN_STATE_LAST_INSTALLED_REQUIREMENTS_HASH: current_hash,
+                pl.PLUGIN_STATE_LAST_INSTALLED_REQUIREMENTS_TARGET: "target:/stale",
+            },
+        )
+        config = {
+            "community-plugins": {
+                "commit-plugin": {
+                    "active": True,
+                    "repository": "https://github.com/user/repo.git",
+                    "commit": "0123456789abcdef0123456789abcdef01234567",
+                    "install_requirements": True,
+                }
+            },
+            "plugins": {},
+        }
+
+        with (
+            patch("mmrelay.plugin_loader.get_custom_plugin_dirs", return_value=[]),
+            patch(
+                "mmrelay.plugin_loader.get_community_plugin_dirs",
+                return_value=[self.community_dir],
+            ),
+            patch("mmrelay.plugin_loader.clone_or_update_repo", return_value=True),
+            patch(
+                "mmrelay.plugin_loader._resolve_local_head_commit",
+                return_value="0123456789abcdef0123456789abcdef01234567",
+            ),
+            patch("mmrelay.plugin_loader.load_plugins_from_directory", return_value=[]),
+            patch("mmrelay.plugin_loader.start_global_scheduler"),
+            patch("mmrelay.plugin_loader._check_commit_pin_for_upstream_updates"),
+            patch(
+                "mmrelay.plugin_loader._install_requirements_for_repo",
+                return_value=True,
+            ) as mock_install_reqs,
+            patch.object(pl, "_PLUGIN_DEPS_DIR", deps_dir),
+        ):
+            load_plugins(config)
+
+        mock_install_reqs.assert_called_once_with(
+            repo_path,
+            "repo",
+            plugin_type=pl.PLUGIN_TYPE_COMMUNITY,
+            requirements_target=current_target,
+        )
+        saved_state = pl._load_plugin_state(repo_path)
+        self.assertEqual(
+            saved_state[pl.PLUGIN_STATE_LAST_INSTALLED_REQUIREMENTS_HASH],
+            current_hash,
+        )
+        self.assertEqual(
+            saved_state[pl.PLUGIN_STATE_LAST_INSTALLED_REQUIREMENTS_TARGET],
+            current_target,
+        )
 
     @patch("mmrelay.plugin_loader.clone_or_update_repo")
     @patch("mmrelay.plugin_loader._install_requirements_for_repo", return_value=False)
@@ -2093,6 +2239,7 @@ class Plugin:
             os.path.join(self.community_dir, "repo"),
             "repo",
             plugin_type=pl.PLUGIN_TYPE_COMMUNITY,
+            requirements_target=ANY,
         )
         saved_state = mock_save_state.call_args.args[1]
         self.assertEqual(
@@ -4718,7 +4865,7 @@ class TestDependencyInstallation(BaseGitTest):
         ]
         # The function tokenizes lines from _collect_requirements, so filter receives tokenized input
         mock_filter.return_value = (
-            ["requests==2.28.0", "--extra-index-url", "https://pypi.org/simple"],
+            ["requests==2.28.0", "--extra-index-url https://pypi.org/simple"],
             [],
         )
         with (
@@ -5179,6 +5326,24 @@ class TestDependencyInstallation(BaseGitTest):
                 )
             )
 
+    def test_metadata_distribution_key_reads_egg_info_pkg_info(self):
+        """egg-info distribution names should be read from PKG-INFO."""
+        egg_info_dir = os.path.join(self.temp_dir, "python_dateutil-2.8.2.egg-info")
+        os.makedirs(egg_info_dir)
+        with open(
+            os.path.join(egg_info_dir, "PKG-INFO"),
+            "w",
+            encoding=pl.DEFAULT_TEXT_ENCODING,
+        ) as metadata_file:
+            metadata_file.write("Metadata-Version: 2.1\nName: python-dateutil\n")
+
+        self.assertEqual(
+            pl._metadata_distribution_key(
+                "python_dateutil-2.8.2.egg-info", egg_info_dir
+            ),
+            "python-dateutil",
+        )
+
     def test_requirements_install_target_valid_unrelated_deps_file_is_invalid(self):
         """Unrelated files in the shared deps dir should not validate a plugin."""
         with open(os.path.join(self.deps_dir, "unrelated.txt"), "w") as handle:
@@ -5226,6 +5391,8 @@ class TestDependencyInstallation(BaseGitTest):
         os.makedirs(unrelated_dir)
         with open(os.path.join(package_dir, "__init__.py"), "w") as handle:
             handle.write("old = True\n")
+        with open(os.path.join(package_dir, "old.py"), "w") as handle:
+            handle.write("stale = True\n")
         with open(os.path.join(dist_info_dir, "METADATA"), "w") as handle:
             handle.write("old metadata\n")
         with open(os.path.join(unrelated_dir, "keep.txt"), "w") as handle:
@@ -5275,6 +5442,46 @@ class TestDependencyInstallation(BaseGitTest):
             os.path.exists(os.path.join(self.deps_dir, "requests-2.28.0.dist-info"))
         )
         self.assertTrue(os.path.exists(os.path.join(unrelated_dir, "keep.txt")))
+
+    def test_install_plugin_requirements_preserves_namespace_package_siblings(self):
+        """Staged merge should not delete existing namespace package subpackages."""
+        existing_namespace = os.path.join(self.deps_dir, "zope", "interface")
+        os.makedirs(existing_namespace)
+        with open(os.path.join(existing_namespace, "__init__.py"), "w") as handle:
+            handle.write("interface = True\n")
+
+        staged_targets: list[str] = []
+
+        def fake_run(cmd, **_kwargs):
+            staged_target = cmd[cmd.index("--target") + 1]
+            staged_targets.append(staged_target)
+            staged_namespace = os.path.join(staged_target, "zope", "proxy")
+            os.makedirs(staged_namespace)
+            with open(os.path.join(staged_namespace, "__init__.py"), "w") as handle:
+                handle.write("proxy = True\n")
+            dist_info = os.path.join(staged_target, "zope_proxy-5.2.dist-info")
+            os.makedirs(dist_info)
+            with open(
+                os.path.join(dist_info, "METADATA"),
+                "w",
+                encoding=pl.DEFAULT_TEXT_ENCODING,
+            ) as handle:
+                handle.write("Name: zope.proxy\n")
+
+        with (
+            patch("mmrelay.plugin_loader._run", side_effect=fake_run),
+            patch("mmrelay.plugin_loader._refresh_dependency_paths") as mock_refresh,
+            patch.object(pl, "_PLUGIN_DEPS_DIR", self.deps_dir),
+        ):
+            result = _install_requirements_for_repo(self.repo_path, "test-plugin")
+
+        self.assertTrue(result)
+        mock_refresh.assert_called_once()
+        self.assertFalse(os.path.exists(staged_targets[0]))
+        self.assertTrue(
+            os.path.exists(os.path.join(self.deps_dir, "zope", "interface"))
+        )
+        self.assertTrue(os.path.exists(os.path.join(self.deps_dir, "zope", "proxy")))
 
     def test_install_plugin_requirements_failed_staged_target_leaves_deps_unchanged(
         self,

--- a/tests/test_plugin_loader.py
+++ b/tests/test_plugin_loader.py
@@ -4670,7 +4670,7 @@ class TestDependencyInstallation(BaseGitTest):
         with (
             patch.dict(os.environ, {"VIRTUAL_ENV": "/venv"}, clear=True),
             patch.object(pl, "_PLUGIN_DEPS_DIR", self.deps_dir),
-            patch("mmrelay.plugin_loader._refresh_dependency_paths"),
+            patch("mmrelay.plugin_loader._refresh_dependency_paths") as mock_refresh,
             patch("mmrelay.plugin_loader._write_requirements_install_marker"),
         ):
             _install_requirements_for_repo(self.repo_path, "test-plugin")
@@ -4695,6 +4695,7 @@ class TestDependencyInstallation(BaseGitTest):
         mock_run.assert_called_once_with(called_cmd, timeout=600)
         mock_unlink.assert_called_once_with(temp_req)
         mock_which.assert_not_called()
+        mock_refresh.assert_called_once()
         mock_logger.info.assert_called()
 
     @patch("mmrelay.plugin_loader.logger")
@@ -4723,7 +4724,7 @@ class TestDependencyInstallation(BaseGitTest):
         with (
             patch.dict(os.environ, {"PIPX_HOME": "/pipx/home"}, clear=True),
             patch.object(pl, "_PLUGIN_DEPS_DIR", None),
-            patch("mmrelay.plugin_loader._refresh_dependency_paths"),
+            patch("mmrelay.plugin_loader._refresh_dependency_paths") as mock_refresh,
         ):
             _install_requirements_for_repo(self.repo_path, "test-plugin")
 
@@ -4745,6 +4746,7 @@ class TestDependencyInstallation(BaseGitTest):
         # Verify timeout
         assert call_args[1]["timeout"] == 600
         mock_which.assert_called_once_with("pipx")
+        mock_refresh.assert_called_once()
         mock_logger.info.assert_called()
 
     def test_install_plugin_requirements_pip_install(self):
@@ -4760,7 +4762,7 @@ class TestDependencyInstallation(BaseGitTest):
             patch("sys.base_prefix", "/fake/prefix"),
             patch("shutil.which", return_value=None),
             patch.object(pl, "_PLUGIN_DEPS_DIR", None),
-            patch("mmrelay.plugin_loader._refresh_dependency_paths"),
+            patch("mmrelay.plugin_loader._refresh_dependency_paths") as mock_refresh,
             patch(
                 "mmrelay.plugin_loader.tempfile.NamedTemporaryFile"
             ) as mock_temp_file,
@@ -4796,12 +4798,13 @@ class TestDependencyInstallation(BaseGitTest):
                 tempfile.gettempdir(), "test_requirements.txt"
             )
             mock_run.assert_called_once_with(called_cmd, timeout=600)
+            mock_refresh.assert_called_once()
 
     def test_install_plugin_requirements_uses_target_when_deps_dir_set(self):
         """Persistent deps dir should use pip --target instead of --user."""
         with (
             patch("mmrelay.plugin_loader._run") as mock_run,
-            patch("mmrelay.plugin_loader._refresh_dependency_paths"),
+            patch("mmrelay.plugin_loader._refresh_dependency_paths") as mock_refresh,
             patch.object(pl, "_PLUGIN_DEPS_DIR", self.deps_dir),
             patch("sys.prefix", "/fake/prefix"),
             patch("sys.base_prefix", "/fake/prefix"),
@@ -4827,12 +4830,13 @@ class TestDependencyInstallation(BaseGitTest):
         self.assertEqual(os.path.dirname(target_path), os.path.dirname(self.deps_dir))
         self.assertNotIn("--user", cmd)
         self.assertNotIn("inject", cmd)
+        mock_refresh.assert_called_once()
 
     def test_install_plugin_requirements_deps_dir_overrides_pipx(self):
         """Persistent deps dir should be preferred even when pipx is detected."""
         with (
             patch("mmrelay.plugin_loader._run") as mock_run,
-            patch("mmrelay.plugin_loader._refresh_dependency_paths"),
+            patch("mmrelay.plugin_loader._refresh_dependency_paths") as mock_refresh,
             patch.object(pl, "_PLUGIN_DEPS_DIR", self.deps_dir),
             patch("shutil.which", return_value="/usr/bin/pipx") as mock_which,
             patch.dict(os.environ, {"PIPX_HOME": "/pipx/home"}, clear=True),
@@ -4847,6 +4851,7 @@ class TestDependencyInstallation(BaseGitTest):
         self.assertEqual(os.path.dirname(target_path), os.path.dirname(self.deps_dir))
         self.assertNotIn("inject", cmd)
         mock_which.assert_not_called()
+        mock_refresh.assert_called_once()
 
     def test_install_plugin_requirements_without_deps_dir_uses_pipx(self):
         """Without a persistent deps dir, pipx environments should use pipx inject."""
@@ -4854,7 +4859,7 @@ class TestDependencyInstallation(BaseGitTest):
             patch("mmrelay.plugin_loader._run") as mock_run,
             patch.object(pl, "_PLUGIN_DEPS_DIR", None),
             patch("shutil.which", return_value="/usr/bin/pipx"),
-            patch("mmrelay.plugin_loader._refresh_dependency_paths"),
+            patch("mmrelay.plugin_loader._refresh_dependency_paths") as mock_refresh,
             patch.dict(os.environ, {"PIPX_HOME": "/pipx/home"}, clear=True),
         ):
             _install_requirements_for_repo(self.repo_path, "test-plugin")
@@ -4863,6 +4868,7 @@ class TestDependencyInstallation(BaseGitTest):
         self.assertEqual(
             cmd[:4], ["/usr/bin/pipx", "inject", "mmrelay", "--requirement"]
         )
+        mock_refresh.assert_called_once()
 
     def test_install_plugin_requirements_without_deps_dir_no_venv_uses_user(self):
         """Without deps dir, non-venv pip installs should use --user."""
@@ -4871,7 +4877,7 @@ class TestDependencyInstallation(BaseGitTest):
             patch.object(pl, "_PLUGIN_DEPS_DIR", None),
             patch("sys.prefix", "/fake/prefix"),
             patch("sys.base_prefix", "/fake/prefix"),
-            patch("mmrelay.plugin_loader._refresh_dependency_paths"),
+            patch("mmrelay.plugin_loader._refresh_dependency_paths") as mock_refresh,
             patch.dict(os.environ, {}, clear=True),
         ):
             _install_requirements_for_repo(self.repo_path, "test-plugin")
@@ -4880,6 +4886,7 @@ class TestDependencyInstallation(BaseGitTest):
         self.assertEqual(cmd[:4], [sys.executable, "-m", "pip", "install"])
         self.assertIn("--user", cmd)
         self.assertNotIn("--target", cmd)
+        mock_refresh.assert_called_once()
 
     def test_requirements_install_target_identity_unknown_user_site_is_stable(self):
         """Missing user-site support should not produce cwd-dependent target IDs."""
@@ -4970,12 +4977,15 @@ class TestDependencyInstallation(BaseGitTest):
 
     def test_requirements_install_marker_path_falls_back_to_repo_when_unwritable(self):
         """Marker should fall back to repo path when install marker dir is unavailable."""
+        user_site = os.path.join(self.temp_dir, "user-site")
+        os.makedirs(user_site)
         with (
             patch.object(pl, "_PLUGIN_DEPS_DIR", None),
             patch.dict(os.environ, {}, clear=True),
             patch("sys.prefix", "/fake/prefix"),
             patch("sys.base_prefix", "/fake/prefix"),
-            patch("site.getusersitepackages", return_value="/missing/user-site"),
+            patch("site.getusersitepackages", return_value=user_site),
+            patch("mmrelay.plugin_loader._is_writable_directory", return_value=False),
         ):
             marker_path = pl._requirements_install_marker_path(
                 self.repo_path, "test-plugin"
@@ -5185,12 +5195,13 @@ class TestDependencyInstallation(BaseGitTest):
         """Successful installs should write a per-plugin marker with hash and target."""
         with (
             patch("mmrelay.plugin_loader._run"),
-            patch("mmrelay.plugin_loader._refresh_dependency_paths"),
+            patch("mmrelay.plugin_loader._refresh_dependency_paths") as mock_refresh,
             patch.object(pl, "_PLUGIN_DEPS_DIR", self.deps_dir),
         ):
             result = _install_requirements_for_repo(self.repo_path, "test-plugin")
 
         self.assertTrue(result)
+        mock_refresh.assert_called_once()
         requirements_hash = pl._requirements_hash(["requests==2.28.0"])
         target = f"target:{os.path.abspath(self.deps_dir)}"
         with patch.object(pl, "_PLUGIN_DEPS_DIR", self.deps_dir):
@@ -5239,13 +5250,14 @@ class TestDependencyInstallation(BaseGitTest):
 
         with (
             patch("mmrelay.plugin_loader._run", side_effect=fake_run) as mock_run,
-            patch("mmrelay.plugin_loader._refresh_dependency_paths"),
+            patch("mmrelay.plugin_loader._refresh_dependency_paths") as mock_refresh,
             patch.object(pl, "_PLUGIN_DEPS_DIR", self.deps_dir),
         ):
             result = _install_requirements_for_repo(self.repo_path, "test-plugin")
 
         self.assertTrue(result)
         mock_run.assert_called_once()
+        mock_refresh.assert_called_once()
         self.assertEqual(len(staged_targets), 1)
         self.assertNotEqual(staged_targets[0], self.deps_dir)
         self.assertFalse(os.path.exists(staged_targets[0]))
@@ -5319,12 +5331,14 @@ class TestDependencyInstallation(BaseGitTest):
 
         with (
             patch("mmrelay.plugin_loader._run") as mock_run,
+            patch("mmrelay.plugin_loader._refresh_dependency_paths") as mock_refresh,
             patch.object(pl, "_PLUGIN_DEPS_DIR", self.deps_dir),
         ):
             result = _install_requirements_for_repo(self.repo_path, "test-plugin")
 
         self.assertTrue(result)
         mock_run.assert_not_called()
+        mock_refresh.assert_not_called()
         requirements_hash = pl._requirements_hash(["--pre"])
         with patch.object(pl, "_PLUGIN_DEPS_DIR", self.deps_dir):
             self.assertTrue(
@@ -5501,11 +5515,13 @@ class TestDependencyInstallation(BaseGitTest):
             patch.dict(os.environ, {"PIPX_HOME": "/pipx/home"}, clear=True),
             patch.object(pl, "_PLUGIN_DEPS_DIR", None),
             patch("shutil.which", return_value="/usr/bin/pipx"),
+            patch("mmrelay.plugin_loader._refresh_dependency_paths") as mock_refresh,
         ):
             _install_requirements_for_repo(self.repo_path, "test-plugin")
 
         # Should not call pipx inject when no packages
         mock_run.assert_not_called()
+        mock_refresh.assert_not_called()
         mock_logger.info.assert_called_with(
             "No dependency installation run for plugin %s",
             "test-plugin",

--- a/tests/test_plugin_loader.py
+++ b/tests/test_plugin_loader.py
@@ -223,6 +223,19 @@ class TestPluginLoader(BaseGitTest):
         mmrelay.plugin_loader.plugins_loaded = False
         mmrelay.plugin_loader.sorted_active_plugins = []
 
+    def _community_repo_path(self) -> str:
+        repo_path = os.path.join(self.community_dir, "repo")
+        os.makedirs(repo_path, exist_ok=True)
+        return repo_path
+
+    def _write_community_requirements(self, content: str = "requests==2.28.0\n") -> str:
+        repo_path = self._community_repo_path()
+        with open(
+            os.path.join(repo_path, pl.PLUGIN_REQUIREMENTS_FILENAME), "w"
+        ) as req_file:
+            req_file.write(content)
+        return repo_path
+
     def tearDown(self):
         """
         Remove temporary directories and clean up resources after each test.
@@ -1522,6 +1535,7 @@ class Plugin:
         """Opted-in commit-pinned community plugin should install requirements."""
         pl.plugins_loaded = False
         pl.sorted_active_plugins = []
+        self._write_community_requirements()
         config = {
             "community-plugins": {
                 "commit-plugin": {
@@ -1589,6 +1603,7 @@ class Plugin:
         """Explicit branch refs should warn but still allow dependency installation."""
         pl.plugins_loaded = False
         pl.sorted_active_plugins = []
+        self._write_community_requirements()
         config = {
             "community-plugins": {
                 "branch-plugin": {
@@ -1660,6 +1675,7 @@ class Plugin:
         """Explicit tag refs should warn but still allow dependency installation."""
         pl.plugins_loaded = False
         pl.sorted_active_plugins = []
+        self._write_community_requirements()
         config = {
             "community-plugins": {
                 "tag-plugin": {
@@ -1754,28 +1770,70 @@ class Plugin:
 
     @patch("mmrelay.plugin_loader.clone_or_update_repo")
     @patch("mmrelay.plugin_loader._install_requirements_for_repo")
-    @patch("mmrelay.plugin_loader._save_plugin_state")
+    @patch("mmrelay.plugin_loader._requirements_install_target_identity")
+    @patch("mmrelay.plugin_loader._requirements_hash")
+    @patch("mmrelay.plugin_loader._effective_requirements_for_repo")
     @patch(
-        "mmrelay.plugin_loader._requirements_install_target_valid", return_value=True
+        "mmrelay.plugin_loader._resolve_local_head_commit",
+        return_value="0123456789abcdef0123456789abcdef01234567",
     )
-    @patch(
-        "mmrelay.plugin_loader._requirements_install_target_identity",
-        return_value="target:/plugins/deps",
-    )
-    @patch(
-        "mmrelay.plugin_loader._effective_requirements_for_repo",
-        return_value=pl.EffectiveRequirements(["requests==2.28.0"], []),
-    )
-    @patch(
-        "mmrelay.plugin_loader._load_plugin_state",
-        return_value={
-            pl.PLUGIN_STATE_LAST_INSTALLED_REQUIREMENTS_COMMIT: "0123456789abcdef0123456789abcdef01234567",
-            pl.PLUGIN_STATE_LAST_INSTALLED_REQUIREMENTS_HASH: pl._requirements_hash(
-                ["requests==2.28.0"]
-            ),
-            pl.PLUGIN_STATE_LAST_INSTALLED_REQUIREMENTS_TARGET: "target:/plugins/deps",
-        },
-    )
+    @patch("mmrelay.plugin_loader.load_plugins_from_directory")
+    @patch("mmrelay.plugin_loader.get_community_plugin_dirs")
+    @patch("mmrelay.plugin_loader.get_custom_plugin_dirs")
+    @patch("mmrelay.plugin_loader.start_global_scheduler")
+    @patch("mmrelay.plugin_loader._check_commit_pin_for_upstream_updates")
+    @patch("mmrelay.plugin_loader.logger")
+    def test_load_plugins_opted_in_no_requirements_file_skips_cache_work(
+        self,
+        mock_logger,
+        _mock_update_check,
+        mock_start_scheduler,
+        mock_get_custom_dirs,
+        mock_get_community_dirs,
+        mock_load_from_dir,
+        _mock_resolve_local_head_commit,
+        mock_effective_requirements,
+        mock_requirements_hash,
+        mock_target_identity,
+        mock_install_reqs,
+        mock_clone_repo,
+    ):
+        """No requirements.txt should not compute install state or churn cache."""
+        pl.plugins_loaded = False
+        pl.sorted_active_plugins = []
+        self._community_repo_path()
+        config = {
+            "community-plugins": {
+                "commit-plugin": {
+                    "active": True,
+                    "repository": "https://github.com/user/repo.git",
+                    "commit": "0123456789abcdef0123456789abcdef01234567",
+                    "install_requirements": True,
+                }
+            },
+            "plugins": {},
+        }
+
+        mock_get_custom_dirs.return_value = []
+        mock_get_community_dirs.return_value = [self.community_dir]
+        mock_clone_repo.return_value = True
+        mock_load_from_dir.return_value = []
+
+        load_plugins(config)
+
+        mock_effective_requirements.assert_not_called()
+        mock_requirements_hash.assert_not_called()
+        mock_target_identity.assert_not_called()
+        mock_install_reqs.assert_not_called()
+        mock_logger.debug.assert_any_call(
+            "Skipping requirements install for community plugin %s; no %s found",
+            "commit-plugin",
+            pl.PLUGIN_REQUIREMENTS_FILENAME,
+        )
+        mock_start_scheduler.assert_called_once()
+
+    @patch("mmrelay.plugin_loader.clone_or_update_repo")
+    @patch("mmrelay.plugin_loader._install_requirements_for_repo")
     @patch(
         "mmrelay.plugin_loader._resolve_local_head_commit",
         return_value="0123456789abcdef0123456789abcdef01234567",
@@ -1787,23 +1845,35 @@ class Plugin:
     @patch("mmrelay.plugin_loader._check_commit_pin_for_upstream_updates")
     def test_load_plugins_opted_in_commit_unchanged_skips_dependency_install(
         self,
-        mock_update_check,
+        _mock_update_check,
         mock_start_scheduler,
         mock_get_custom_dirs,
         mock_get_community_dirs,
         mock_load_from_dir,
-        mock_resolve_local_head_commit,
-        mock_load_state,
-        mock_effective_requirements,
-        mock_target_identity,
-        mock_target_valid,
-        mock_save_state,
+        _mock_resolve_local_head_commit,
         mock_install_reqs,
         mock_clone_repo,
     ):
         """Dependency install should be skipped when commit is already installed."""
         pl.plugins_loaded = False
         pl.sorted_active_plugins = []
+        repo_path = self._write_community_requirements()
+        deps_dir = os.path.join(self.test_dir, "plugins", "deps")
+        os.makedirs(deps_dir, exist_ok=True)
+        requirements_hash = pl._requirements_hash(["requests==2.28.0"])
+        with patch.object(pl, "_PLUGIN_DEPS_DIR", deps_dir):
+            requirements_target = pl._requirements_install_target_identity()
+            pl._write_requirements_install_marker(
+                repo_path, "repo", requirements_hash, requirements_target
+            )
+        pl._save_plugin_state(
+            repo_path,
+            {
+                pl.PLUGIN_STATE_LAST_INSTALLED_REQUIREMENTS_COMMIT: "0123456789abcdef0123456789abcdef01234567",
+                pl.PLUGIN_STATE_LAST_INSTALLED_REQUIREMENTS_HASH: requirements_hash,
+                pl.PLUGIN_STATE_LAST_INSTALLED_REQUIREMENTS_TARGET: requirements_target,
+            },
+        )
         config = {
             "community-plugins": {
                 "commit-plugin": {
@@ -1821,53 +1891,14 @@ class Plugin:
         mock_clone_repo.return_value = True
         mock_load_from_dir.return_value = []
 
-        load_plugins(config)
+        with patch.object(pl, "_PLUGIN_DEPS_DIR", deps_dir):
+            load_plugins(config)
 
-        mock_update_check.assert_called_once()
-        mock_resolve_local_head_commit.assert_called_once_with(
-            os.path.join(self.community_dir, "repo")
-        )
-        mock_load_state.assert_called_once_with(
-            os.path.join(self.community_dir, "repo")
-        )
         mock_install_reqs.assert_not_called()
-        mock_effective_requirements.assert_called_once_with(
-            os.path.join(self.community_dir, "repo"), "repo"
-        )
-        mock_target_identity.assert_called_once()
-        mock_target_valid.assert_called_once_with(
-            os.path.join(self.community_dir, "repo"),
-            "repo",
-            pl._requirements_hash(["requests==2.28.0"]),
-            "target:/plugins/deps",
-        )
-        mock_save_state.assert_not_called()
         mock_start_scheduler.assert_called_once()
 
     @patch("mmrelay.plugin_loader.clone_or_update_repo")
     @patch("mmrelay.plugin_loader._install_requirements_for_repo", return_value=True)
-    @patch("mmrelay.plugin_loader._save_plugin_state")
-    @patch(
-        "mmrelay.plugin_loader._requirements_install_target_valid", return_value=False
-    )
-    @patch(
-        "mmrelay.plugin_loader._requirements_install_target_identity",
-        return_value="target:/plugins/deps",
-    )
-    @patch(
-        "mmrelay.plugin_loader._effective_requirements_for_repo",
-        return_value=pl.EffectiveRequirements(["requests==2.28.0"], []),
-    )
-    @patch(
-        "mmrelay.plugin_loader._load_plugin_state",
-        return_value={
-            pl.PLUGIN_STATE_LAST_INSTALLED_REQUIREMENTS_COMMIT: "0123456789abcdef0123456789abcdef01234567",
-            pl.PLUGIN_STATE_LAST_INSTALLED_REQUIREMENTS_HASH: pl._requirements_hash(
-                ["requests==2.28.0"]
-            ),
-            pl.PLUGIN_STATE_LAST_INSTALLED_REQUIREMENTS_TARGET: "target:/plugins/deps",
-        },
-    )
     @patch(
         "mmrelay.plugin_loader._resolve_local_head_commit",
         return_value="0123456789abcdef0123456789abcdef01234567",
@@ -1879,23 +1910,32 @@ class Plugin:
     @patch("mmrelay.plugin_loader._check_commit_pin_for_upstream_updates")
     def test_load_plugins_matching_commit_empty_deps_reinstalls_requirements(
         self,
-        mock_update_check,
+        _mock_update_check,
         mock_start_scheduler,
         mock_get_custom_dirs,
         mock_get_community_dirs,
         mock_load_from_dir,
-        mock_resolve_local_head_commit,
-        mock_load_state,
-        mock_effective_requirements,
-        mock_target_identity,
-        mock_target_valid,
-        mock_save_state,
+        _mock_resolve_local_head_commit,
         mock_install_reqs,
         mock_clone_repo,
     ):
         """Matching state should not skip install when the target is invalid."""
         pl.plugins_loaded = False
         pl.sorted_active_plugins = []
+        repo_path = self._write_community_requirements()
+        deps_dir = os.path.join(self.test_dir, "plugins", "deps")
+        os.makedirs(deps_dir, exist_ok=True)
+        requirements_hash = pl._requirements_hash(["requests==2.28.0"])
+        with patch.object(pl, "_PLUGIN_DEPS_DIR", deps_dir):
+            requirements_target = pl._requirements_install_target_identity()
+        pl._save_plugin_state(
+            repo_path,
+            {
+                pl.PLUGIN_STATE_LAST_INSTALLED_REQUIREMENTS_COMMIT: "0123456789abcdef0123456789abcdef01234567",
+                pl.PLUGIN_STATE_LAST_INSTALLED_REQUIREMENTS_HASH: requirements_hash,
+                pl.PLUGIN_STATE_LAST_INSTALLED_REQUIREMENTS_TARGET: requirements_target,
+            },
+        )
         config = {
             "community-plugins": {
                 "commit-plugin": {
@@ -1913,43 +1953,27 @@ class Plugin:
         mock_clone_repo.return_value = True
         mock_load_from_dir.return_value = []
 
-        load_plugins(config)
+        with patch.object(pl, "_PLUGIN_DEPS_DIR", deps_dir):
+            load_plugins(config)
 
-        mock_update_check.assert_called_once()
-        mock_target_valid.assert_called_once_with(
-            os.path.join(self.community_dir, "repo"),
-            "repo",
-            pl._requirements_hash(["requests==2.28.0"]),
-            "target:/plugins/deps",
-        )
         mock_install_reqs.assert_called_once_with(
-            os.path.join(self.community_dir, "repo"),
+            repo_path,
             "repo",
             plugin_type=pl.PLUGIN_TYPE_COMMUNITY,
         )
-        saved_state = mock_save_state.call_args.args[1]
+        saved_state = pl._load_plugin_state(repo_path)
         self.assertEqual(
             saved_state.get(pl.PLUGIN_STATE_LAST_INSTALLED_REQUIREMENTS_HASH),
-            pl._requirements_hash(["requests==2.28.0"]),
+            requirements_hash,
         )
         self.assertEqual(
             saved_state.get(pl.PLUGIN_STATE_LAST_INSTALLED_REQUIREMENTS_TARGET),
-            "target:/plugins/deps",
+            requirements_target,
         )
         mock_start_scheduler.assert_called_once()
 
     @patch("mmrelay.plugin_loader.clone_or_update_repo")
     @patch("mmrelay.plugin_loader._install_requirements_for_repo", return_value=False)
-    @patch("mmrelay.plugin_loader._save_plugin_state")
-    @patch(
-        "mmrelay.plugin_loader._requirements_install_target_identity",
-        return_value="target:/plugins/deps",
-    )
-    @patch(
-        "mmrelay.plugin_loader._effective_requirements_for_repo",
-        return_value=pl.EffectiveRequirements(["requests==2.28.0"], []),
-    )
-    @patch("mmrelay.plugin_loader._load_plugin_state", return_value={})
     @patch(
         "mmrelay.plugin_loader._resolve_local_head_commit",
         return_value="0123456789abcdef0123456789abcdef01234567",
@@ -1961,22 +1985,21 @@ class Plugin:
     @patch("mmrelay.plugin_loader._check_commit_pin_for_upstream_updates")
     def test_load_plugins_failed_requirements_install_does_not_update_state(
         self,
-        mock_update_check,
+        _mock_update_check,
         mock_start_scheduler,
         mock_get_custom_dirs,
         mock_get_community_dirs,
         mock_load_from_dir,
-        mock_resolve_local_head_commit,
-        mock_load_state,
-        mock_effective_requirements,
-        mock_target_identity,
-        mock_save_state,
+        _mock_resolve_local_head_commit,
         mock_install_reqs,
         mock_clone_repo,
     ):
         """Failed dependency installs should not refresh plugin install state."""
         pl.plugins_loaded = False
         pl.sorted_active_plugins = []
+        repo_path = self._write_community_requirements()
+        deps_dir = os.path.join(self.test_dir, "plugins", "deps")
+        os.makedirs(deps_dir, exist_ok=True)
         config = {
             "community-plugins": {
                 "commit-plugin": {
@@ -1994,10 +2017,11 @@ class Plugin:
         mock_clone_repo.return_value = True
         mock_load_from_dir.return_value = []
 
-        load_plugins(config)
+        with patch.object(pl, "_PLUGIN_DEPS_DIR", deps_dir):
+            load_plugins(config)
 
         mock_install_reqs.assert_called_once()
-        mock_save_state.assert_not_called()
+        self.assertEqual(pl._load_plugin_state(repo_path), {})
         mock_start_scheduler.assert_called_once()
 
     @patch("mmrelay.plugin_loader.clone_or_update_repo")
@@ -2034,6 +2058,7 @@ class Plugin:
         """Dependency install should run when commit changes."""
         pl.plugins_loaded = False
         pl.sorted_active_plugins = []
+        self._write_community_requirements()
         config = {
             "community-plugins": {
                 "commit-plugin": {
@@ -4641,6 +4666,7 @@ class TestDependencyInstallation(BaseGitTest):
         with (
             patch.dict(os.environ, {"VIRTUAL_ENV": "/venv"}, clear=True),
             patch.object(pl, "_PLUGIN_DEPS_DIR", self.deps_dir),
+            patch("mmrelay.plugin_loader._write_requirements_install_marker"),
         ):
             _install_requirements_for_repo(self.repo_path, "test-plugin")
 
@@ -4688,7 +4714,7 @@ class TestDependencyInstallation(BaseGitTest):
             [],
         )
         with (
-            patch.dict(os.environ, {"PIPX_HOME": "/pipx/home"}),
+            patch.dict(os.environ, {"PIPX_HOME": "/pipx/home"}, clear=True),
             patch.object(pl, "_PLUGIN_DEPS_DIR", None),
         ):
             _install_requirements_for_repo(self.repo_path, "test-plugin")
@@ -4730,6 +4756,7 @@ class TestDependencyInstallation(BaseGitTest):
                 "mmrelay.plugin_loader.tempfile.NamedTemporaryFile"
             ) as mock_temp_file,
             patch("mmrelay.plugin_loader.os.unlink"),
+            patch("mmrelay.plugin_loader._write_requirements_install_marker"),
         ):
             mock_collect.return_value = ["requests==2.28.0"]
             mock_filter.return_value = (["requests==2.28.0"], [])
@@ -4797,7 +4824,7 @@ class TestDependencyInstallation(BaseGitTest):
             patch("mmrelay.plugin_loader._refresh_dependency_paths"),
             patch.object(pl, "_PLUGIN_DEPS_DIR", self.deps_dir),
             patch("shutil.which", return_value="/usr/bin/pipx") as mock_which,
-            patch.dict(os.environ, {"PIPX_HOME": "/pipx/home"}),
+            patch.dict(os.environ, {"PIPX_HOME": "/pipx/home"}, clear=True),
         ):
             _install_requirements_for_repo(self.repo_path, "test-plugin")
 
@@ -4814,7 +4841,7 @@ class TestDependencyInstallation(BaseGitTest):
             patch("mmrelay.plugin_loader._run") as mock_run,
             patch.object(pl, "_PLUGIN_DEPS_DIR", None),
             patch("shutil.which", return_value="/usr/bin/pipx"),
-            patch.dict(os.environ, {"PIPX_HOME": "/pipx/home"}),
+            patch.dict(os.environ, {"PIPX_HOME": "/pipx/home"}, clear=True),
         ):
             _install_requirements_for_repo(self.repo_path, "test-plugin")
 
@@ -4849,6 +4876,66 @@ class TestDependencyInstallation(BaseGitTest):
             patch("site.getusersitepackages", side_effect=AttributeError),
         ):
             self.assertEqual(pl._requirements_install_target_identity(), "user:unknown")
+
+    def test_requirements_install_target_pipx_uses_site_packages_marker_dir(self):
+        """pipx fallback target should include site-packages freshness."""
+        site_packages = os.path.join(self.temp_dir, "pipx-venv", "site-packages")
+        os.makedirs(site_packages)
+        with (
+            patch.object(pl, "_PLUGIN_DEPS_DIR", None),
+            patch.dict(os.environ, {"PIPX_HOME": "/pipx/home"}, clear=True),
+            patch("sys.prefix", os.path.join(self.temp_dir, "pipx-venv")),
+            patch(
+                "mmrelay.plugin_loader._site_packages_for_prefix",
+                return_value=site_packages,
+            ),
+        ):
+            target = pl._requirements_install_target()
+
+        self.assertTrue(target.identity.startswith("pipx:"))
+        self.assertIn(os.path.abspath(site_packages), target.identity)
+        self.assertIn(str(os.stat(site_packages).st_mtime_ns), target.identity)
+        self.assertEqual(target.marker_dir, site_packages)
+
+    def test_requirements_install_target_venv_uses_site_packages_marker_dir(self):
+        """venv fallback target should include site-packages freshness."""
+        site_packages = os.path.join(self.temp_dir, "venv", "site-packages")
+        os.makedirs(site_packages)
+        with (
+            patch.object(pl, "_PLUGIN_DEPS_DIR", None),
+            patch.dict(os.environ, {"VIRTUAL_ENV": "/venv"}, clear=True),
+            patch("sys.prefix", os.path.join(self.temp_dir, "venv")),
+            patch("sys.base_prefix", "/usr"),
+            patch(
+                "mmrelay.plugin_loader._site_packages_for_prefix",
+                return_value=site_packages,
+            ),
+        ):
+            target = pl._requirements_install_target()
+
+        self.assertTrue(target.identity.startswith("python:"))
+        self.assertIn(os.path.abspath(site_packages), target.identity)
+        self.assertIn(str(os.stat(site_packages).st_mtime_ns), target.identity)
+        self.assertEqual(target.marker_dir, site_packages)
+
+    def test_requirements_install_target_user_uses_user_site_marker_dir(self):
+        """user fallback target should include user-site freshness."""
+        user_site = os.path.join(self.temp_dir, "user-site")
+        os.makedirs(user_site)
+        with (
+            patch.object(pl, "_PLUGIN_DEPS_DIR", None),
+            patch.dict(os.environ, {}, clear=True),
+            patch("sys.prefix", "/fake/prefix"),
+            patch("sys.base_prefix", "/fake/prefix"),
+            patch("site.getusersitepackages", return_value=user_site),
+        ):
+            target = pl._requirements_install_target()
+
+        self.assertTrue(
+            target.identity.startswith(f"user:{os.path.abspath(user_site)}")
+        )
+        self.assertIn(str(os.stat(user_site).st_mtime_ns), target.identity)
+        self.assertEqual(target.marker_dir, user_site)
 
     def test_requirements_hash_includes_safe_pip_options(self):
         """Requirement state hash covers all safe effective lines, including options."""
@@ -5070,6 +5157,7 @@ class TestDependencyInstallation(BaseGitTest):
                 "mmrelay.plugin_loader.tempfile.NamedTemporaryFile"
             ) as mock_temp_file,
             patch("mmrelay.plugin_loader.os.unlink"),
+            patch("mmrelay.plugin_loader._write_requirements_install_marker"),
         ):
             mock_collect.return_value = ["requests==2.28.0"]
             mock_filter.return_value = (["requests==2.28.0"], [])
@@ -5120,7 +5208,7 @@ class TestDependencyInstallation(BaseGitTest):
         mock_run.side_effect = subprocess.CalledProcessError(1, "pipx")
 
         with (
-            patch.dict(os.environ, {"PIPX_HOME": "/pipx/home"}),
+            patch.dict(os.environ, {"PIPX_HOME": "/pipx/home"}, clear=True),
             patch.object(pl, "_PLUGIN_DEPS_DIR", None),
         ):
             _install_requirements_for_repo(self.repo_path, "test-plugin")
@@ -5150,7 +5238,7 @@ class TestDependencyInstallation(BaseGitTest):
             f.write("--extra-index-url https://pypi.org/simple\n")
 
         with (
-            patch.dict(os.environ, {"PIPX_HOME": "/pipx/home"}),
+            patch.dict(os.environ, {"PIPX_HOME": "/pipx/home"}, clear=True),
             patch.object(pl, "_PLUGIN_DEPS_DIR", None),
             patch("shutil.which", return_value="/usr/bin/pipx"),
         ):

--- a/tests/test_plugin_loader.py
+++ b/tests/test_plugin_loader.py
@@ -4826,7 +4826,6 @@ class TestDependencyInstallation(BaseGitTest):
             "requests==2.28.0",
             "--extra-index-url https://pypi.org/simple",
         ]
-        # The function tokenizes lines from _collect_requirements, so filter receives tokenized input
         mock_filter.return_value = (
             ["requests==2.28.0", "--extra-index-url https://pypi.org/simple"],
             [],

--- a/tests/test_plugin_loader.py
+++ b/tests/test_plugin_loader.py
@@ -1755,9 +1755,24 @@ class Plugin:
     @patch("mmrelay.plugin_loader._install_requirements_for_repo")
     @patch("mmrelay.plugin_loader._save_plugin_state")
     @patch(
+        "mmrelay.plugin_loader._requirements_install_target_valid", return_value=True
+    )
+    @patch(
+        "mmrelay.plugin_loader._requirements_install_target_identity",
+        return_value="target:/plugins/deps",
+    )
+    @patch(
+        "mmrelay.plugin_loader._effective_requirements_for_repo",
+        return_value=["requests==2.28.0"],
+    )
+    @patch(
         "mmrelay.plugin_loader._load_plugin_state",
         return_value={
-            pl.PLUGIN_STATE_LAST_INSTALLED_REQUIREMENTS_COMMIT: "0123456789abcdef0123456789abcdef01234567"
+            pl.PLUGIN_STATE_LAST_INSTALLED_REQUIREMENTS_COMMIT: "0123456789abcdef0123456789abcdef01234567",
+            pl.PLUGIN_STATE_LAST_INSTALLED_REQUIREMENTS_HASH: pl._requirements_hash(
+                ["requests==2.28.0"]
+            ),
+            pl.PLUGIN_STATE_LAST_INSTALLED_REQUIREMENTS_TARGET: "target:/plugins/deps",
         },
     )
     @patch(
@@ -1778,6 +1793,9 @@ class Plugin:
         mock_load_from_dir,
         mock_resolve_local_head_commit,
         mock_load_state,
+        mock_effective_requirements,
+        mock_target_identity,
+        mock_target_valid,
         mock_save_state,
         mock_install_reqs,
         mock_clone_repo,
@@ -1812,6 +1830,166 @@ class Plugin:
             os.path.join(self.community_dir, "repo")
         )
         mock_install_reqs.assert_not_called()
+        mock_effective_requirements.assert_called_once_with(
+            os.path.join(self.community_dir, "repo"), "repo"
+        )
+        mock_target_identity.assert_called_once()
+        mock_target_valid.assert_called_once_with(
+            os.path.join(self.community_dir, "repo")
+        )
+        mock_save_state.assert_not_called()
+        mock_start_scheduler.assert_called_once()
+
+    @patch("mmrelay.plugin_loader.clone_or_update_repo")
+    @patch("mmrelay.plugin_loader._install_requirements_for_repo", return_value=True)
+    @patch("mmrelay.plugin_loader._save_plugin_state")
+    @patch(
+        "mmrelay.plugin_loader._requirements_install_target_valid", return_value=False
+    )
+    @patch(
+        "mmrelay.plugin_loader._requirements_install_target_identity",
+        return_value="target:/plugins/deps",
+    )
+    @patch(
+        "mmrelay.plugin_loader._effective_requirements_for_repo",
+        return_value=["requests==2.28.0"],
+    )
+    @patch(
+        "mmrelay.plugin_loader._load_plugin_state",
+        return_value={
+            pl.PLUGIN_STATE_LAST_INSTALLED_REQUIREMENTS_COMMIT: "0123456789abcdef0123456789abcdef01234567",
+            pl.PLUGIN_STATE_LAST_INSTALLED_REQUIREMENTS_HASH: pl._requirements_hash(
+                ["requests==2.28.0"]
+            ),
+            pl.PLUGIN_STATE_LAST_INSTALLED_REQUIREMENTS_TARGET: "target:/plugins/deps",
+        },
+    )
+    @patch(
+        "mmrelay.plugin_loader._resolve_local_head_commit",
+        return_value="0123456789abcdef0123456789abcdef01234567",
+    )
+    @patch("mmrelay.plugin_loader.load_plugins_from_directory")
+    @patch("mmrelay.plugin_loader.get_community_plugin_dirs")
+    @patch("mmrelay.plugin_loader.get_custom_plugin_dirs")
+    @patch("mmrelay.plugin_loader.start_global_scheduler")
+    @patch("mmrelay.plugin_loader._check_commit_pin_for_upstream_updates")
+    def test_load_plugins_matching_commit_empty_deps_reinstalls_requirements(
+        self,
+        mock_update_check,
+        mock_start_scheduler,
+        mock_get_custom_dirs,
+        mock_get_community_dirs,
+        mock_load_from_dir,
+        mock_resolve_local_head_commit,
+        mock_load_state,
+        mock_effective_requirements,
+        mock_target_identity,
+        mock_target_valid,
+        mock_save_state,
+        mock_install_reqs,
+        mock_clone_repo,
+    ):
+        """Matching state should not skip install when the target is invalid."""
+        pl.plugins_loaded = False
+        pl.sorted_active_plugins = []
+        config = {
+            "community-plugins": {
+                "commit-plugin": {
+                    "active": True,
+                    "repository": "https://github.com/user/repo.git",
+                    "commit": "0123456789abcdef0123456789abcdef01234567",
+                    "install_requirements": True,
+                }
+            },
+            "plugins": {},
+        }
+
+        mock_get_custom_dirs.return_value = []
+        mock_get_community_dirs.return_value = [self.community_dir]
+        mock_clone_repo.return_value = True
+        mock_load_from_dir.return_value = []
+
+        load_plugins(config)
+
+        mock_update_check.assert_called_once()
+        mock_target_valid.assert_called_once_with(
+            os.path.join(self.community_dir, "repo")
+        )
+        mock_install_reqs.assert_called_once_with(
+            os.path.join(self.community_dir, "repo"),
+            "repo",
+            plugin_type=pl.PLUGIN_TYPE_COMMUNITY,
+        )
+        saved_state = mock_save_state.call_args.args[1]
+        self.assertEqual(
+            saved_state.get(pl.PLUGIN_STATE_LAST_INSTALLED_REQUIREMENTS_HASH),
+            pl._requirements_hash(["requests==2.28.0"]),
+        )
+        self.assertEqual(
+            saved_state.get(pl.PLUGIN_STATE_LAST_INSTALLED_REQUIREMENTS_TARGET),
+            "target:/plugins/deps",
+        )
+        mock_start_scheduler.assert_called_once()
+
+    @patch("mmrelay.plugin_loader.clone_or_update_repo")
+    @patch("mmrelay.plugin_loader._install_requirements_for_repo", return_value=False)
+    @patch("mmrelay.plugin_loader._save_plugin_state")
+    @patch(
+        "mmrelay.plugin_loader._requirements_install_target_identity",
+        return_value="target:/plugins/deps",
+    )
+    @patch(
+        "mmrelay.plugin_loader._effective_requirements_for_repo",
+        return_value=["requests==2.28.0"],
+    )
+    @patch("mmrelay.plugin_loader._load_plugin_state", return_value={})
+    @patch(
+        "mmrelay.plugin_loader._resolve_local_head_commit",
+        return_value="0123456789abcdef0123456789abcdef01234567",
+    )
+    @patch("mmrelay.plugin_loader.load_plugins_from_directory")
+    @patch("mmrelay.plugin_loader.get_community_plugin_dirs")
+    @patch("mmrelay.plugin_loader.get_custom_plugin_dirs")
+    @patch("mmrelay.plugin_loader.start_global_scheduler")
+    @patch("mmrelay.plugin_loader._check_commit_pin_for_upstream_updates")
+    def test_load_plugins_failed_requirements_install_does_not_update_state(
+        self,
+        mock_update_check,
+        mock_start_scheduler,
+        mock_get_custom_dirs,
+        mock_get_community_dirs,
+        mock_load_from_dir,
+        mock_resolve_local_head_commit,
+        mock_load_state,
+        mock_effective_requirements,
+        mock_target_identity,
+        mock_save_state,
+        mock_install_reqs,
+        mock_clone_repo,
+    ):
+        """Failed dependency installs should not refresh plugin install state."""
+        pl.plugins_loaded = False
+        pl.sorted_active_plugins = []
+        config = {
+            "community-plugins": {
+                "commit-plugin": {
+                    "active": True,
+                    "repository": "https://github.com/user/repo.git",
+                    "commit": "0123456789abcdef0123456789abcdef01234567",
+                    "install_requirements": True,
+                }
+            },
+            "plugins": {},
+        }
+
+        mock_get_custom_dirs.return_value = []
+        mock_get_community_dirs.return_value = [self.community_dir]
+        mock_clone_repo.return_value = True
+        mock_load_from_dir.return_value = []
+
+        load_plugins(config)
+
+        mock_install_reqs.assert_called_once()
         mock_save_state.assert_not_called()
         mock_start_scheduler.assert_called_once()
 
@@ -4373,6 +4551,8 @@ class TestDependencyInstallation(BaseGitTest):
         self.temp_dir = tempfile.mkdtemp()
         self.repo_path = os.path.join(self.temp_dir, "test-plugin")
         self.requirements_path = os.path.join(self.repo_path, "requirements.txt")
+        self.deps_dir = os.path.join(self.temp_dir, "deps")
+        os.makedirs(self.deps_dir, exist_ok=True)
         os.makedirs(self.repo_path, exist_ok=True)
         with open(self.requirements_path, "w") as f:
             f.write("requests==2.28.0\n")
@@ -4451,7 +4631,10 @@ class TestDependencyInstallation(BaseGitTest):
         temp_req = os.path.join(self.temp_dir, "test_requirements.txt")
         mock_file.name = temp_req
 
-        with patch.dict(os.environ, {"VIRTUAL_ENV": "/venv"}, clear=True):
+        with (
+            patch.dict(os.environ, {"VIRTUAL_ENV": "/venv"}, clear=True),
+            patch.object(pl, "_PLUGIN_DEPS_DIR", self.deps_dir),
+        ):
             _install_requirements_for_repo(self.repo_path, "test-plugin")
 
         # Check that the command uses -r with the temporary file
@@ -4463,8 +4646,10 @@ class TestDependencyInstallation(BaseGitTest):
             "install",
             "--disable-pip-version-check",
             "--no-input",
+            "--target",
+            self.deps_dir,
         ]
-        assert called_cmd[:6] == expected_base
+        assert called_cmd[:8] == expected_base
         assert "-r" in called_cmd
         assert called_cmd[called_cmd.index("-r") + 1] == temp_req
         mock_run.assert_called_once_with(called_cmd, timeout=600)
@@ -4496,7 +4681,10 @@ class TestDependencyInstallation(BaseGitTest):
             [],
             False,
         )
-        with patch.dict(os.environ, {"PIPX_HOME": "/pipx/home"}):
+        with (
+            patch.dict(os.environ, {"PIPX_HOME": "/pipx/home"}),
+            patch.object(pl, "_PLUGIN_DEPS_DIR", None),
+        ):
             _install_requirements_for_repo(self.repo_path, "test-plugin")
 
         # Verify the call uses temporary file approach
@@ -4529,6 +4717,7 @@ class TestDependencyInstallation(BaseGitTest):
             patch("sys.prefix", "/fake/prefix"),
             patch("sys.base_prefix", "/fake/prefix"),
             patch("shutil.which", return_value=None),
+            patch.object(pl, "_PLUGIN_DEPS_DIR", None),
             patch(
                 "mmrelay.plugin_loader.tempfile.NamedTemporaryFile"
             ) as mock_temp_file,
@@ -4563,6 +4752,95 @@ class TestDependencyInstallation(BaseGitTest):
                 tempfile.gettempdir(), "test_requirements.txt"
             )
             mock_run.assert_called_once_with(called_cmd, timeout=600)
+
+    def test_install_plugin_requirements_uses_target_when_deps_dir_set(self):
+        """Persistent deps dir should use pip --target instead of --user."""
+        with (
+            patch("mmrelay.plugin_loader._run") as mock_run,
+            patch("mmrelay.plugin_loader._refresh_dependency_paths"),
+            patch.object(pl, "_PLUGIN_DEPS_DIR", self.deps_dir),
+            patch("sys.prefix", "/fake/prefix"),
+            patch("sys.base_prefix", "/fake/prefix"),
+            patch.dict(os.environ, {}, clear=True),
+        ):
+            _install_requirements_for_repo(self.repo_path, "test-plugin")
+
+        cmd = mock_run.call_args.args[0]
+        self.assertEqual(
+            cmd[:6],
+            [
+                sys.executable,
+                "-m",
+                "pip",
+                "install",
+                "--disable-pip-version-check",
+                "--no-input",
+            ],
+        )
+        self.assertIn("--target", cmd)
+        self.assertEqual(cmd[cmd.index("--target") + 1], self.deps_dir)
+        self.assertNotIn("--user", cmd)
+        self.assertNotIn("inject", cmd)
+
+    def test_install_plugin_requirements_deps_dir_overrides_pipx(self):
+        """Persistent deps dir should be preferred even when pipx is detected."""
+        with (
+            patch("mmrelay.plugin_loader._run") as mock_run,
+            patch("mmrelay.plugin_loader._refresh_dependency_paths"),
+            patch.object(pl, "_PLUGIN_DEPS_DIR", self.deps_dir),
+            patch("shutil.which", return_value="/usr/bin/pipx") as mock_which,
+            patch.dict(os.environ, {"PIPX_HOME": "/pipx/home"}),
+        ):
+            _install_requirements_for_repo(self.repo_path, "test-plugin")
+
+        cmd = mock_run.call_args.args[0]
+        self.assertEqual(cmd[:4], [sys.executable, "-m", "pip", "install"])
+        self.assertIn("--target", cmd)
+        self.assertEqual(cmd[cmd.index("--target") + 1], self.deps_dir)
+        self.assertNotIn("inject", cmd)
+        mock_which.assert_not_called()
+
+    def test_install_plugin_requirements_without_deps_dir_uses_pipx(self):
+        """Without a persistent deps dir, pipx environments should use pipx inject."""
+        with (
+            patch("mmrelay.plugin_loader._run") as mock_run,
+            patch.object(pl, "_PLUGIN_DEPS_DIR", None),
+            patch("shutil.which", return_value="/usr/bin/pipx"),
+            patch.dict(os.environ, {"PIPX_HOME": "/pipx/home"}),
+        ):
+            _install_requirements_for_repo(self.repo_path, "test-plugin")
+
+        cmd = mock_run.call_args.args[0]
+        self.assertEqual(
+            cmd[:4], ["/usr/bin/pipx", "inject", "mmrelay", "--requirement"]
+        )
+
+    def test_install_plugin_requirements_without_deps_dir_no_venv_uses_user(self):
+        """Without deps dir, non-venv pip installs should use --user."""
+        with (
+            patch("mmrelay.plugin_loader._run") as mock_run,
+            patch.object(pl, "_PLUGIN_DEPS_DIR", None),
+            patch("sys.prefix", "/fake/prefix"),
+            patch("sys.base_prefix", "/fake/prefix"),
+            patch.dict(os.environ, {}, clear=True),
+        ):
+            _install_requirements_for_repo(self.repo_path, "test-plugin")
+
+        cmd = mock_run.call_args.args[0]
+        self.assertEqual(cmd[:4], [sys.executable, "-m", "pip", "install"])
+        self.assertIn("--user", cmd)
+        self.assertNotIn("--target", cmd)
+
+    def test_requirements_install_target_valid_empty_deps_dir_is_invalid(self):
+        """An empty persistent deps dir should not satisfy cached install state."""
+        with patch.object(pl, "_PLUGIN_DEPS_DIR", self.deps_dir):
+            self.assertFalse(pl._requirements_install_target_valid(self.repo_path))
+
+    def test_requirements_install_target_valid_deps_dir_marker_is_valid(self):
+        """A marker in the persistent deps dir should satisfy cached install state."""
+        with patch.object(pl, "_PLUGIN_DEPS_DIR", self.deps_dir):
+            pl._write_requirements_install_marker(self.repo_path)
+            self.assertTrue(pl._requirements_install_target_valid(self.repo_path))
 
     @patch("mmrelay.plugin_loader.logger")
     @patch("mmrelay.plugin_loader._run")
@@ -4621,6 +4899,7 @@ class TestDependencyInstallation(BaseGitTest):
             patch("sys.prefix", "/fake/prefix"),
             patch("sys.base_prefix", "/fake/prefix"),
             patch("shutil.which", return_value=None),
+            patch.object(pl, "_PLUGIN_DEPS_DIR", None),
             patch(
                 "mmrelay.plugin_loader.tempfile.NamedTemporaryFile"
             ) as mock_temp_file,
@@ -4674,7 +4953,10 @@ class TestDependencyInstallation(BaseGitTest):
         mock_filter.return_value = (["requests==2.28.0"], [], False)
         mock_run.side_effect = subprocess.CalledProcessError(1, "pipx")
 
-        with patch.dict(os.environ, {"PIPX_HOME": "/pipx/home"}):
+        with (
+            patch.dict(os.environ, {"PIPX_HOME": "/pipx/home"}),
+            patch.object(pl, "_PLUGIN_DEPS_DIR", None),
+        ):
             _install_requirements_for_repo(self.repo_path, "test-plugin")
 
         # Should log error and warning
@@ -4702,9 +4984,12 @@ class TestDependencyInstallation(BaseGitTest):
         with open(self.requirements_path, "w") as f:
             f.write("--extra-index-url https://pypi.org/simple\n")
 
-        with patch.dict(os.environ, {"PIPX_HOME": "/pipx/home"}):
-            with patch("shutil.which", return_value="/usr/bin/pipx"):
-                _install_requirements_for_repo(self.repo_path, "test-plugin")
+        with (
+            patch.dict(os.environ, {"PIPX_HOME": "/pipx/home"}),
+            patch.object(pl, "_PLUGIN_DEPS_DIR", None),
+            patch("shutil.which", return_value="/usr/bin/pipx"),
+        ):
+            _install_requirements_for_repo(self.repo_path, "test-plugin")
 
         # Should not call pipx inject when no packages
         mock_run.assert_not_called()

--- a/tests/test_plugin_loader_edge_cases.py
+++ b/tests/test_plugin_loader_edge_cases.py
@@ -289,11 +289,15 @@ class Plugin:
         ):
             with patch("mmrelay.plugin_loader.get_app_path", return_value="/test/app"):
                 with patch("os.makedirs", side_effect=side_effect):
-                    with patch("mmrelay.plugin_loader.logger"):
-                        dirs = get_custom_plugin_dirs()
-                        # Should still include local directory
-                        self.assertEqual(len(dirs), 1)
-                        self.assertIn("/test/app/plugins/custom", dirs)
+                    with patch(
+                        "os.path.isdir",
+                        side_effect=lambda path: path == "/test/app/plugins/custom",
+                    ):
+                        with patch("mmrelay.plugin_loader.logger"):
+                            dirs = get_custom_plugin_dirs()
+                            # Should still include existing local directory
+                            self.assertEqual(len(dirs), 1)
+                            self.assertIn("/test/app/plugins/custom", dirs)
 
     def test_get_custom_plugin_dirs_broken_symlinks(self):
         """
@@ -307,13 +311,19 @@ class Plugin:
         ):
             with patch("mmrelay.plugin_loader.get_app_path", return_value="/test/app"):
                 with patch("os.makedirs") as mock_makedirs:
-                    dirs = get_custom_plugin_dirs()
-                    # Should have called makedirs for the user directory
-                    mock_makedirs.assert_called()
-                    # Should return both directories
-                    self.assertEqual(len(dirs), 2)
-                    self.assertIn("/test/plugins/custom", dirs)
-                    self.assertIn("/test/app/plugins/custom", dirs)
+                    with patch(
+                        "os.path.isdir",
+                        side_effect=lambda path: path == "/test/app/plugins/custom",
+                    ):
+                        dirs = get_custom_plugin_dirs()
+                        # Should have called makedirs for the user directory
+                        mock_makedirs.assert_called_once_with(
+                            "/test/plugins/custom", exist_ok=True
+                        )
+                        # Should return both directories
+                        self.assertEqual(len(dirs), 2)
+                        self.assertIn("/test/plugins/custom", dirs)
+                        self.assertIn("/test/app/plugins/custom", dirs)
 
     def test_get_community_plugin_dirs_git_clone_failure(self):
         """
@@ -322,6 +332,7 @@ class Plugin:
         with tempfile.TemporaryDirectory() as temp_dir:
             plugin_root = os.path.join(temp_dir, "plugins")
             app_root = os.path.join(temp_dir, "app")
+            os.makedirs(os.path.join(app_root, "plugins", "community"))
 
             with patch(
                 "mmrelay.plugin_loader._get_plugin_root_dirs",
@@ -343,6 +354,7 @@ class Plugin:
         with tempfile.TemporaryDirectory() as temp_dir:
             plugin_root = os.path.join(temp_dir, "plugins")
             app_root = os.path.join(temp_dir, "app")
+            os.makedirs(os.path.join(app_root, "plugins", "community"))
 
             with patch(
                 "mmrelay.plugin_loader._get_plugin_root_dirs",
@@ -364,6 +376,7 @@ class Plugin:
         with tempfile.TemporaryDirectory() as temp_dir:
             plugin_root = os.path.join(temp_dir, "plugins")
             app_root = os.path.join(temp_dir, "app")
+            os.makedirs(os.path.join(app_root, "plugins", "community"))
 
             with patch(
                 "mmrelay.plugin_loader._get_plugin_root_dirs",
@@ -602,8 +615,8 @@ class Plugin:
                     self.assertEqual(result[0], os.path.join(home_dir, "plugins"))
                     self.assertIn(legacy_root, result)
 
-    def test_get_plugin_dirs_local_directory_error(self):
-        """Test _get_plugin_dirs handles errors when creating local directory."""
+    def test_get_plugin_dirs_missing_local_directory_is_skipped(self):
+        """Test _get_plugin_dirs skips missing local fallback directories."""
         with tempfile.TemporaryDirectory() as temp_dir:
             plugin_type = "custom"
 
@@ -611,28 +624,23 @@ class Plugin:
                 "mmrelay.plugin_loader._get_plugin_root_dirs", return_value=[temp_dir]
             ):
                 with patch("os.makedirs") as mock_makedirs:
-                    # Make local directory creation fail
-                    def side_effect(_path, **_kwargs):
-                        if "app" in _path:  # Local app directory
-                            raise OSError()
-                        return None
-
-                    mock_makedirs.side_effect = side_effect
-
                     with patch(
                         "mmrelay.plugin_loader.get_app_path", return_value="/fake/app"
                     ):
-                        with patch("mmrelay.plugin_loader.logger") as mock_logger:
-                            result = _get_plugin_dirs(plugin_type)
+                        with patch("os.path.isdir", return_value=False):
+                            with patch("mmrelay.plugin_loader.logger") as mock_logger:
+                                result = _get_plugin_dirs(plugin_type)
 
-                            # Should still return the root directory
-                            self.assertEqual(len(result), 1)
-                            self.assertIn(temp_dir, result)
-                            # Should log debug about local directory creation failure
-                            mock_logger.debug.assert_called()
+                                # Should still return the root directory
+                                self.assertEqual(len(result), 1)
+                                self.assertIn(temp_dir, result)
+                                mock_makedirs.assert_called_once_with(
+                                    temp_dir, exist_ok=True
+                                )
+                                mock_logger.debug.assert_not_called()
 
-    def test_get_plugin_dirs_local_permission_error(self):
-        """Test _get_plugin_dirs handles PermissionError when creating local directory."""
+    def test_get_plugin_dirs_missing_local_permission_path_is_skipped(self):
+        """Test _get_plugin_dirs does not create local fallback directories."""
         with tempfile.TemporaryDirectory() as temp_dir:
             plugin_type = "community"
 
@@ -640,25 +648,20 @@ class Plugin:
                 "mmrelay.plugin_loader._get_plugin_root_dirs", return_value=[temp_dir]
             ):
                 with patch("os.makedirs") as mock_makedirs:
-                    # Make local directory creation fail with PermissionError
-                    def side_effect(_path, **_kwargs):
-                        if "app" in _path:  # Local app directory
-                            raise PermissionError()
-                        return None
-
-                    mock_makedirs.side_effect = side_effect
-
                     with patch(
                         "mmrelay.plugin_loader.get_app_path", return_value="/fake/app"
                     ):
-                        with patch("mmrelay.plugin_loader.logger") as mock_logger:
-                            result = _get_plugin_dirs(plugin_type)
+                        with patch("os.path.isdir", return_value=False):
+                            with patch("mmrelay.plugin_loader.logger") as mock_logger:
+                                result = _get_plugin_dirs(plugin_type)
 
-                            # Should still return the root directory
-                            self.assertEqual(len(result), 1)
-                            self.assertIn(temp_dir, result)
-                            # Should log debug about local directory creation failure
-                            mock_logger.debug.assert_called()
+                                # Should still return the root directory
+                                self.assertEqual(len(result), 1)
+                                self.assertIn(temp_dir, result)
+                                mock_makedirs.assert_called_once_with(
+                                    temp_dir, exist_ok=True
+                                )
+                                mock_logger.debug.assert_not_called()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview

This PR makes community plugin dependency installation persistent and verifiable. It ensures dependencies are installed into a resolved persistent deps directory when available (instead of ephemeral user-site locations), records install metadata and a per-repo atomic install marker, validates that marker on subsequent runs, and re-installs when validation fails. It also adds security-aware requirement filtering and harmonizes install-target selection and behavior across installation branches. Tests were expanded heavily to cover these behaviors.

## Key Changes

**Fixes**
- Persist dependency installs to a resolved persistent deps directory (using mmrelay.paths and PLUGINS_DIRNAME) so dependencies survive container restarts instead of being placed in ephemeral user-site locations.
- Tighten install-skip logic so installs are skipped only when all of these match: commit SHA, computed effective-requirements hash, recorded install-target identity, and successful per-repo install-marker validation; otherwise trigger reinstall.
- Detect and recover from missing installs: validate a JSON install marker written under the configured marker prefix and force reinstall when marker validation fails (including empty deps dir or missing staged/merged outputs).

**Features**
- Persistent install metadata added to plugin state: last_installed_requirements_commit, last_installed_requirements_hash, last_installed_requirements_target, last_requirements_installed_at (and writing of an atomic per-repo marker file in the chosen marker_dir).
- Effective-requirements model: requirement lines are classified into allowed vs flagged (VCS/URL/etc. per risky prefixes); flagged lines are included only if security.allow_untrusted_dependencies is enabled; hashing and install decisions use the effective allowed set.
- Install-target identity abstraction (RequirementsInstallTarget): records whether a persistent pip --target was used (preferred), pipx inject, or pip --user, and which marker_dir was written; that identity is validated on subsequent runs.
- Staged install workflow for pip --target: install into a temporary staged target, perform a metadata-aware merge into the persistent deps dir on success, remove staging on success; on failure leave deps unchanged and retain staging for inspection.
- Failure behavior: staged failures do not overwrite existing deps; successful installs refresh import paths and write markers.

**Refactors**
- _install_requirements_for_repo refactored to prefer pip install --target into a persistent deps dir (staging + merge), fall back to pipx inject when pipx is present and no persistent deps dir is available, otherwise use pip --user; it now always receives/returns a requirements_target identity and writes markers on success.
- New helpers and types: EffectiveRequirements, RequirementsInstallTarget, utilities for filtering requirement lines (risk-aware), computing effective hashes, resolving/validating install-target identity, marker JSON validation, staging/merge utilities, and safe-path helpers.
- Plugin root discovery and naming updated to use PLUGINS_DIRNAME and mmrelay.paths helpers when resolving plugin roots and dependency directories.
- Tests expanded and updated to reflect new behaviors (see below).

**Tests**
- Extensive new unit tests cover: deterministic requirements fixtures, effective-requirements hashing, filter behavior for risky lines, marker JSON structure and validation, install-target precedence (pip --target > pipx > pip user), staged merge semantics and cleanup, marker writing/cleanup on success/failure, handling of missing requirements.txt (skips marker/state churn), and namespace-package detection helpers.
- Existing "commit-only" cache tests updated to require matching requirements hash and target identity plus marker validation for skips.

## Breaking Changes / Migration Notes

- No public API changes for plugins, but operational considerations:
  - Ensure the mmrelay data path (resolved via mmrelay.paths) is writable and that the persistent deps path is available on sys.path (the loader attempts to resolve and prepend it).
  - When a persistent deps directory is available, pip --target into that directory is preferred over pipx injection; deployments that previously relied on pipx injection should expect pip --target to be used when persistence is possible.
- Operators should confirm container images/volumes expose and persist the plugins deps directory so recorded markers and dependencies remain available across restarts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Closes #546 
