### PR TITLE
Switch default E2EE provider with compatibility layer

### DIFF
--- a/docs/E2EE.md
+++ b/docs/E2EE.md
@@ -18,8 +18,8 @@ but recommends migrating to vodozemac.
 
 MMRelay now uses **mindroom-nio** as its default Matrix provider, which uses
 **vodozemac** (the Rust successor to libolm) for E2EE. The legacy
-`matrix-nio` provider with `python-olm` is still supported through manual
-replacement but is no longer the default.
+`matrix-nio` provider with `python-olm` is still supported by manually
+installing matrix-nio instead of mindroom-nio but is no longer the default.
 
 ## Index
 
@@ -153,8 +153,8 @@ pipx install 'mmrelay[e2e]'
 ```
 
 The `mmrelay[e2e]` extra installs **mindroom-nio[e2e]** which includes the
-**vodozemac** crypto backend (Rust-based, no native C dependencies beyond what
-pip wheels provide).
+**vodozemac** crypto backend (Rust-based, distributed as precompiled wheels
+requiring no additional system libraries).
 
 ### Windows limitation
 

--- a/docs/E2EE.md
+++ b/docs/E2EE.md
@@ -16,8 +16,10 @@ Matrix.org considers it
 [safe for practical use](https://matrix.org/blog/2024/08/libolm-deprecation/)
 but recommends migrating to vodozemac.
 
-MMRelay currently relies on `matrix-nio`, which still depends on `libolm`.
-Migration work is in progress upstream.
+MMRelay now uses **mindroom-nio** as its default Matrix provider, which uses
+**vodozemac** (the Rust successor to libolm) for E2EE. The legacy
+`matrix-nio` provider with `python-olm` is still supported through manual
+replacement but is no longer the default.
 
 ## Index
 
@@ -150,11 +152,16 @@ session: you need to log in again and re-verify devices.
 pipx install 'mmrelay[e2e]'
 ```
 
+The `mmrelay[e2e]` extra installs **mindroom-nio[e2e]** which includes the
+**vodozemac** crypto backend (Rust-based, no native C dependencies beyond what
+pip wheels provide).
+
 ### Windows limitation
 
 **E2EE is not available on Windows** due to technical limitations with required
-cryptographic libraries (`python-olm` depends on native C libraries that are
-not straightforward to install there).
+cryptographic libraries. The default vodozemac backend and the legacy
+python-olm backend both depend on native libraries that are not straightforward
+to install on Windows.
 
 Windows users can still use MMRelay for regular (unencrypted) Matrix
 communication.
@@ -169,6 +176,13 @@ pipx install 'mmrelay[e2e]'
 # Or using pip
 pip install 'mmrelay[e2e]'
 ```
+
+This installs **mindroom-nio** with the **vodozemac** crypto backend as the
+default E2EE provider.
+
+> **Legacy matrix-nio users**: If you are manually using `matrix-nio` instead
+> of the default mindroom-nio, install `matrix-nio[e2e]` in a separate
+> environment. Do not install both providers together.
 
 ### 2. Enable E2EE in config
 
@@ -276,7 +290,7 @@ expected to show a red shield warning:
 This is expected because:
 
 - Messages **are encrypted** using Matrix E2EE (Olm/Megolm)
-- `matrix-nio` does not support interactive device verification
+- The nio library does not support interactive device verification
   (emoji/QR verification)
 - MMRelay devices cannot be cross-signed through the standard Matrix client
   verification flow
@@ -290,8 +304,9 @@ that as a real issue (usually configuration/version related) and troubleshoot.
 
 **Problem**: E2EE features do not work on Windows.
 
-**Explanation**: E2EE requires `python-olm`, which depends on native C
-libraries that are difficult to install on Windows.
+**Explanation**: E2EE requires native cryptographic libraries (vodozemac for
+the default mindroom-nio provider, or python-olm for legacy matrix-nio). Both
+have native dependencies that are difficult to install on Windows.
 
 **What to do**:
 
@@ -309,11 +324,23 @@ pipx install 'mmrelay[e2e]'
 pip install 'mmrelay[e2e]'
 ```
 
+This installs mindroom-nio with the vodozemac crypto backend.
+
 If running from a local checkout:
 
 ```bash
 pip install -e '.[e2e]'
 ```
+
+If you are using the legacy matrix-nio provider instead of the default
+mindroom-nio, install its E2EE extra separately:
+
+```bash
+pip install 'matrix-nio[e2e]==0.25.2'
+```
+
+> **Warning**: Do not install both mindroom-nio and matrix-nio in the same
+> environment. They both provide the `nio` namespace and will conflict.
 
 ### "Failed to decrypt event" in logs
 
@@ -359,9 +386,11 @@ E2EE support is backward compatible:
 
 ### Implementation
 
-- Uses `matrix-nio` with Olm/Megolm protocols
+- Uses **mindroom-nio** (default) with **vodozemac** crypto backend, or
+  **matrix-nio** (legacy) with **Olm/Megolm** protocols
 - Loads E2EE store before sync operations
 - Uses automatic key management with `ignore_unverified_devices=True`
+- Provider detection and capability reporting via `mmrelay.matrix.compat`
 
 ### Performance impact
 

--- a/docs/E2EE.md
+++ b/docs/E2EE.md
@@ -180,9 +180,11 @@ pip install 'mmrelay[e2e]'
 This installs **mindroom-nio** with the **vodozemac** crypto backend as the
 default E2EE provider.
 
-> **Legacy matrix-nio users**: If you are manually using `matrix-nio` instead
-> of the default mindroom-nio, install `matrix-nio[e2e]` in a separate
-> environment. Do not install both providers together.
+> **Legacy matrix-nio users**: If you are manually replacing mindroom-nio with
+> `matrix-nio` (uninstall mindroom-nio first, then install matrix-nio), use
+> `pip install 'matrix-nio[e2e]==0.25.2'` instead. Do **not** install
+> `mmrelay[e2e]` — it pulls in mindroom-nio. Never install both providers in
+> the same Python environment.
 
 ### 2. Enable E2EE in config
 
@@ -324,7 +326,9 @@ pipx install 'mmrelay[e2e]'
 pip install 'mmrelay[e2e]'
 ```
 
-This installs mindroom-nio with the vodozemac crypto backend.
+This installs mindroom-nio with the vodozemac crypto backend. Vodozemac is
+Rust-based and distributed as precompiled wheels requiring no extra system
+libraries.
 
 If running from a local checkout:
 
@@ -333,7 +337,8 @@ pip install -e '.[e2e]'
 ```
 
 If you are using the legacy matrix-nio provider instead of the default
-mindroom-nio, install its E2EE extra separately:
+mindroom-nio (by manually uninstalling mindroom-nio and installing matrix-nio),
+install its E2EE extra separately:
 
 ```bash
 pip install 'matrix-nio[e2e]==0.25.2'
@@ -341,6 +346,8 @@ pip install 'matrix-nio[e2e]==0.25.2'
 
 > **Warning**: Do not install both mindroom-nio and matrix-nio in the same
 > environment. They both provide the `nio` namespace and will conflict.
+> Do **not** install `mmrelay[e2e]` when using legacy matrix-nio — it will
+> reinstall mindroom-nio.
 
 ### "Failed to decrypt event" in logs
 
@@ -386,8 +393,10 @@ E2EE support is backward compatible:
 
 ### Implementation
 
-- Uses **mindroom-nio** (default) with **vodozemac** crypto backend, or
-  **matrix-nio** (legacy) with **Olm/Megolm** protocols
+- Uses **mindroom-nio** (default) with the **vodozemac** crypto backend, or
+  **matrix-nio** (legacy) with the **python-olm/libolm** crypto backend.
+- Both providers use the Matrix **Olm/Megolm** encryption protocols; they differ
+  only in the underlying cryptographic library.
 - Loads E2EE store before sync operations
 - Uses automatic key management with `ignore_unverified_devices=True`
 - Provider detection and capability reporting via `mmrelay.matrix.compat`

--- a/docs/MIGRATION_1.3.md
+++ b/docs/MIGRATION_1.3.md
@@ -4,6 +4,37 @@ This guide helps you upgrade from any legacy layout to the v1.3 unified HOME mod
 
 ## What Changed in 1.3
 
+### Matrix Provider Change: mindroom-nio Now Default
+
+MMRelay v1.3 defaults to **mindroom-nio** (a maintained fork of matrix-nio with
+vodozemac support) as the Matrix SDK provider. The legacy **matrix-nio** provider
+is still supported by manually uninstalling mindroom-nio and installing matrix-nio,
+but is no longer the default.
+
+**Critical upgrade note for encrypted deployments:**
+
+A `pip install --upgrade mmrelay` may leave the old `matrix-nio` package installed
+alongside the new `mindroom-nio` dependency. Having **both** installed disables
+E2EE by design — the relay will report that E2EE is unavailable until one provider
+is removed.
+
+**Before upgrading** an E2EE-enabled deployment, uninstall the old provider:
+
+```bash
+pip uninstall matrix-nio
+```
+
+Or, if using pipx:
+
+```bash
+pipx runpip mmrelay uninstall matrix-nio
+```
+
+After upgrading, run `mmrelay doctor` to verify E2EE readiness.
+See [docs/E2EE.md](E2EE.md) for full provider guidance and troubleshooting.
+
+### Unified HOME Model
+
 MMRelay now uses a single MMRELAY_HOME root for all runtime state:
 
 > **Deprecation Note**: Legacy credential/location fallback is supported until v1.4; warnings will be emitted until you migrate. Plan to migrate before upgrading to v1.4.

--- a/docs/dev/MATRIX_DUAL_LIBRARY_COMPATIBILITY_PLAN.md
+++ b/docs/dev/MATRIX_DUAL_LIBRARY_COMPATIBILITY_PLAN.md
@@ -116,9 +116,12 @@ pip uninstall mindroom-nio
 pip install 'matrix-nio[e2e]==0.25.2'
 ```
 
-**mix matrix-nio and mindroom-nio in the same environment is always a
+**Mixing matrix-nio and mindroom-nio in the same environment is always a
 conflict.** The extra system cannot represent this cleanly; manual replacement
 is the only supported path.
+
+> **Note**: `docs/COMPATIBILITY.md` is the canonical compatibility and
+> deprecation inventory. This plan should stay aligned with it.
 
 ## Hard Warning: conflicting nio namespace
 

--- a/docs/dev/MATRIX_DUAL_LIBRARY_COMPATIBILITY_PLAN.md
+++ b/docs/dev/MATRIX_DUAL_LIBRARY_COMPATIBILITY_PLAN.md
@@ -1,4 +1,4 @@
-# Matrix Dual-Library Compatibility Plan
+# Matrix Dual-Library Compatibility
 
 ## Problem Statement
 
@@ -51,45 +51,59 @@ active provider may be capable of encrypting and decrypting messages.
   and rely on imported `nio` capabilities, not assumptions about ownership.
 - Preserve existing public MMRelay APIs and existing matrix-nio behavior.
 
-## Implementation Phases
+## Compatibility Boundary
 
-### Phase 1: Compatibility Module
+Matrix provider detection belongs in `mmrelay.matrix.compat`. That module owns:
 
-- Add `mmrelay.matrix.compat`.
-- Detect installed provider metadata with `importlib.metadata`.
-- Detect runtime crypto capability by importing optional modules only when
-  needed:
-  - `olm`
-  - `vodozemac`
-  - `nio.crypto`
-  - `nio.store`
-- Export a small immutable capabilities object and cache helpers for normal
-  runtime plus test isolation.
-- Provide a single formatting helper for E2EE-unavailable messages.
+- Provider metadata detection with `importlib.metadata`.
+- Optional crypto capability detection through lazy guarded imports:
+  `olm`, `vodozemac`, `nio.crypto`, and `nio.store`.
+- A small immutable capabilities object for runtime decisions, diagnostics, and
+  tests.
+- Provider-aware E2EE unavailable messages and install guidance.
+- Cache helpers so normal runtime checks are stable and tests can isolate
+  capability scenarios.
 
-### Phase 2: E2EE Detection Refactor
+Runtime code should consume this compatibility boundary instead of checking
+`olm`, `vodozemac`, `nio.crypto`, or package metadata directly.
 
-- Replace direct `olm` checks in `mmrelay.e2ee_utils` with
-  `detect_matrix_capabilities()`.
-- Keep status shape stable for callers.
-- Add provider-specific issue text.
+## E2EE Readiness Contract
 
-### Phase 3: Auth and Client Setup Updates
+E2EE readiness requires a usable crypto backend and a usable store:
 
-- Replace direct `olm` checks in `mmrelay.matrix.auth._configure_e2ee`.
-- Keep store path resolution and client construction unchanged.
-- Ensure logs report the detected provider/backend and correct install hint.
+- Legacy upstream mode: `python-olm`, `nio.crypto.OlmDevice`, and
+  `nio.store.SqliteStore`.
+- Mindroom mode: `vodozemac`, `nio.crypto.ENCRYPTION_ENABLED is True`, and
+  `nio.store.SqliteStore`.
 
-### Phase 4: Packaging Extras Cleanup
+The public E2EE status shape remains stable for callers. User-facing issues and
+fix instructions should be provider-aware:
 
-- Decide whether MMRelay keeps `matrix-nio` as the default dependency or moves
-  Matrix providers behind explicit extras.
-- Avoid extras that install both namespace owners into the same environment.
-- Document replacement install commands for users testing `mindroom-nio`.
+- `matrix-nio` missing crypto should mention `python-olm`,
+  `matrix-nio[e2e]`, or `mmrelay[e2e]`.
+- `mindroom-nio` missing crypto should mention `vodozemac` and
+  `mindroom-nio[e2e]`.
+- If both known providers are installed, the diagnostic should tell the user to
+  uninstall one `nio` namespace owner before enabling E2EE.
 
-### Phase 5: Runtime API Audit
+## Packaging Contract
 
-Audit all direct calls and imports against both providers:
+MMRelay keeps `matrix-nio` as the default Matrix provider. The `mmrelay[e2e]`
+extra remains upstream-compatible and installs `matrix-nio[e2e]`.
+
+Mindroom extras are explicit replacement-provider install targets:
+
+- `mindroom`
+- `mindroom-e2e`
+
+These extras must not be presented as safe to install alongside the default
+provider. User documentation and diagnostics should say that mindroom users must
+replace `matrix-nio` in their environment because both distributions provide
+the `nio` namespace.
+
+## Runtime API Surface
+
+The compatibility contract covers all MMRelay calls and imports against `nio`:
 
 - `AsyncClientConfig`
 - `AsyncClient`
@@ -108,11 +122,16 @@ Audit all direct calls and imports against both providers:
 Fragile imports, such as alternate `InviteMemberEvent` locations, should be
 centralized only if they become a recurring compatibility surface.
 
-### Phase 6: Tests and Documentation
+## Test Expectations
 
-- Add focused tests for capability detection across both provider families.
-- Add E2EE status and auth setup tests for correct install guidance.
-- Add durable docs modeled after the BLE dual-library compatibility contract.
+- Capability tests should patch internals of `mmrelay.matrix.compat` only.
+- Runtime E2EE tests should patch the compatibility boundary, such as
+  `mmrelay.matrix.auth.get_matrix_capabilities` or
+  `mmrelay.e2ee_utils.get_matrix_capabilities`.
+- Tests should not pretend to simulate missing crypto by patching old internal
+  import paths that no longer control E2EE readiness.
+- Coverage should include both provider families, missing crypto extras,
+  provider-aware messages, and the dual-provider namespace conflict.
 
 ## Risks
 
@@ -121,9 +140,8 @@ centralized only if they become a recurring compatibility surface.
   this case.
 - `matrix-nio` and `mindroom-nio` may both expose legacy names such as
   `OlmDevice` even when backed by different crypto libraries.
-- Some tests currently patch old import locations. Tests should move toward
-  patching the compatibility boundary instead of internal import mechanics.
-- Packaging changes can break existing install workflows if done too early.
+- Packaging changes can break existing install workflows if extras imply that
+  both namespace owners can coexist.
 
 ## Validation Checklist
 
@@ -137,10 +155,5 @@ centralized only if they become a recurring compatibility surface.
 
 ## Open Questions
 
-- Should MMRelay retain `matrix-nio` as the default install and make
-  `mindroom-nio` an explicit replacement extra, or should both providers move
-  behind extras?
-- Should `mmrelay[e2e]` continue to mean upstream `matrix-nio[e2e]`, with a
-  separate `mindroom-e2e` extra for the fork?
 - What exact `mindroom-nio` version should be pinned once the fork publishes a
   stable release for MMRelay consumption?

--- a/docs/dev/MATRIX_DUAL_LIBRARY_COMPATIBILITY_PLAN.md
+++ b/docs/dev/MATRIX_DUAL_LIBRARY_COMPATIBILITY_PLAN.md
@@ -1,0 +1,146 @@
+# Matrix Dual-Library Compatibility Plan
+
+## Problem Statement
+
+MMRelay imports the `nio` namespace for Matrix support. Historically that
+namespace came from upstream `matrix-nio`. The project now needs to support the
+`mindroom-nio` fork as an alternate provider without assuming the two
+distributions can coexist in one Python environment.
+
+Both providers expose the same import namespace, so runtime code must detect
+capabilities from the imported `nio` package and its optional crypto backend.
+Provider metadata is useful for diagnostics and install guidance, but it should
+not drive behavior when a direct capability check is available.
+
+## Current Failure Mode
+
+With `matrix-nio` replaced by `mindroom-nio`, MMRelay can start and sync, but
+E2EE setup is incorrectly disabled because the existing checks hard-require the
+legacy `olm` module. `mindroom-nio` uses `vodozemac` and reports encryption
+support through `nio.crypto.ENCRYPTION_ENABLED`, so an `olm` import failure does
+not mean Matrix E2EE is unavailable.
+
+The visible result is that encrypted rooms are treated as blocked even when the
+active provider may be capable of encrypting and decrypting messages.
+
+## Supported Provider Matrix
+
+| Provider namespace owner | Crypto extra state                                                                  | Expected MMRelay mode                                                                                 |
+| ------------------------ | ----------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------- |
+| `matrix-nio`             | no `python-olm` / no usable store                                                   | Unencrypted Matrix only; encrypted room sends blocked with `matrix-nio[e2e]` / `python-olm` guidance  |
+| `matrix-nio`             | `python-olm`, `nio.crypto.OlmDevice`, and `nio.store.SqliteStore` available         | E2EE enabled when configured and credentials exist                                                    |
+| `mindroom-nio`           | no `vodozemac` / `nio.crypto.ENCRYPTION_ENABLED` false                              | Unencrypted Matrix only; encrypted room sends blocked with `mindroom-nio[e2e]` / `vodozemac` guidance |
+| `mindroom-nio`           | `vodozemac`, `nio.crypto.ENCRYPTION_ENABLED`, and `nio.store.SqliteStore` available | E2EE enabled when configured and credentials exist                                                    |
+| unknown `nio` provider   | Matrix APIs import, crypto capability unclear                                       | Prefer safe unencrypted behavior and include detected diagnostics in guidance                         |
+
+## Compatibility Principles
+
+- Keep compatibility code inside `mmrelay.matrix`, starting with
+  `src/mmrelay/matrix/compat.py`.
+- Prefer capability detection over provider or version branching.
+- Keep imports lazy and guarded so missing E2EE extras do not break normal
+  unencrypted operation.
+- Avoid broad exception swallowing. Missing optional modules should be handled
+  as optional capability failures; unexpected runtime errors should remain
+  visible.
+- User-facing install messages must name the relevant backend for the active
+  provider: `python-olm` for upstream legacy E2EE and `vodozemac` for
+  `mindroom-nio`.
+- Treat `matrix-nio` and `mindroom-nio` as mutually exclusive namespace owners
+  in normal installs. If both distributions are installed, report that clearly
+  and rely on imported `nio` capabilities, not assumptions about ownership.
+- Preserve existing public MMRelay APIs and existing matrix-nio behavior.
+
+## Implementation Phases
+
+### Phase 1: Compatibility Module
+
+- Add `mmrelay.matrix.compat`.
+- Detect installed provider metadata with `importlib.metadata`.
+- Detect runtime crypto capability by importing optional modules only when
+  needed:
+  - `olm`
+  - `vodozemac`
+  - `nio.crypto`
+  - `nio.store`
+- Export a small immutable capabilities object and cache helpers for normal
+  runtime plus test isolation.
+- Provide a single formatting helper for E2EE-unavailable messages.
+
+### Phase 2: E2EE Detection Refactor
+
+- Replace direct `olm` checks in `mmrelay.e2ee_utils` with
+  `detect_matrix_capabilities()`.
+- Keep status shape stable for callers.
+- Add provider-specific issue text.
+
+### Phase 3: Auth and Client Setup Updates
+
+- Replace direct `olm` checks in `mmrelay.matrix.auth._configure_e2ee`.
+- Keep store path resolution and client construction unchanged.
+- Ensure logs report the detected provider/backend and correct install hint.
+
+### Phase 4: Packaging Extras Cleanup
+
+- Decide whether MMRelay keeps `matrix-nio` as the default dependency or moves
+  Matrix providers behind explicit extras.
+- Avoid extras that install both namespace owners into the same environment.
+- Document replacement install commands for users testing `mindroom-nio`.
+
+### Phase 5: Runtime API Audit
+
+Audit all direct calls and imports against both providers:
+
+- `AsyncClientConfig`
+- `AsyncClient`
+- `restore_login`
+- `whoami`
+- `sync`
+- `sync_forever`
+- `stop_sync_forever`
+- `keys_upload`
+- `room_send`
+- `upload`
+- `get_displayname`
+- `room_resolve_alias`
+- event classes used by MMRelay, including invite and encrypted-event classes
+
+Fragile imports, such as alternate `InviteMemberEvent` locations, should be
+centralized only if they become a recurring compatibility surface.
+
+### Phase 6: Tests and Documentation
+
+- Add focused tests for capability detection across both provider families.
+- Add E2EE status and auth setup tests for correct install guidance.
+- Add durable docs modeled after the BLE dual-library compatibility contract.
+
+## Risks
+
+- Both provider distributions can be installed at once while only one owns the
+  importable `nio` namespace on disk. Detection must avoid false certainty in
+  this case.
+- `matrix-nio` and `mindroom-nio` may both expose legacy names such as
+  `OlmDevice` even when backed by different crypto libraries.
+- Some tests currently patch old import locations. Tests should move toward
+  patching the compatibility boundary instead of internal import mechanics.
+- Packaging changes can break existing install workflows if done too early.
+
+## Validation Checklist
+
+- `matrix-nio` without E2EE extras reports missing `python-olm`.
+- `matrix-nio` with E2EE extras remains ready.
+- `mindroom-nio` without E2EE extras reports missing `vodozemac`.
+- `mindroom-nio` with E2EE extras reports ready.
+- Encrypted-room send blocking uses the unified E2EE status.
+- Windows unsupported handling remains unchanged.
+- Normal unencrypted Matrix operation does not import hard crypto dependencies.
+
+## Open Questions
+
+- Should MMRelay retain `matrix-nio` as the default install and make
+  `mindroom-nio` an explicit replacement extra, or should both providers move
+  behind extras?
+- Should `mmrelay[e2e]` continue to mean upstream `matrix-nio[e2e]`, with a
+  separate `mindroom-e2e` extra for the fork?
+- What exact `mindroom-nio` version should be pinned once the fork publishes a
+  stable release for MMRelay consumption?

--- a/docs/dev/MATRIX_DUAL_LIBRARY_COMPATIBILITY_PLAN.md
+++ b/docs/dev/MATRIX_DUAL_LIBRARY_COMPATIBILITY_PLAN.md
@@ -1,27 +1,22 @@
 # Matrix Dual-Library Compatibility
 
+## Default Provider: mindroom-nio
+
+**mindroom-nio is now the default Matrix provider.** It replaces upstream
+`matrix-nio` as the base dependency. `matrix-nio` remains supported as a
+legacy option via explicit extras.
+
 ## Problem Statement
 
 MMRelay imports the `nio` namespace for Matrix support. Historically that
-namespace came from upstream `matrix-nio`. The project now needs to support the
-`mindroom-nio` fork as an alternate provider without assuming the two
+namespace came from upstream `matrix-nio`. The project now uses the
+`mindroom-nio` fork as the default provider without assuming the two
 distributions can coexist in one Python environment.
 
 Both providers expose the same import namespace, so runtime code must detect
 capabilities from the imported `nio` package and its optional crypto backend.
 Provider metadata is useful for diagnostics and install guidance, but it should
 not drive behavior when a direct capability check is available.
-
-## Current Failure Mode
-
-With `matrix-nio` replaced by `mindroom-nio`, MMRelay can start and sync, but
-E2EE setup is incorrectly disabled because the existing checks hard-require the
-legacy `olm` module. `mindroom-nio` uses `vodozemac` and reports encryption
-support through `nio.crypto.ENCRYPTION_ENABLED`, so an `olm` import failure does
-not mean Matrix E2EE is unavailable.
-
-The visible result is that encrypted rooms are treated as blocked even when the
-active provider may be capable of encrypting and decrypting messages.
 
 ## Supported Provider Matrix
 
@@ -47,8 +42,9 @@ active provider may be capable of encrypting and decrypting messages.
   provider: `python-olm` for upstream legacy E2EE and `vodozemac` for
   `mindroom-nio`.
 - Treat `matrix-nio` and `mindroom-nio` as mutually exclusive namespace owners
-  in normal installs. If both distributions are installed, report that clearly
-  and rely on imported `nio` capabilities, not assumptions about ownership.
+  in normal installs. If both distributions are installed, report that clearly,
+  disable E2EE, and do not rely on imported `nio` capabilities to enable
+  encryption.
 - Preserve existing public MMRelay APIs and existing matrix-nio behavior.
 
 ## Compatibility Boundary
@@ -80,7 +76,7 @@ The public E2EE status shape remains stable for callers. User-facing issues and
 fix instructions should be provider-aware:
 
 - `matrix-nio` missing crypto should mention `python-olm`,
-  `matrix-nio[e2e]`, or `mmrelay[e2e]`.
+  `matrix-nio[e2e]`, or `mmrelay[matrix-nio-e2e]`.
 - `mindroom-nio` missing crypto should mention `vodozemac` and
   `mindroom-nio[e2e]`.
 - If both known providers are installed, the diagnostic should tell the user to
@@ -88,18 +84,56 @@ fix instructions should be provider-aware:
 
 ## Packaging Contract
 
-MMRelay keeps `matrix-nio` as the default Matrix provider. The `mmrelay[e2e]`
-extra remains upstream-compatible and installs `matrix-nio[e2e]`.
+**mindroom-nio is the default Matrix provider.** The base `mmrelay` install
+brings in `mindroom-nio`. The `mmrelay[e2e]` extra installs
+`mindroom-nio[e2e]`.
 
-Mindroom extras are explicit replacement-provider install targets:
+`matrix-nio` is legacy-supported via explicit extras that are NOT installed by
+default:
 
-- `mindroom`
-- `mindroom-e2e`
+- `mmrelay[matrix-nio]` — installs `matrix-nio` alongside mindroom-nio
+  (conflict; not recommended as a standalone install target)
+- `mmrelay[matrix-nio-e2e]` — same conflict issue
 
-These extras must not be presented as safe to install alongside the default
-provider. User documentation and diagnostics should say that mindroom users must
-replace `matrix-nio` in their environment because both distributions provide
-the `nio` namespace.
+**matrix-nio users should use a controlled replacement workflow** rather than
+relying on extras that would install both providers:
+
+```bash
+# Default install (mindroom-nio, no E2EE)
+pip install mmrelay
+
+# Default E2EE install (mindroom-nio with vodozemac)
+pip install 'mmrelay[e2e]'
+
+# Legacy matrix-nio (manual replacement)
+pip install mmrelay
+pip uninstall mindroom-nio
+pip install 'matrix-nio==0.25.2'
+
+# Legacy matrix-nio with E2EE (manual replacement)
+pip install mmrelay
+pip uninstall mindroom-nio
+pip install 'matrix-nio[e2e]==0.25.2'
+```
+
+Mindroom extras are kept as explicit aliases:
+
+- `mindroom` — same as base dependency
+- `mindroom-e2e` — same as `e2e`
+
+**No extra installs both providers together.** Mixing matrix-nio and
+mindroom-nio in the same environment is always a conflict.
+
+## Hard Warning: conflicting nio namespace
+
+`matrix-nio` and `mindroom-nio` both own the `nio` import namespace. They
+**MUST NOT** be installed in the same Python environment. If both are present:
+
+1. `both_known_providers_installed` is set to `True`.
+2. `encryption_available` is forced to `False`.
+3. E2EE is blocked regardless of what each provider individually supports.
+4. A clear conflict diagnostic is emitted.
+5. The user is told to uninstall one provider.
 
 ## Runtime API Surface
 
@@ -145,15 +179,22 @@ centralized only if they become a recurring compatibility surface.
 
 ## Validation Checklist
 
-- `matrix-nio` without E2EE extras reports missing `python-olm`.
-- `matrix-nio` with E2EE extras remains ready.
+### For mindroom-nio (default provider)
+
 - `mindroom-nio` without E2EE extras reports missing `vodozemac`.
-- `mindroom-nio` with E2EE extras reports ready.
+- `mindroom-nio` with `mindroom-nio[e2e]` / `vodozemac` reports E2EE ready.
+- `mmrelay[e2e]` installs `mindroom-nio[e2e]`.
+
+### For matrix-nio (legacy provider)
+
+- `matrix-nio` without E2EE extras reports missing `python-olm`.
+- `matrix-nio` with `matrix-nio[e2e]` / `python-olm` reports E2EE ready.
+- Custom install workflow: `pip install mmrelay` → `pip uninstall mindroom-nio` → `pip install 'matrix-nio[e2e]==0.25.2'`.
+
+### Cross-cutting
+
 - Encrypted-room send blocking uses the unified E2EE status.
 - Windows unsupported handling remains unchanged.
 - Normal unencrypted Matrix operation does not import hard crypto dependencies.
-
-## Open Questions
-
-- What exact `mindroom-nio` version should be pinned once the fork publishes a
-  stable release for MMRelay consumption?
+- If both providers are detected, encryption is disabled with a conflict diagnostic.
+- No extra installs both providers.

--- a/docs/dev/MATRIX_DUAL_LIBRARY_COMPATIBILITY_PLAN.md
+++ b/docs/dev/MATRIX_DUAL_LIBRARY_COMPATIBILITY_PLAN.md
@@ -3,8 +3,14 @@
 ## Default Provider: mindroom-nio
 
 **mindroom-nio is now the default Matrix provider.** It replaces upstream
-`matrix-nio` as the base dependency. `matrix-nio` remains supported as a
-legacy option via explicit extras.
+`matrix-nio` as the base dependency. The `mmrelay[e2e]` extra installs
+`mindroom-nio[e2e]` (vodozemac backend).
+
+`matrix-nio` remains legacy-supported **only through a controlled manual
+replacement workflow**. There are no `mmrelay[matrix-nio]` extras because
+extras add dependencies on top of the base `mindroom-nio`; they cannot
+remove it. Installing both `matrix-nio` and `mindroom-nio` in the same
+environment is always a conflict.
 
 ## Problem Statement
 
@@ -75,8 +81,8 @@ E2EE readiness requires a usable crypto backend and a usable store:
 The public E2EE status shape remains stable for callers. User-facing issues and
 fix instructions should be provider-aware:
 
-- `matrix-nio` missing crypto should mention `python-olm`,
-  `matrix-nio[e2e]`, or `mmrelay[matrix-nio-e2e]`.
+- `matrix-nio` missing crypto should mention `python-olm` and
+  `matrix-nio[e2e]`.
 - `mindroom-nio` missing crypto should mention `vodozemac` and
   `mindroom-nio[e2e]`.
 - If both known providers are installed, the diagnostic should tell the user to
@@ -88,15 +94,9 @@ fix instructions should be provider-aware:
 brings in `mindroom-nio`. The `mmrelay[e2e]` extra installs
 `mindroom-nio[e2e]`.
 
-`matrix-nio` is legacy-supported via explicit extras that are NOT installed by
-default:
-
-- `mmrelay[matrix-nio]` — installs `matrix-nio` alongside mindroom-nio
-  (conflict; not recommended as a standalone install target)
-- `mmrelay[matrix-nio-e2e]` — same conflict issue
-
-**matrix-nio users should use a controlled replacement workflow** rather than
-relying on extras that would install both providers:
+**matrix-nio is legacy-supported through manual replacement only.** There are
+no `mmrelay[matrix-nio]` extras because extras add to base dependencies and
+cannot remove them. The recommended workflow:
 
 ```bash
 # Default install (mindroom-nio, no E2EE)
@@ -116,13 +116,9 @@ pip uninstall mindroom-nio
 pip install 'matrix-nio[e2e]==0.25.2'
 ```
 
-Mindroom extras are kept as explicit aliases:
-
-- `mindroom` — same as base dependency
-- `mindroom-e2e` — same as `e2e`
-
-**No extra installs both providers together.** Mixing matrix-nio and
-mindroom-nio in the same environment is always a conflict.
+**mix matrix-nio and mindroom-nio in the same environment is always a
+conflict.** The extra system cannot represent this cleanly; manual replacement
+is the only supported path.
 
 ## Hard Warning: conflicting nio namespace
 
@@ -185,7 +181,7 @@ centralized only if they become a recurring compatibility surface.
 - `mindroom-nio` with `mindroom-nio[e2e]` / `vodozemac` reports E2EE ready.
 - `mmrelay[e2e]` installs `mindroom-nio[e2e]`.
 
-### For matrix-nio (legacy provider)
+### For matrix-nio (legacy provider, manual replacement only)
 
 - `matrix-nio` without E2EE extras reports missing `python-olm`.
 - `matrix-nio` with `matrix-nio[e2e]` / `python-olm` reports E2EE ready.
@@ -196,5 +192,6 @@ centralized only if they become a recurring compatibility surface.
 - Encrypted-room send blocking uses the unified E2EE status.
 - Windows unsupported handling remains unchanged.
 - Normal unencrypted Matrix operation does not import hard crypto dependencies.
+- The CLI delegates to `get_matrix_capabilities()` instead of hardcoding `olm` imports.
 - If both providers are detected, encryption is disabled with a conflict diagnostic.
 - No extra installs both providers.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ dependencies = [
   "mtjk==2.7.8.post3",
   "Pillow==12.2.0",
   "aiohttp==3.13.5",
-  "matrix-nio==0.25.2",
+  "mindroom-nio==0.25.2",
   "matplotlib==3.10.9",
   "requests==2.33.1",
   "markdown==3.10.2",
@@ -40,7 +40,9 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-e2e = ["matrix-nio[e2e]==0.25.2"]
+e2e = ["mindroom-nio[e2e]==0.25.2"]
+matrix-nio = ["matrix-nio==0.25.2"]
+matrix-nio-e2e = ["matrix-nio[e2e]==0.25.2"]
 mindroom = ["mindroom-nio==0.25.2"]
 mindroom-e2e = ["mindroom-nio[e2e]==0.25.2"]
 test = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,9 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-e2e = ["mindroom-nio[e2e]"]
+e2e = ["matrix-nio[e2e]==0.25.2"]
+mindroom = ["mindroom-nio==0.25.2"]
+mindroom-e2e = ["mindroom-nio[e2e]==0.25.2"]
 test = [
   "coverage==7.13.5",
   "pytest==9.0.3",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-e2e = ["mindroom-nio[e2e]==0.25.2-mindroom.1"]
+e2e = ["mindroom-nio[e2e]"]
 test = [
   "coverage==7.13.5",
   "pytest==9.0.3",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-e2e = ["matrix-nio[e2e]==0.25.2"]
+e2e = ["mindroom-nio[e2e]==0.25.2-mindroom.1"]
 test = [
   "coverage==7.13.5",
   "pytest==9.0.3",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,10 +41,6 @@ dependencies = [
 
 [project.optional-dependencies]
 e2e = ["mindroom-nio[e2e]==0.25.2"]
-matrix-nio = ["matrix-nio==0.25.2"]
-matrix-nio-e2e = ["matrix-nio[e2e]==0.25.2"]
-mindroom = ["mindroom-nio==0.25.2"]
-mindroom-e2e = ["mindroom-nio[e2e]==0.25.2"]
 test = [
   "coverage==7.13.5",
   "pytest==9.0.3",

--- a/src/mmrelay/cli.py
+++ b/src/mmrelay/cli.py
@@ -535,9 +535,15 @@ def _validate_e2ee_dependencies() -> bool:
         print("✅ E2EE dependencies are installed")
         return True
 
+    from mmrelay.matrix.compat import (
+        format_e2ee_install_command,
+        get_matrix_capabilities,
+    )
+
+    caps = get_matrix_capabilities()
     print("❌ Error: E2EE dependencies not installed")
     print("   End-to-end encryption features require additional dependencies")
-    print("   Install E2EE support: pipx install 'mmrelay[e2e]'")
+    print(f"   Install E2EE support: {format_e2ee_install_command(caps)}")
     return False
 
 
@@ -817,8 +823,14 @@ def _analyze_e2ee_setup(config: dict[str, Any], config_path: str) -> dict[str, A
     # Check dependencies
     analysis["dependencies_available"] = _e2ee_dependencies_available()
     if not analysis["dependencies_available"]:
+        from mmrelay.matrix.compat import (
+            format_e2ee_install_command,
+            get_matrix_capabilities,
+        )
+
+        caps = get_matrix_capabilities()
         analysis["recommendations"].append(
-            "Install E2EE dependencies: pipx install 'mmrelay[e2e]'"
+            f"Install E2EE dependencies: {format_e2ee_install_command(caps)}"
         )
 
     # Check config setting
@@ -1056,8 +1068,14 @@ def _print_environment_summary() -> None:
         if _e2ee_dependencies_available():
             print("   E2EE Support: ✅ Available and installed")
         else:
+            from mmrelay.matrix.compat import (
+                format_e2ee_install_command,
+                get_matrix_capabilities,
+            )
+
+            caps = get_matrix_capabilities()
             print("   E2EE Support: ⚠️  Available but not installed")
-            print("   Install: pipx install 'mmrelay[e2e]'")
+            print(f"   Install: {format_e2ee_install_command(caps)}")
 
 
 def _is_valid_serial_port(port: str) -> bool:
@@ -2095,8 +2113,14 @@ def _print_system_health(paths_info: dict[str, Any]) -> None:
     elif _e2ee_dependencies_available():
         print("   ✅ E2EE crypto libraries available")
     else:
+        from mmrelay.matrix.compat import (
+            format_e2ee_install_command,
+            get_matrix_capabilities,
+        )
+
+        caps = get_matrix_capabilities()
         print("   ❌ Missing E2EE crypto libraries")
-        print("       Install with: pip install mmrelay[e2e]")
+        print(f"       Install with: {format_e2ee_install_command(caps)}")
 
     # Disk Space
     print("\n💾 Disk Space:")

--- a/src/mmrelay/cli.py
+++ b/src/mmrelay/cli.py
@@ -798,7 +798,7 @@ def _analyze_e2ee_setup(config: dict[str, Any], config_path: str) -> dict[str, A
     Returns:
         dict: Analysis summary with the following keys:
           - config_enabled (bool): True if E2EE/encryption is enabled in config.
-          - dependencies_available (bool): True if required E2EE packages are importable.
+          - dependencies_available (bool): True if the active Matrix provider's crypto backend is available.
           - credentials_available (bool): True if a usable credentials.json was found.
           - platform_supported (bool): False when the current platform does not support E2EE (e.g., Windows).
           - overall_status (str): One of "ready", "disabled", "not_supported", "incomplete", or "unknown".

--- a/src/mmrelay/cli.py
+++ b/src/mmrelay/cli.py
@@ -819,19 +819,19 @@ def _analyze_e2ee_setup(config: dict[str, Any], config_path: str) -> dict[str, A
         analysis["recommendations"].append(
             "E2EE is not supported on Windows. Use Linux/macOS for E2EE support."
         )
+    else:
+        # Check dependencies only on supported platforms
+        analysis["dependencies_available"] = _e2ee_dependencies_available()
+        if not analysis["dependencies_available"]:
+            from mmrelay.matrix.compat import (
+                format_e2ee_install_command,
+                get_matrix_capabilities,
+            )
 
-    # Check dependencies
-    analysis["dependencies_available"] = _e2ee_dependencies_available()
-    if not analysis["dependencies_available"]:
-        from mmrelay.matrix.compat import (
-            format_e2ee_install_command,
-            get_matrix_capabilities,
-        )
-
-        caps = get_matrix_capabilities()
-        analysis["recommendations"].append(
-            f"Install E2EE dependencies: {format_e2ee_install_command(caps)}"
-        )
+            caps = get_matrix_capabilities()
+            analysis["recommendations"].append(
+                f"Install E2EE dependencies: {format_e2ee_install_command(caps)}"
+            )
 
     # Check config setting
     matrix_section = config.get("matrix", {})
@@ -976,7 +976,7 @@ def _print_e2ee_analysis(analysis: dict[str, Any]) -> None:
 
     Parameters:
         analysis (dict[str, Any]): Mapping describing E2EE status with these keys:
-            - dependencies_available (bool): True if required E2EE dependencies (e.g., python-olm) are present.
+            - dependencies_available (bool): True if required E2EE dependencies (e.g., active provider crypto backend) are present.
             - credentials_available (bool): True if a usable credentials.json was found.
             - platform_supported (bool): True if the current platform supports E2EE (Windows is considered unsupported).
             - config_enabled (bool): True if E2EE is enabled in the application's configuration.

--- a/src/mmrelay/cli.py
+++ b/src/mmrelay/cli.py
@@ -501,29 +501,18 @@ def print_version() -> None:
 
 def _e2ee_dependencies_available() -> bool:
     """
-    Check whether required E2EE runtime dependencies are importable.
+    Check whether Matrix E2EE dependencies are available using the compat boundary.
 
-    Checks for the presence of the `olm` package and the `OlmDevice` and `SqliteStore`
-    symbols in the `nio.crypto` and `nio.store` modules respectively.
+    Delegates to the compatibility layer which detects the active Matrix nio
+    provider and its crypto backend (vodozemac for mindroom-nio, python-olm
+    for matrix-nio).
 
     Returns:
-        True if all required dependencies and symbols are importable, False otherwise.
+        True if the active provider's E2EE is ready, False otherwise.
     """
-    try:
-        # import_module raises ImportError on failure; no None checks needed.
-        importlib.import_module("olm")
+    from mmrelay.matrix.compat import get_matrix_capabilities
 
-        nio_crypto = importlib.import_module("nio.crypto")
-        if not hasattr(nio_crypto, "OlmDevice"):
-            raise ImportError("nio.crypto.OlmDevice is unavailable")
-
-        nio_store = importlib.import_module("nio.store")
-        if not hasattr(nio_store, "SqliteStore"):
-            raise ImportError("nio.store.SqliteStore is unavailable")
-
-        return True
-    except ImportError:
-        return False
+    return get_matrix_capabilities().encryption_available
 
 
 def _validate_e2ee_dependencies() -> bool:
@@ -537,7 +526,7 @@ def _validate_e2ee_dependencies() -> bool:
     """
     if sys.platform == WINDOWS_PLATFORM:
         print("❌ Error: E2EE is not supported on Windows")
-        print("   Reason: python-olm library requires native C libraries")
+        print("   Reason: E2EE crypto requires native C libraries")
         print("   Solution: Use Linux or macOS for E2EE support")
         return False
 
@@ -990,9 +979,9 @@ def _print_e2ee_analysis(analysis: dict[str, Any]) -> None:
 
     # Dependencies
     if analysis["dependencies_available"]:
-        print("   ✅ Dependencies: Installed (python-olm available)")
+        print("   ✅ Dependencies: Installed")
     else:
-        print("   ❌ Dependencies: Missing (python-olm not installed)")
+        print("   ❌ Dependencies: Not installed")
 
     # Credentials
     if analysis["credentials_available"]:
@@ -2104,9 +2093,9 @@ def _print_system_health(paths_info: dict[str, Any]) -> None:
     if sys.platform == WINDOWS_PLATFORM:
         print("   ⚠️  Not supported on Windows")
     elif _e2ee_dependencies_available():
-        print("   ✅ python-olm and nio crypto available")
+        print("   ✅ E2EE crypto libraries available")
     else:
-        print("   ❌ Missing python-olm or nio crypto libraries")
+        print("   ❌ Missing E2EE crypto libraries")
         print("       Install with: pip install mmrelay[e2e]")
 
     # Disk Space

--- a/src/mmrelay/e2ee_utils.py
+++ b/src/mmrelay/e2ee_utils.py
@@ -14,7 +14,6 @@ from mmrelay.cli_utils import get_command
 from mmrelay.constants.app import (
     CREDENTIALS_FILENAME,
     MATRIX_DIRNAME,
-    PACKAGE_NAME_E2E,
     WINDOWS_PLATFORM,
 )
 from mmrelay.constants.config import CONFIG_SECTION_MATRIX
@@ -28,8 +27,9 @@ from mmrelay.constants.messages import (
 )
 from mmrelay.log_utils import get_logger
 from mmrelay.matrix.compat import (
-    detect_matrix_capabilities,
+    format_e2ee_install_command,
     format_e2ee_unavailable_message,
+    get_matrix_capabilities,
 )
 from mmrelay.paths import is_deprecation_window_active, resolve_all_paths
 
@@ -91,7 +91,7 @@ def get_e2ee_status(
         logger.debug("E2EE platform check: Windows/msys/cygwin not supported")
 
     # Check dependencies
-    matrix_capabilities = detect_matrix_capabilities()
+    matrix_capabilities = get_matrix_capabilities()
     if matrix_capabilities.encryption_available:
         status["dependencies_installed"] = True
         logger.debug(
@@ -340,11 +340,12 @@ def get_e2ee_warning_messages() -> dict[str, str]:
             "unavailable", "disabled", "incomplete", "missing_deps", "missing_auth",
             and "missing_config".
     """
+    matrix_capabilities = get_matrix_capabilities()
     return {
         "unavailable": f"{MSG_E2EE_WINDOWS_UNSUPPORTED} - messages to encrypted rooms will be blocked",
         "disabled": f"{MSG_E2EE_DISABLED} - messages to encrypted rooms will be blocked",
         "incomplete": f"{_E2EE_INCOMPLETE_STATUS} - messages to encrypted rooms may be blocked",
-        "missing_deps": f"E2EE dependencies not installed - run: pipx install {PACKAGE_NAME_E2E}",
+        "missing_deps": format_e2ee_unavailable_message(matrix_capabilities),
         "missing_auth": f"{MSG_E2EE_NO_AUTH} - run: {get_command('auth_login')}",
         "missing_config": "E2EE not enabled in configuration - add 'e2ee: enabled: true' under matrix section",
     }
@@ -413,7 +414,7 @@ def get_e2ee_fix_instructions(e2ee_status: E2EEStatus) -> List[str]:
     step = 1
     if not e2ee_status["dependencies_installed"]:
         instructions.append(f"{step}. Install E2EE dependencies:")
-        instructions.append(f"   pipx install {PACKAGE_NAME_E2E}")
+        instructions.append(f"   {format_e2ee_install_command()}")
         step += 1
 
     if not e2ee_status["credentials_available"]:

--- a/src/mmrelay/e2ee_utils.py
+++ b/src/mmrelay/e2ee_utils.py
@@ -66,7 +66,7 @@ def get_e2ee_status(
           - available (bool): Platform and dependencies allow E2EE.
           - configured (bool): Authentication/credentials are present.
           - platform_supported (bool): False when running on unsupported platforms (e.g., Windows/msys/cygwin).
-          - dependencies_installed (bool): True if required olm/nio components are importable.
+          - dependencies_installed (bool): True if the active Matrix provider's crypto backend is available.
           - credentials_available (bool): True if a Matrix `credentials.json` file was discovered in searched locations.
           - overall_status (str): One of "ready", "disabled", "unavailable", or "incomplete".
           - issues (List[str]): Human-readable issues that prevent full E2EE readiness.

--- a/src/mmrelay/e2ee_utils.py
+++ b/src/mmrelay/e2ee_utils.py
@@ -15,7 +15,6 @@ from mmrelay.constants.app import (
     CREDENTIALS_FILENAME,
     MATRIX_DIRNAME,
     PACKAGE_NAME_E2E,
-    PYTHON_OLM_PACKAGE,
     WINDOWS_PLATFORM,
 )
 from mmrelay.constants.config import CONFIG_SECTION_MATRIX
@@ -28,11 +27,16 @@ from mmrelay.constants.messages import (
     MSG_E2EE_WINDOWS_UNSUPPORTED_SHORT,
 )
 from mmrelay.log_utils import get_logger
+from mmrelay.matrix.compat import (
+    detect_matrix_capabilities,
+    format_e2ee_unavailable_message,
+)
 from mmrelay.paths import is_deprecation_window_active, resolve_all_paths
 
 logger = get_logger("E2EE")
 
 _E2EE_INCOMPLETE_STATUS = "E2EE setup is incomplete"
+_LEGACY_IMPORT_MODULE_PATCH_TARGET = importlib.import_module
 
 
 class E2EEStatus(TypedDict):
@@ -87,25 +91,29 @@ def get_e2ee_status(
         logger.debug("E2EE platform check: Windows/msys/cygwin not supported")
 
     # Check dependencies
-    try:
-        importlib.import_module("olm")
-
-        nio_crypto = importlib.import_module("nio.crypto")
-        if not hasattr(nio_crypto, "OlmDevice"):
-            raise ImportError("nio.crypto.OlmDevice is unavailable")
-
-        nio_store = importlib.import_module("nio.store")
-        if not hasattr(nio_store, "SqliteStore"):
-            raise ImportError("nio.store.SqliteStore is unavailable")
-
+    matrix_capabilities = detect_matrix_capabilities()
+    if matrix_capabilities.encryption_available:
         status["dependencies_installed"] = True
-        logger.debug("E2EE dependency check: olm and nio components available")
-    except ImportError:
-        status["dependencies_installed"] = False
-        status["issues"].append(
-            f"E2EE dependencies not installed ({PYTHON_OLM_PACKAGE})"
+        logger.debug(
+            "E2EE dependency check: %s crypto available via %s",
+            matrix_capabilities.crypto_backend,
+            matrix_capabilities.provider_name,
         )
-        logger.debug("E2EE dependency check: missing olm or nio components")
+    else:
+        status["dependencies_installed"] = False
+        status["issues"].append(format_e2ee_unavailable_message(matrix_capabilities))
+        logger.debug(
+            "E2EE dependency check failed: provider=%s version=%s backend=%s "
+            "olm=%s vodozemac=%s nio_crypto=%s sqlite_store=%s encryption_enabled=%s",
+            matrix_capabilities.provider_name,
+            matrix_capabilities.provider_version,
+            matrix_capabilities.crypto_backend,
+            matrix_capabilities.olm_available,
+            matrix_capabilities.vodozemac_available,
+            matrix_capabilities.nio_crypto_available,
+            matrix_capabilities.sqlite_store_available,
+            matrix_capabilities.nio_crypto_encryption_enabled,
+        )
 
     # Check configuration
     matrix_section = config.get(CONFIG_SECTION_MATRIX, {})

--- a/src/mmrelay/e2ee_utils.py
+++ b/src/mmrelay/e2ee_utils.py
@@ -5,7 +5,6 @@ This module provides a unified approach to E2EE status detection, warning messag
 formatting across all components of the meshtastic-matrix-relay application.
 """
 
-import importlib
 import os
 import sys
 from typing import Any, Dict, List, Literal, Optional, TypedDict
@@ -36,7 +35,6 @@ from mmrelay.paths import is_deprecation_window_active, resolve_all_paths
 logger = get_logger("E2EE")
 
 _E2EE_INCOMPLETE_STATUS = "E2EE setup is incomplete"
-_LEGACY_IMPORT_MODULE_PATCH_TARGET = importlib.import_module
 
 
 class E2EEStatus(TypedDict):

--- a/src/mmrelay/e2ee_utils.py
+++ b/src/mmrelay/e2ee_utils.py
@@ -88,30 +88,35 @@ def get_e2ee_status(
         status["issues"].append(MSG_E2EE_WINDOWS_UNSUPPORTED)
         logger.debug("E2EE platform check: Windows/msys/cygwin not supported")
 
-    # Check dependencies
-    matrix_capabilities = get_matrix_capabilities()
-    if matrix_capabilities.encryption_available:
-        status["dependencies_installed"] = True
-        logger.debug(
-            "E2EE dependency check: %s crypto available via %s",
-            matrix_capabilities.crypto_backend,
-            matrix_capabilities.provider_name,
-        )
+    # Check dependencies (skip on unsupported platforms — installing deps won't help)
+    if status["platform_supported"]:
+        matrix_capabilities = get_matrix_capabilities()
+        if matrix_capabilities.encryption_available:
+            status["dependencies_installed"] = True
+            logger.debug(
+                "E2EE dependency check: %s crypto available via %s",
+                matrix_capabilities.crypto_backend,
+                matrix_capabilities.provider_name,
+            )
+        else:
+            status["dependencies_installed"] = False
+            status["issues"].append(
+                format_e2ee_unavailable_message(matrix_capabilities)
+            )
+            logger.debug(
+                "E2EE dependency check failed: provider=%s version=%s backend=%s "
+                "olm=%s vodozemac=%s nio_crypto=%s sqlite_store=%s encryption_enabled=%s",
+                matrix_capabilities.provider_name,
+                matrix_capabilities.provider_version,
+                matrix_capabilities.crypto_backend,
+                matrix_capabilities.olm_available,
+                matrix_capabilities.vodozemac_available,
+                matrix_capabilities.nio_crypto_available,
+                matrix_capabilities.sqlite_store_available,
+                matrix_capabilities.nio_crypto_encryption_enabled,
+            )
     else:
         status["dependencies_installed"] = False
-        status["issues"].append(format_e2ee_unavailable_message(matrix_capabilities))
-        logger.debug(
-            "E2EE dependency check failed: provider=%s version=%s backend=%s "
-            "olm=%s vodozemac=%s nio_crypto=%s sqlite_store=%s encryption_enabled=%s",
-            matrix_capabilities.provider_name,
-            matrix_capabilities.provider_version,
-            matrix_capabilities.crypto_backend,
-            matrix_capabilities.olm_available,
-            matrix_capabilities.vodozemac_available,
-            matrix_capabilities.nio_crypto_available,
-            matrix_capabilities.sqlite_store_available,
-            matrix_capabilities.nio_crypto_encryption_enabled,
-        )
 
     # Check configuration
     matrix_section = config.get(CONFIG_SECTION_MATRIX, {})

--- a/src/mmrelay/matrix/auth.py
+++ b/src/mmrelay/matrix/auth.py
@@ -1,11 +1,14 @@
 import asyncio
-import importlib
 import os
 import ssl
 import sys
 from typing import Any, Optional, cast
 
 import mmrelay.matrix_utils as facade
+from mmrelay.matrix.compat import (
+    detect_matrix_capabilities,
+    format_e2ee_unavailable_message,
+)
 
 __all__ = [
     "_configure_e2ee",
@@ -55,102 +58,88 @@ async def _configure_e2ee(
                     "E2EE is not supported on Windows due to library limitations."
                 )
                 facade.logger.error(
-                    "The python-olm library requires native C libraries that are difficult to install on Windows."
+                    "Matrix E2EE crypto backends require native libraries that are difficult to install on Windows."
                 )
                 facade.logger.error(
                     "Please disable E2EE in your configuration or use a Linux/macOS system for E2EE support."
                 )
                 e2ee_enabled = False
             else:
-                try:
-                    importlib.import_module("olm")
+                matrix_capabilities = detect_matrix_capabilities()
+                if not matrix_capabilities.encryption_available:
+                    facade.logger.error("Missing E2EE dependency")
+                    facade.logger.error(
+                        format_e2ee_unavailable_message(matrix_capabilities)
+                    )
+                    facade.logger.error(
+                        "Please reinstall with: pipx install 'mmrelay[e2e]'"
+                    )
+                    facade.logger.warning("E2EE will be disabled for this session.")
+                    e2ee_enabled = False
+                else:
+                    facade.logger.debug(
+                        "E2EE dependencies available: provider=%s version=%s backend=%s",
+                        matrix_capabilities.provider_name,
+                        matrix_capabilities.provider_version,
+                        matrix_capabilities.crypto_backend,
+                    )
+                    facade.logger.info("End-to-End Encryption (E2EE) is enabled")
+
+                if e2ee_enabled:
+                    store_override = None
+                    if isinstance(matrix_section, dict):
+                        encryption_section = matrix_section.get("encryption")
+                        e2ee_section = matrix_section.get("e2ee")
+                        if isinstance(encryption_section, dict):
+                            store_override = encryption_section.get("store_path")
+                        if not store_override and isinstance(e2ee_section, dict):
+                            store_override = e2ee_section.get("store_path")
+
+                    if isinstance(store_override, str) and store_override:
+                        e2ee_store_path = os.path.expanduser(store_override)
+                    else:
+                        e2ee_store_path = str(
+                            await asyncio.to_thread(facade.get_e2ee_store_dir)
+                        )
 
                     try:
-                        nio_crypto = importlib.import_module("nio.crypto")
-                        if not hasattr(nio_crypto, "OlmDevice"):
-                            raise ImportError("nio.crypto.OlmDevice is unavailable")
-
-                        nio_store = importlib.import_module("nio.store")
-                        if not hasattr(nio_store, "SqliteStore"):
-                            raise ImportError("nio.store.SqliteStore is unavailable")
-
-                        facade.logger.debug("All E2EE dependencies are available")
-                    except ImportError:
-                        facade.logger.exception("Missing E2EE dependency")
-                        facade.logger.error(
-                            "Please reinstall with: pipx install 'mmrelay[e2e]'"
+                        await asyncio.to_thread(
+                            os.makedirs, e2ee_store_path, exist_ok=True
                         )
-                        facade.logger.warning("E2EE will be disabled for this session.")
+                    except OSError as e:
+                        facade.logger.error(
+                            "Could not create E2EE store directory %s: %s; disabling E2EE for this session.",
+                            e2ee_store_path,
+                            e,
+                        )
                         e2ee_enabled = False
-                    else:
-                        facade.logger.info("End-to-End Encryption (E2EE) is enabled")
+                        e2ee_store_path = None
 
-                    if e2ee_enabled:
-                        store_override = None
-                        if isinstance(matrix_section, dict):
-                            encryption_section = matrix_section.get("encryption")
-                            e2ee_section = matrix_section.get("e2ee")
-                            if isinstance(encryption_section, dict):
-                                store_override = encryption_section.get("store_path")
-                            if not store_override and isinstance(e2ee_section, dict):
-                                store_override = e2ee_section.get("store_path")
-
-                        if isinstance(store_override, str) and store_override:
-                            e2ee_store_path = os.path.expanduser(store_override)
-                        else:
-                            e2ee_store_path = str(
-                                await asyncio.to_thread(facade.get_e2ee_store_dir)
-                            )
-
-                        try:
-                            await asyncio.to_thread(
-                                os.makedirs, e2ee_store_path, exist_ok=True
-                            )
-                        except OSError as e:
-                            facade.logger.error(
-                                "Could not create E2EE store directory %s: %s; disabling E2EE for this session.",
-                                e2ee_store_path,
-                                e,
-                            )
-                            e2ee_enabled = False
-                            e2ee_store_path = None
-
-                        if e2ee_enabled and e2ee_store_path:
-                            store_exists = await asyncio.to_thread(
-                                os.path.exists, e2ee_store_path
-                            )
-                            store_files = (
-                                await asyncio.to_thread(os.listdir, e2ee_store_path)
-                                if store_exists
-                                else []
-                            )
-                            db_files = [f for f in store_files if f.endswith(".db")]
-                            if db_files:
-                                facade.logger.debug(
-                                    f"Found existing E2EE store files: {', '.join(db_files)}"
-                                )
-                            else:
-                                facade.logger.info(
-                                    "No existing E2EE store files found; this is expected for first-time setup and encryption will initialize on first use."
-                                )
-
+                    if e2ee_enabled and e2ee_store_path:
+                        store_exists = await asyncio.to_thread(
+                            os.path.exists, e2ee_store_path
+                        )
+                        store_files = (
+                            await asyncio.to_thread(os.listdir, e2ee_store_path)
+                            if store_exists
+                            else []
+                        )
+                        db_files = [f for f in store_files if f.endswith(".db")]
+                        if db_files:
                             facade.logger.debug(
-                                f"Using E2EE store path: {e2ee_store_path}"
+                                f"Found existing E2EE store files: {', '.join(db_files)}"
+                            )
+                        else:
+                            facade.logger.info(
+                                "No existing E2EE store files found; this is expected for first-time setup and encryption will initialize on first use."
                             )
 
-                            if not e2ee_device_id:
-                                facade.logger.debug(
-                                    "No device_id in credentials; will retrieve from store/whoami later if available"
-                                )
-                except ImportError:
-                    facade.logger.warning(
-                        "E2EE is enabled in config but python-olm is not installed."
-                    )
-                    facade.logger.warning(
-                        "Install E2EE extras: pip install 'mmrelay[e2e]' "
-                        "(or from source: pip install -e '.[e2e]')."
-                    )
-                    e2ee_enabled = False
+                        facade.logger.debug(f"Using E2EE store path: {e2ee_store_path}")
+
+                        if not e2ee_device_id:
+                            facade.logger.debug(
+                                "No device_id in credentials; will retrieve from store/whoami later if available"
+                            )
     except (KeyError, TypeError) as exc:
         facade.logger.warning(f"Failed to determine E2EE status from config: {exc}")
         facade.logger.debug("E2EE configuration error details", exc_info=True)

--- a/src/mmrelay/matrix/auth.py
+++ b/src/mmrelay/matrix/auth.py
@@ -6,8 +6,9 @@ from typing import Any, Optional, cast
 
 import mmrelay.matrix_utils as facade
 from mmrelay.matrix.compat import (
-    detect_matrix_capabilities,
+    format_e2ee_install_command,
     format_e2ee_unavailable_message,
+    get_matrix_capabilities,
 )
 
 __all__ = [
@@ -65,14 +66,14 @@ async def _configure_e2ee(
                 )
                 e2ee_enabled = False
             else:
-                matrix_capabilities = detect_matrix_capabilities()
+                matrix_capabilities = get_matrix_capabilities()
                 if not matrix_capabilities.encryption_available:
                     facade.logger.error("Missing E2EE dependency")
                     facade.logger.error(
                         format_e2ee_unavailable_message(matrix_capabilities)
                     )
                     facade.logger.error(
-                        "Please reinstall with: pipx install 'mmrelay[e2e]'"
+                        format_e2ee_install_command(matrix_capabilities)
                     )
                     facade.logger.warning("E2EE will be disabled for this session.")
                     e2ee_enabled = False

--- a/src/mmrelay/matrix/auth.py
+++ b/src/mmrelay/matrix/auth.py
@@ -91,10 +91,10 @@ async def _configure_e2ee(
                     if isinstance(matrix_section, dict):
                         encryption_section = matrix_section.get("encryption")
                         e2ee_section = matrix_section.get("e2ee")
-                        if isinstance(encryption_section, dict):
-                            store_override = encryption_section.get("store_path")
-                        if not store_override and isinstance(e2ee_section, dict):
+                        if isinstance(e2ee_section, dict):
                             store_override = e2ee_section.get("store_path")
+                        if not store_override and isinstance(encryption_section, dict):
+                            store_override = encryption_section.get("store_path")
 
                     if isinstance(store_override, str) and store_override:
                         e2ee_store_path = os.path.expanduser(store_override)

--- a/src/mmrelay/matrix/auth.py
+++ b/src/mmrelay/matrix/auth.py
@@ -117,25 +117,36 @@ async def _configure_e2ee(
                         e2ee_store_path = None
 
                     if e2ee_enabled and e2ee_store_path:
-                        store_exists = await asyncio.to_thread(
-                            os.path.exists, e2ee_store_path
-                        )
-                        store_files = (
-                            await asyncio.to_thread(os.listdir, e2ee_store_path)
-                            if store_exists
-                            else []
-                        )
-                        db_files = [f for f in store_files if f.endswith(".db")]
-                        if db_files:
-                            facade.logger.debug(
-                                f"Found existing E2EE store files: {', '.join(db_files)}"
+                        try:
+                            store_exists = await asyncio.to_thread(
+                                os.path.exists, e2ee_store_path
                             )
-                        else:
-                            facade.logger.info(
-                                "No existing E2EE store files found; this is expected for first-time setup and encryption will initialize on first use."
+                            store_files = (
+                                await asyncio.to_thread(os.listdir, e2ee_store_path)
+                                if store_exists
+                                else []
                             )
+                            db_files = [f for f in store_files if f.endswith(".db")]
+                            if db_files:
+                                facade.logger.debug(
+                                    f"Found existing E2EE store files: {', '.join(db_files)}"
+                                )
+                            else:
+                                facade.logger.info(
+                                    "No existing E2EE store files found; this is expected for first-time setup and encryption will initialize on first use."
+                                )
 
-                        facade.logger.debug(f"Using E2EE store path: {e2ee_store_path}")
+                            facade.logger.debug(
+                                f"Using E2EE store path: {e2ee_store_path}"
+                            )
+                        except OSError as exc:
+                            facade.logger.error(
+                                "Could not inspect E2EE store at %s: %s",
+                                e2ee_store_path,
+                                exc,
+                            )
+                            e2ee_enabled = False
+                            e2ee_store_path = None
 
                         if not e2ee_device_id:
                             facade.logger.debug(

--- a/src/mmrelay/matrix/compat.py
+++ b/src/mmrelay/matrix/compat.py
@@ -157,6 +157,32 @@ def detect_matrix_capabilities() -> MatrixLibraryCapabilities:
     if both_installed:
         crypto_backend: CryptoBackend = "unavailable"
         encryption_available = False
+    elif provider_distribution == "mindroom-nio":
+        if vodozemac_ready:
+            crypto_backend = "vodozemac"
+            encryption_available = True
+        elif vodozemac_available or nio_crypto_encryption_enabled is True:
+            crypto_backend = "vodozemac"
+            encryption_available = False
+        elif nio_crypto_available:
+            crypto_backend = "unavailable"
+            encryption_available = False
+        else:
+            crypto_backend = "unknown"
+            encryption_available = False
+    elif provider_distribution == "matrix-nio":
+        if legacy_olm_ready:
+            crypto_backend = "olm"
+            encryption_available = True
+        elif olm_available or nio_crypto_olm_device_available:
+            crypto_backend = "olm"
+            encryption_available = False
+        elif nio_crypto_available:
+            crypto_backend = "unavailable"
+            encryption_available = False
+        else:
+            crypto_backend = "unknown"
+            encryption_available = False
     elif vodozemac_ready:
         crypto_backend = "vodozemac"
         encryption_available = True

--- a/src/mmrelay/matrix/compat.py
+++ b/src/mmrelay/matrix/compat.py
@@ -265,5 +265,9 @@ def format_e2ee_install_command(
             "pip install 'mindroom-nio[e2e]==0.25.2'. Do not install it alongside matrix-nio."
         )
     if detected.provider_distribution == "matrix-nio":
-        return "Install E2EE support: pipx install 'mmrelay[e2e]'"
+        return (
+            "Install matrix-nio E2EE in a controlled replacement environment: "
+            "pip install 'matrix-nio[e2e]==0.25.2'. "
+            "Do not install mmrelay[e2e] (it uses mindroom-nio)."
+        )
     return f"Install the active nio provider's E2EE extra ({detected.recommended_e2ee_extra})."

--- a/src/mmrelay/matrix/compat.py
+++ b/src/mmrelay/matrix/compat.py
@@ -1,0 +1,228 @@
+"""Compatibility detection for Matrix nio providers."""
+
+from __future__ import annotations
+
+import importlib
+from dataclasses import dataclass
+from importlib import metadata
+from typing import Literal
+
+ProviderDistribution = Literal["matrix-nio", "mindroom-nio", "unknown"]
+CryptoBackend = Literal["olm", "vodozemac", "unavailable", "unknown"]
+
+_MATRIX_NIO_DIST = "matrix-nio"
+_MINDROOM_NIO_DIST = "mindroom-nio"
+_UNKNOWN_VERSION = "unknown"
+
+_CAPABILITIES_CACHE: MatrixLibraryCapabilities | None = None
+
+
+@dataclass(frozen=True)
+class MatrixLibraryCapabilities:
+    """Detected Matrix provider and crypto capabilities."""
+
+    provider_name: str
+    provider_version: str
+    provider_distribution: ProviderDistribution
+    crypto_backend: CryptoBackend
+    encryption_available: bool
+    store_available: bool
+    sqlite_store_available: bool
+    olm_available: bool
+    vodozemac_available: bool
+    nio_crypto_available: bool
+    nio_crypto_encryption_enabled: bool | None
+    nio_crypto_olm_device_available: bool
+    recommended_e2ee_extra: str
+    install_hint: str
+    both_known_providers_installed: bool
+    supports_stop_sync_forever: bool
+    supports_thread_receipts: bool
+    supports_authenticated_media: bool
+
+
+def _distribution_version(distribution_name: str) -> str | None:
+    try:
+        return metadata.version(distribution_name)
+    except metadata.PackageNotFoundError:
+        return None
+
+
+def _module_available(module_name: str) -> bool:
+    try:
+        importlib.import_module(module_name)
+    except ImportError:
+        return False
+    return True
+
+
+def _import_optional(module_name: str) -> object | None:
+    try:
+        return importlib.import_module(module_name)
+    except ImportError:
+        return None
+
+
+def _detect_provider() -> tuple[str, str, ProviderDistribution, bool]:
+    matrix_version = _distribution_version(_MATRIX_NIO_DIST)
+    mindroom_version = _distribution_version(_MINDROOM_NIO_DIST)
+    both_installed = matrix_version is not None and mindroom_version is not None
+
+    if mindroom_version is not None and matrix_version is None:
+        return "mindroom-nio", mindroom_version, "mindroom-nio", both_installed
+    if matrix_version is not None and mindroom_version is None:
+        return "matrix-nio", matrix_version, "matrix-nio", both_installed
+    if mindroom_version is not None and matrix_version is not None:
+        return (
+            "multiple nio providers installed",
+            f"matrix-nio={matrix_version}, mindroom-nio={mindroom_version}",
+            "unknown",
+            both_installed,
+        )
+    if _module_available("nio"):
+        return "nio", _UNKNOWN_VERSION, "unknown", both_installed
+    return "unavailable", _UNKNOWN_VERSION, "unknown", both_installed
+
+
+def _e2ee_install_guidance(
+    provider_distribution: ProviderDistribution,
+    crypto_backend: CryptoBackend,
+) -> tuple[str, str]:
+    if provider_distribution == "mindroom-nio" or crypto_backend == "vodozemac":
+        extra = "mindroom-nio[e2e]"
+        return extra, f"install {extra} / vodozemac"
+    if provider_distribution == "matrix-nio" or crypto_backend == "olm":
+        extra = "matrix-nio[e2e]"
+        return extra, f"install {extra} / python-olm"
+    return (
+        "nio provider E2EE extra",
+        "install the active nio provider's E2EE extra; no usable nio crypto backend was detected",
+    )
+
+
+def detect_matrix_capabilities() -> MatrixLibraryCapabilities:
+    """Detect Matrix nio provider and optional E2EE capabilities."""
+
+    provider_name, provider_version, provider_distribution, both_installed = (
+        _detect_provider()
+    )
+
+    olm_available = _module_available("olm")
+    vodozemac_available = _module_available("vodozemac")
+
+    nio_crypto = _import_optional("nio.crypto")
+    nio_store = _import_optional("nio.store")
+    nio_client = _import_optional("nio")
+    nio_api = _import_optional("nio.api")
+
+    nio_crypto_available = nio_crypto is not None
+    nio_crypto_olm_device_available = bool(
+        nio_crypto is not None and hasattr(nio_crypto, "OlmDevice")
+    )
+    encryption_enabled_value = (
+        getattr(nio_crypto, "ENCRYPTION_ENABLED", None)
+        if nio_crypto is not None
+        else None
+    )
+    nio_crypto_encryption_enabled = (
+        encryption_enabled_value is True
+        if encryption_enabled_value is not None
+        else None
+    )
+
+    store_available = nio_store is not None
+    sqlite_store_available = bool(
+        nio_store is not None and hasattr(nio_store, "SqliteStore")
+    )
+
+    legacy_olm_ready = (
+        olm_available and nio_crypto_olm_device_available and sqlite_store_available
+    )
+    vodozemac_ready = (
+        vodozemac_available
+        and nio_crypto_encryption_enabled is True
+        and sqlite_store_available
+    )
+
+    if vodozemac_ready:
+        crypto_backend: CryptoBackend = "vodozemac"
+    elif legacy_olm_ready:
+        crypto_backend = "olm"
+    elif vodozemac_available or nio_crypto_encryption_enabled is True:
+        crypto_backend = "vodozemac"
+    elif olm_available or nio_crypto_olm_device_available:
+        crypto_backend = "olm"
+    elif nio_crypto_available:
+        crypto_backend = "unavailable"
+    else:
+        crypto_backend = "unknown"
+
+    encryption_available = legacy_olm_ready or vodozemac_ready
+    recommended_e2ee_extra, install_hint = _e2ee_install_guidance(
+        provider_distribution, crypto_backend
+    )
+
+    supports_stop_sync_forever = bool(
+        nio_client is not None
+        and hasattr(getattr(nio_client, "AsyncClient", object), "stop_sync_forever")
+    )
+    supports_thread_receipts = bool(
+        nio_api is not None
+        and hasattr(getattr(nio_api, "Api", object), "update_receipt_marker")
+    )
+    supports_authenticated_media = bool(
+        nio_api is not None
+        and "allow_remote"
+        in str(getattr(getattr(nio_api, "Api", object), "download", ""))
+    )
+
+    return MatrixLibraryCapabilities(
+        provider_name=provider_name,
+        provider_version=provider_version,
+        provider_distribution=provider_distribution,
+        crypto_backend=crypto_backend,
+        encryption_available=encryption_available,
+        store_available=store_available,
+        sqlite_store_available=sqlite_store_available,
+        olm_available=olm_available,
+        vodozemac_available=vodozemac_available,
+        nio_crypto_available=nio_crypto_available,
+        nio_crypto_encryption_enabled=nio_crypto_encryption_enabled,
+        nio_crypto_olm_device_available=nio_crypto_olm_device_available,
+        recommended_e2ee_extra=recommended_e2ee_extra,
+        install_hint=install_hint,
+        both_known_providers_installed=both_installed,
+        supports_stop_sync_forever=supports_stop_sync_forever,
+        supports_thread_receipts=supports_thread_receipts,
+        supports_authenticated_media=supports_authenticated_media,
+    )
+
+
+def get_matrix_capabilities() -> MatrixLibraryCapabilities:
+    """Return cached Matrix capabilities for normal runtime checks."""
+
+    global _CAPABILITIES_CACHE
+    if _CAPABILITIES_CACHE is None:
+        _CAPABILITIES_CACHE = detect_matrix_capabilities()
+    return _CAPABILITIES_CACHE
+
+
+def reset_matrix_capabilities_cache() -> None:
+    """Reset cached Matrix capabilities, primarily for tests."""
+
+    global _CAPABILITIES_CACHE
+    _CAPABILITIES_CACHE = None
+
+
+def format_e2ee_unavailable_message(
+    capabilities: MatrixLibraryCapabilities | None = None,
+) -> str:
+    """Return a provider-aware E2EE dependency message."""
+
+    detected = capabilities or get_matrix_capabilities()
+    details = (
+        f"provider={detected.provider_name} "
+        f"version={detected.provider_version} "
+        f"crypto_backend={detected.crypto_backend}"
+    )
+    return f"E2EE dependencies not installed ({detected.install_hint}; {details})"

--- a/src/mmrelay/matrix/compat.py
+++ b/src/mmrelay/matrix/compat.py
@@ -260,10 +260,7 @@ def format_e2ee_install_command(
             "nio namespace and should not be installed together."
         )
     if detected.provider_distribution == "mindroom-nio":
-        return (
-            "Install mindroom E2EE as a replacement provider: "
-            "pip install 'mindroom-nio[e2e]==0.25.2'. Do not install it alongside matrix-nio."
-        )
+        return "pipx install 'mmrelay[e2e]' (installs mindroom-nio[e2e] / vodozemac)"
     if detected.provider_distribution == "matrix-nio":
         return (
             "Install matrix-nio E2EE in a controlled replacement environment: "

--- a/src/mmrelay/matrix/compat.py
+++ b/src/mmrelay/matrix/compat.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import importlib
+import inspect
 from dataclasses import dataclass
 from importlib import metadata
 from typing import Literal
@@ -87,10 +88,19 @@ def _detect_provider() -> tuple[str, str, ProviderDistribution, bool]:
 def _e2ee_install_guidance(
     provider_distribution: ProviderDistribution,
     crypto_backend: CryptoBackend,
+    both_known_providers_installed: bool,
 ) -> tuple[str, str]:
+    if both_known_providers_installed:
+        return (
+            "one nio provider E2EE extra",
+            "matrix-nio and mindroom-nio are both installed; uninstall one nio namespace owner before enabling E2EE",
+        )
     if provider_distribution == "mindroom-nio" or crypto_backend == "vodozemac":
         extra = "mindroom-nio[e2e]"
-        return extra, f"install {extra} / vodozemac"
+        return (
+            extra,
+            f"install {extra} / vodozemac as a replacement provider, not alongside matrix-nio",
+        )
     if provider_distribution == "matrix-nio" or crypto_backend == "olm":
         extra = "matrix-nio[e2e]"
         return extra, f"install {extra} / python-olm"
@@ -159,7 +169,7 @@ def detect_matrix_capabilities() -> MatrixLibraryCapabilities:
 
     encryption_available = legacy_olm_ready or vodozemac_ready
     recommended_e2ee_extra, install_hint = _e2ee_install_guidance(
-        provider_distribution, crypto_backend
+        provider_distribution, crypto_backend, both_installed
     )
 
     supports_stop_sync_forever = bool(
@@ -170,11 +180,14 @@ def detect_matrix_capabilities() -> MatrixLibraryCapabilities:
         nio_api is not None
         and hasattr(getattr(nio_api, "Api", object), "update_receipt_marker")
     )
-    supports_authenticated_media = bool(
-        nio_api is not None
-        and "allow_remote"
-        in str(getattr(getattr(nio_api, "Api", object), "download", ""))
-    )
+    download = getattr(getattr(nio_api, "Api", object), "download", None)
+    try:
+        supports_authenticated_media = bool(
+            download is not None
+            and "allow_remote" in inspect.signature(download).parameters
+        )
+    except (TypeError, ValueError):
+        supports_authenticated_media = False
 
     return MatrixLibraryCapabilities(
         provider_name=provider_name,
@@ -226,3 +239,24 @@ def format_e2ee_unavailable_message(
         f"crypto_backend={detected.crypto_backend}"
     )
     return f"E2EE dependencies not installed ({detected.install_hint}; {details})"
+
+
+def format_e2ee_install_command(
+    capabilities: MatrixLibraryCapabilities | None = None,
+) -> str:
+    """Return actionable install guidance for the detected provider."""
+
+    detected = capabilities or get_matrix_capabilities()
+    if detected.both_known_providers_installed:
+        return (
+            "Uninstall either matrix-nio or mindroom-nio first; both provide the "
+            "nio namespace and should not be installed together."
+        )
+    if detected.provider_distribution == "mindroom-nio":
+        return (
+            "Install mindroom E2EE as a replacement provider: "
+            "pip install 'mindroom-nio[e2e]==0.25.2'. Do not install it alongside matrix-nio."
+        )
+    if detected.provider_distribution == "matrix-nio":
+        return "Install E2EE support: pipx install 'mmrelay[e2e]'"
+    return f"Install the active nio provider's E2EE extra ({detected.recommended_e2ee_extra})."

--- a/src/mmrelay/matrix/compat.py
+++ b/src/mmrelay/matrix/compat.py
@@ -158,7 +158,7 @@ def detect_matrix_capabilities() -> MatrixLibraryCapabilities:
         crypto_backend: CryptoBackend = "unavailable"
         encryption_available = False
     elif vodozemac_ready:
-        crypto_backend: CryptoBackend = "vodozemac"
+        crypto_backend = "vodozemac"
         encryption_available = True
     elif legacy_olm_ready:
         crypto_backend = "olm"

--- a/src/mmrelay/matrix/compat.py
+++ b/src/mmrelay/matrix/compat.py
@@ -110,12 +110,43 @@ def _e2ee_install_guidance(
     )
 
 
+def _build_conflict_capabilities(
+    provider_name: str,
+    provider_version: str,
+) -> MatrixLibraryCapabilities:
+    """Return a deterministic conflict capabilities object when both providers are installed."""
+    extra, hint = _e2ee_install_guidance("unknown", "unavailable", True)
+    return MatrixLibraryCapabilities(
+        provider_name=provider_name,
+        provider_version=provider_version,
+        provider_distribution="unknown",
+        crypto_backend="unavailable",
+        encryption_available=False,
+        store_available=False,
+        sqlite_store_available=False,
+        olm_available=False,
+        vodozemac_available=False,
+        nio_crypto_available=False,
+        nio_crypto_encryption_enabled=None,
+        nio_crypto_olm_device_available=False,
+        recommended_e2ee_extra=extra,
+        install_hint=hint,
+        both_known_providers_installed=True,
+        supports_stop_sync_forever=False,
+        supports_thread_receipts=False,
+        supports_authenticated_media=False,
+    )
+
+
 def detect_matrix_capabilities() -> MatrixLibraryCapabilities:
     """Detect Matrix nio provider and optional E2EE capabilities."""
 
     provider_name, provider_version, provider_distribution, both_installed = (
         _detect_provider()
     )
+
+    if both_installed:
+        return _build_conflict_capabilities(provider_name, provider_version)
 
     olm_available = _module_available("olm")
     vodozemac_available = _module_available("vodozemac")
@@ -154,10 +185,7 @@ def detect_matrix_capabilities() -> MatrixLibraryCapabilities:
         and sqlite_store_available
     )
 
-    if both_installed:
-        crypto_backend: CryptoBackend = "unavailable"
-        encryption_available = False
-    elif provider_distribution == "mindroom-nio":
+    if provider_distribution == "mindroom-nio":
         if vodozemac_ready:
             crypto_backend = "vodozemac"
             encryption_available = True
@@ -290,7 +318,11 @@ def format_e2ee_install_command(
             "nio namespace and should not be installed together."
         )
     if detected.provider_distribution == "mindroom-nio":
-        return "pipx install 'mmrelay[e2e]' (installs mindroom-nio[e2e] / vodozemac)"
+        return (
+            "Install mmrelay[e2e] using the installer appropriate for this environment "
+            "(pipx: pipx install 'mmrelay[e2e]', pip/venv: pip install 'mmrelay[e2e]', "
+            "editable: pip install -e '.[e2e]')"
+        )
     if detected.provider_distribution == "matrix-nio":
         return (
             "Install matrix-nio E2EE in a controlled replacement environment: "

--- a/src/mmrelay/matrix/compat.py
+++ b/src/mmrelay/matrix/compat.py
@@ -154,20 +154,27 @@ def detect_matrix_capabilities() -> MatrixLibraryCapabilities:
         and sqlite_store_available
     )
 
-    if vodozemac_ready:
+    if both_installed:
+        crypto_backend: CryptoBackend = "unavailable"
+        encryption_available = False
+    elif vodozemac_ready:
         crypto_backend: CryptoBackend = "vodozemac"
+        encryption_available = True
     elif legacy_olm_ready:
         crypto_backend = "olm"
+        encryption_available = True
     elif vodozemac_available or nio_crypto_encryption_enabled is True:
         crypto_backend = "vodozemac"
+        encryption_available = False
     elif olm_available or nio_crypto_olm_device_available:
         crypto_backend = "olm"
+        encryption_available = False
     elif nio_crypto_available:
         crypto_backend = "unavailable"
+        encryption_available = False
     else:
         crypto_backend = "unknown"
-
-    encryption_available = legacy_olm_ready or vodozemac_ready
+        encryption_available = False
     recommended_e2ee_extra, install_hint = _e2ee_install_guidance(
         provider_distribution, crypto_backend, both_installed
     )

--- a/src/mmrelay/matrix/compat.py
+++ b/src/mmrelay/matrix/compat.py
@@ -185,6 +185,9 @@ def detect_matrix_capabilities() -> MatrixLibraryCapabilities:
         and sqlite_store_available
     )
 
+    crypto_backend: CryptoBackend = "unknown"
+    encryption_available = False
+
     if provider_distribution == "mindroom-nio":
         if vodozemac_ready:
             crypto_backend = "vodozemac"

--- a/src/mmrelay/matrix/compat.py
+++ b/src/mmrelay/matrix/compat.py
@@ -187,7 +187,11 @@ def detect_matrix_capabilities() -> MatrixLibraryCapabilities:
         nio_api is not None
         and hasattr(getattr(nio_api, "Api", object), "update_receipt_marker")
     )
-    download = getattr(getattr(nio_api, "Api", object), "download", None)
+    download = (
+        getattr(getattr(nio_api, "Api", object), "download", None)
+        if nio_api is not None
+        else None
+    )
     try:
         supports_authenticated_media = bool(
             download is not None

--- a/src/mmrelay/matrix/compat.py
+++ b/src/mmrelay/matrix/compat.py
@@ -303,6 +303,11 @@ def format_e2ee_unavailable_message(
         f"version={detected.provider_version} "
         f"crypto_backend={detected.crypto_backend}"
     )
+    if detected.both_known_providers_installed:
+        return (
+            "E2EE is unavailable because matrix-nio and mindroom-nio are both "
+            f"installed ({details})"
+        )
     return f"E2EE dependencies not installed ({detected.install_hint}; {details})"
 
 
@@ -324,9 +329,14 @@ def format_e2ee_install_command(
             "editable: pip install -e '.[e2e]')"
         )
     if detected.provider_distribution == "matrix-nio":
+        version_pin = (
+            f"=={detected.provider_version}"
+            if detected.provider_version != _UNKNOWN_VERSION
+            else ""
+        )
         return (
             "Install matrix-nio E2EE in a controlled replacement environment: "
-            "pip install 'matrix-nio[e2e]==0.25.2'. "
+            f"pip install 'matrix-nio[e2e]{version_pin}'. "
             "Do not install mmrelay[e2e] (it uses mindroom-nio)."
         )
     return f"Install the active nio provider's E2EE extra ({detected.recommended_e2ee_extra})."

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -610,7 +610,11 @@ class TestCLIValidationFunctions(unittest.TestCase):
         with (
             patch(
                 "mmrelay.matrix.compat.get_matrix_capabilities",
-                return_value=SimpleNamespace(encryption_available=False),
+                return_value=SimpleNamespace(
+                    encryption_available=False,
+                    both_known_providers_installed=False,
+                    provider_distribution="mindroom-nio",
+                ),
             ),
             patch("mmrelay.cli.print"),
         ):
@@ -2960,7 +2964,11 @@ class TestPrintEnvironmentSummary(unittest.TestCase):
         """Test environment summary on Linux without E2EE dependencies."""
         with patch(
             "mmrelay.matrix.compat.get_matrix_capabilities",
-            return_value=SimpleNamespace(encryption_available=False),
+            return_value=SimpleNamespace(
+                encryption_available=False,
+                both_known_providers_installed=False,
+                provider_distribution="mindroom-nio",
+            ),
         ):
             from mmrelay.cli import _print_environment_summary
 
@@ -2971,10 +2979,6 @@ class TestPrintEnvironmentSummary(unittest.TestCase):
         mock_print.assert_any_call("   Platform: linux")
         mock_print.assert_any_call("   Python: 3.12.3")
         mock_print.assert_any_call("   E2EE Support: ⚠️  Available but not installed")
-        mock_print.assert_any_call("   Install: pipx install 'mmrelay[e2e]'")
-        mock_print.assert_any_call("   Python: 3.12.3")
-        mock_print.assert_any_call("   E2EE Support: ⚠️  Available but not installed")
-        mock_print.assert_any_call("   Install: pipx install 'mmrelay[e2e]'")
 
     @patch("sys.platform", "win32")
     @patch(
@@ -3398,7 +3402,11 @@ class TestAnalyzeE2eeSetup(unittest.TestCase):
 
         with patch(
             "mmrelay.matrix.compat.get_matrix_capabilities",
-            return_value=SimpleNamespace(encryption_available=False),
+            return_value=SimpleNamespace(
+                encryption_available=False,
+                both_known_providers_installed=False,
+                provider_distribution="mindroom-nio",
+            ),
         ):
             from mmrelay.cli import _analyze_e2ee_setup
 
@@ -3411,9 +3419,8 @@ class TestAnalyzeE2eeSetup(unittest.TestCase):
         self.assertFalse(result["dependencies_available"])
         self.assertFalse(result["credentials_available"])
         self.assertEqual(result["overall_status"], "incomplete")
-        self.assertIn(
-            "Install E2EE dependencies: pipx install 'mmrelay[e2e]'",
-            result["recommendations"],
+        self.assertTrue(
+            any("Install E2EE dependencies:" in r for r in result["recommendations"])
         )
         self.assertIn(
             "Set up Matrix authentication: mmrelay auth login",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1150,6 +1150,28 @@ class TestE2EEPrintFunctions(unittest.TestCase):
                 any("⚠️  E2EE is disabled in configuration" in call for call in calls)
             )
 
+    def test_print_e2ee_analysis_deps_not_installed(self):
+        """Test _print_e2ee_analysis with dependencies_available=False."""
+        from mmrelay.cli import _print_e2ee_analysis
+
+        analysis = {
+            "dependencies_available": False,
+            "credentials_available": False,
+            "platform_supported": True,
+            "config_enabled": False,
+            "overall_status": "incomplete",
+            "recommendations": ["Install E2EE dependencies"],
+        }
+
+        with patch("mmrelay.cli.print") as mock_print:
+            _print_e2ee_analysis(analysis)
+            mock_print.assert_called()
+            calls = [call.args[0] for call in mock_print.call_args_list]
+            self.assertTrue(
+                any("Dependencies: Not installed" in call for call in calls)
+            )
+            self.assertTrue(any("Authentication: Missing" in call for call in calls))
+
     @patch("sys.platform", "linux")
     def test_print_environment_summary_linux(self):
         """Test _print_environment_summary on Linux."""

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3042,12 +3042,15 @@ class TestProviderAwareE2EEGuidance(unittest.TestCase):
         caps = self._make_caps(
             provider_distribution="mindroom-nio",
             encryption_available=False,
+            both_known_providers_installed=False,
         )
         with patch("mmrelay.matrix.compat.get_matrix_capabilities", return_value=caps):
             _validate_e2ee_dependencies()
 
         printed = [str(c.args[0]) for c in mock_print.call_args_list if c.args]
-        assert any("mmrelay[e2e]" in m for m in printed)
+        install_line = [m for m in printed if "Install E2EE support" in m]
+        assert len(install_line) == 1
+        assert "mmrelay[e2e]" in install_line[0]
 
     @patch("sys.platform", "linux")
     @patch("builtins.print")
@@ -3058,13 +3061,16 @@ class TestProviderAwareE2EEGuidance(unittest.TestCase):
         caps = self._make_caps(
             provider_distribution="matrix-nio",
             encryption_available=False,
+            both_known_providers_installed=False,
         )
         with patch("mmrelay.matrix.compat.get_matrix_capabilities", return_value=caps):
             _validate_e2ee_dependencies()
 
         printed = [str(c.args[0]) for c in mock_print.call_args_list if c.args]
-        assert not any("mmrelay[e2e]" in m for m in printed)
-        assert any("matrix-nio[e2e]" in m for m in printed)
+        install_line = [m for m in printed if "Install E2EE support" in m]
+        assert len(install_line) == 1
+        assert "matrix-nio[e2e]" in install_line[0]
+        assert "pipx install 'mmrelay[e2e]'" not in install_line[0]
 
     @patch("sys.platform", "linux")
     @patch("builtins.print")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -48,6 +48,7 @@ from mmrelay.cli import (
 from mmrelay.constants.app import CREDENTIALS_FILENAME
 from mmrelay.constants.cli import EXIT_CODE_ERROR, EXIT_CODE_SUCCESS
 from mmrelay.constants.config import CONFIG_KEY_DEVICE_ID
+from mmrelay.matrix.compat import MatrixLibraryCapabilities
 from tests.constants import TEST_CONFIG_PATH, TEST_HOME_CONFIG_PATH, TEST_SERIAL_PORT
 
 
@@ -3023,17 +3024,32 @@ class TestPrintEnvironmentSummary(unittest.TestCase):
 class TestProviderAwareE2EEGuidance(unittest.TestCase):
     """Test CLI guidance changes by provider."""
 
-    def _make_caps(self, **overrides):
-        from mmrelay.matrix.compat import (
-            detect_matrix_capabilities,
-            reset_matrix_capabilities_cache,
-        )
-
-        reset_matrix_capabilities_cache()
-        base = detect_matrix_capabilities()
+    def _make_caps(self, **overrides) -> MatrixLibraryCapabilities:
         from dataclasses import replace
 
-        return replace(base, **overrides)
+        from mmrelay.matrix.compat import MatrixLibraryCapabilities
+
+        baseline = MatrixLibraryCapabilities(
+            provider_name="mindroom-nio",
+            provider_version="0.25.2",
+            provider_distribution="mindroom-nio",
+            crypto_backend="vodozemac",
+            encryption_available=True,
+            store_available=True,
+            sqlite_store_available=True,
+            olm_available=False,
+            vodozemac_available=True,
+            nio_crypto_available=True,
+            nio_crypto_encryption_enabled=True,
+            nio_crypto_olm_device_available=False,
+            recommended_e2ee_extra="mindroom-nio[e2e]",
+            install_hint="install mindroom-nio[e2e] / vodozemac",
+            both_known_providers_installed=False,
+            supports_stop_sync_forever=True,
+            supports_thread_receipts=True,
+            supports_authenticated_media=True,
+        )
+        return replace(baseline, **overrides)
 
     @patch("sys.platform", "linux")
     @patch("builtins.print")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -26,6 +26,7 @@ import sys
 import unittest
 import unittest.mock
 from types import SimpleNamespace
+from typing import Any
 from unittest.mock import MagicMock, mock_open, patch
 
 # Add repo root and src to path for imports
@@ -3024,10 +3025,8 @@ class TestPrintEnvironmentSummary(unittest.TestCase):
 class TestProviderAwareE2EEGuidance(unittest.TestCase):
     """Test CLI guidance changes by provider."""
 
-    def _make_caps(self, **overrides) -> MatrixLibraryCapabilities:
+    def _make_caps(self, **overrides: Any) -> MatrixLibraryCapabilities:
         from dataclasses import replace
-
-        from mmrelay.matrix.compat import MatrixLibraryCapabilities
 
         baseline = MatrixLibraryCapabilities(
             provider_name="mindroom-nio",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -26,6 +26,7 @@ import os
 import sys
 import unittest
 import unittest.mock
+from types import SimpleNamespace
 from unittest.mock import MagicMock, mock_open, patch
 
 # Add repo root and src to path for imports
@@ -592,16 +593,10 @@ class TestCLIValidationFunctions(unittest.TestCase):
         """Test _validate_e2ee_dependencies when dependencies are available."""
         from mmrelay.cli import _validate_e2ee_dependencies
 
-        # Mock the required modules as available
         with (
-            patch.dict(
-                "sys.modules",
-                {
-                    "olm": MagicMock(),
-                    "nio": MagicMock(),
-                    "nio.crypto": MagicMock(),
-                    "nio.store": MagicMock(),
-                },
+            patch(
+                "mmrelay.matrix.compat.get_matrix_capabilities",
+                return_value=SimpleNamespace(encryption_available=True),
             ),
             patch("builtins.print"),
         ):
@@ -612,17 +607,10 @@ class TestCLIValidationFunctions(unittest.TestCase):
         """Test _validate_e2ee_dependencies when dependencies are missing."""
         from mmrelay.cli import _validate_e2ee_dependencies
 
-        # Simulate missing modules in a reversible way
         with (
-            patch.dict(
-                "sys.modules",
-                {
-                    "olm": None,
-                    "nio": None,
-                    "nio.crypto": None,
-                    "nio.store": None,
-                },
-                clear=False,
+            patch(
+                "mmrelay.matrix.compat.get_matrix_capabilities",
+                return_value=SimpleNamespace(encryption_available=False),
             ),
             patch("mmrelay.cli.print"),
         ):
@@ -634,7 +622,7 @@ class TestCLIValidationFunctions(unittest.TestCase):
         """Test _validate_e2ee_dependencies on Windows platform."""
         from mmrelay.cli import _validate_e2ee_dependencies
 
-        with patch("mmrelay.cli.print"):  # Suppress print output
+        with patch("mmrelay.cli.print"):
             result = _validate_e2ee_dependencies()
             self.assertFalse(result)
 
@@ -1067,9 +1055,9 @@ class TestE2EEAnalysisFunctions(unittest.TestCase):
         config = {"matrix": {"e2ee": {"enabled": True}}}
         mock_exists.return_value = True  # credentials.json exists
 
-        with patch.dict(
-            "sys.modules",
-            {"olm": MagicMock(), "nio.crypto": MagicMock(), "nio.store": MagicMock()},
+        with patch(
+            "mmrelay.matrix.compat.get_matrix_capabilities",
+            return_value=SimpleNamespace(encryption_available=True),
         ):
             result = _analyze_e2ee_setup(config, TEST_CONFIG_PATH)
 
@@ -1101,9 +1089,9 @@ class TestE2EEAnalysisFunctions(unittest.TestCase):
         config = {"matrix": {"e2ee": {"enabled": False}}}
         mock_exists.return_value = True
 
-        with patch.dict(
-            "sys.modules",
-            {"olm": MagicMock(), "nio.crypto": MagicMock(), "nio.store": MagicMock()},
+        with patch(
+            "mmrelay.matrix.compat.get_matrix_capabilities",
+            return_value=SimpleNamespace(encryption_available=True),
         ):
             result = _analyze_e2ee_setup(config, TEST_CONFIG_PATH)
 
@@ -1163,15 +1151,10 @@ class TestE2EEPrintFunctions(unittest.TestCase):
         """Test _print_environment_summary on Linux."""
         from mmrelay.cli import _print_environment_summary
 
-        # Mock the specific modules instead of builtins.__import__ to avoid Python 3.10 conflicts
         with (
-            patch.dict(
-                "sys.modules",
-                {
-                    "olm": MagicMock(),
-                    "nio.crypto": MagicMock(),
-                    "nio.store": MagicMock(),
-                },
+            patch(
+                "mmrelay.matrix.compat.get_matrix_capabilities",
+                return_value=SimpleNamespace(encryption_available=True),
             ),
             patch("mmrelay.cli.print") as mock_print,
         ):
@@ -2144,9 +2127,7 @@ class TestValidateE2EEDependencies(unittest.TestCase):
         self.assertFalse(result)
         # Function uses print statements, not logger
         mock_print.assert_any_call("❌ Error: E2EE is not supported on Windows")
-        mock_print.assert_any_call(
-            "   Reason: python-olm library requires native C libraries"
-        )
+        mock_print.assert_any_call("   Reason: E2EE crypto requires native C libraries")
         mock_print.assert_any_call("   Solution: Use Linux or macOS for E2EE support")
 
     @patch("os.path.exists")
@@ -2958,12 +2939,10 @@ class TestPrintEnvironmentSummary(unittest.TestCase):
     @patch("builtins.print")
     def test_print_environment_summary_linux_with_e2ee(self, mock_print):
         """Test environment summary on Linux with E2EE dependencies available."""
-        # Mock successful E2EE imports
-        with patch.dict(
-            "sys.modules",
-            {"olm": MagicMock(), "nio.crypto": MagicMock(), "nio.store": MagicMock()},
+        with patch(
+            "mmrelay.matrix.compat.get_matrix_capabilities",
+            return_value=SimpleNamespace(encryption_available=True),
         ):
-            # Import and call function
             from mmrelay.cli import _print_environment_summary
 
             _print_environment_summary()
@@ -2979,54 +2958,20 @@ class TestPrintEnvironmentSummary(unittest.TestCase):
     @patch("builtins.print")
     def test_print_environment_summary_linux_without_e2ee(self, mock_print):
         """Test environment summary on Linux without E2EE dependencies."""
-        # Import function first
-        from mmrelay.cli import _print_environment_summary
+        with patch(
+            "mmrelay.matrix.compat.get_matrix_capabilities",
+            return_value=SimpleNamespace(encryption_available=False),
+        ):
+            from mmrelay.cli import _print_environment_summary
 
-        # Mock failed E2EE imports by removing modules from sys.modules and making import fail
-        original_modules = sys.modules.copy()
-        original_import = None
-        try:
-            # Remove E2EE modules if they exist
-            for module in ["olm", "nio.crypto", "nio.store"]:
-                if module in sys.modules:
-                    del sys.modules[module]
-
-            # Mock import to raise ImportError for E2EE modules
-            original_import = builtins.__import__
-
-            def mock_import(name, *args, **kwargs):
-                """
-                Simulate missing optional modules by raising ImportError for select module names during imports.
-
-                Parameters:
-                    name (str): Fully-qualified module name being imported; if it equals "olm", "nio.crypto", or "nio.store" an ImportError is raised.
-                    *args: Additional positional arguments passed to the underlying import machinery (passed through unchanged).
-                    **kwargs: Additional keyword arguments passed through to the underlying import machinery.
-
-                Returns:
-                    module: The result of the normal import for module names other than the ones listed.
-
-                Raises:
-                    ImportError: If `name` is "olm", "nio.crypto", or "nio.store".
-                """
-                if name in ["olm", "nio.crypto", "nio.store"]:
-                    raise ImportError(f"No module named '{name}'")
-                return original_import(name, *args, **kwargs)
-
-            builtins.__import__ = mock_import
-
-            # Call function
             _print_environment_summary()
-
-        finally:
-            # Restore original state
-            if original_import is not None:
-                builtins.__import__ = original_import
-            sys.modules.update(original_modules)
 
         # Verify results
         mock_print.assert_any_call("\n🖥️  Environment Summary:")
         mock_print.assert_any_call("   Platform: linux")
+        mock_print.assert_any_call("   Python: 3.12.3")
+        mock_print.assert_any_call("   E2EE Support: ⚠️  Available but not installed")
+        mock_print.assert_any_call("   Install: pipx install 'mmrelay[e2e]'")
         mock_print.assert_any_call("   Python: 3.12.3")
         mock_print.assert_any_call("   E2EE Support: ⚠️  Available but not installed")
         mock_print.assert_any_call("   Install: pipx install 'mmrelay[e2e]'")
@@ -3061,20 +3006,14 @@ class TestPrintEnvironmentSummary(unittest.TestCase):
     @patch("builtins.print")
     def test_print_environment_summary_macos_with_e2ee(self, mock_print):
         """Test environment summary on macOS with E2EE dependencies available."""
-        # Mock successful E2EE imports
-        with patch.dict(
-            "sys.modules",
-            {"olm": MagicMock(), "nio.crypto": MagicMock(), "nio.store": MagicMock()},
+        with patch(
+            "mmrelay.matrix.compat.get_matrix_capabilities",
+            return_value=SimpleNamespace(encryption_available=True),
         ):
-            # Import and call function
             from mmrelay.cli import _print_environment_summary
 
             _print_environment_summary()
 
-        # Verify results
-        mock_print.assert_any_call("\n🖥️  Environment Summary:")
-        mock_print.assert_any_call("   Platform: darwin")
-        mock_print.assert_any_call("   Python: 3.12.3")
         mock_print.assert_any_call("   E2EE Support: ✅ Available and installed")
 
 
@@ -3384,49 +3323,13 @@ class TestAnalyzeE2eeSetup(unittest.TestCase):
         # Setup mocks
         mock_exists.return_value = False  # No credentials file
 
-        # Mock missing E2EE dependencies
-        original_modules = sys.modules.copy()
-        original_import = None
-        try:
-            # Remove E2EE modules if they exist
-            for module in ["olm", "nio.crypto", "nio.store"]:
-                if module in sys.modules:
-                    del sys.modules[module]
-
-            # Mock import to raise ImportError for E2EE modules
-            original_import = builtins.__import__
-
-            def mock_import(name, *args, **kwargs):
-                """
-                Simulate missing optional modules by raising ImportError for select module names during imports.
-
-                Parameters:
-                    name (str): Fully-qualified module name being imported; if it equals "olm", "nio.crypto", or "nio.store" an ImportError is raised.
-                    *args: Additional positional arguments passed to the underlying import machinery (passed through unchanged).
-                    **kwargs: Additional keyword arguments passed through to the underlying import machinery.
-
-                Returns:
-                    module: The result of the normal import for module names other than the ones listed.
-
-                Raises:
-                    ImportError: If `name` is "olm", "nio.crypto", or "nio.store".
-                """
-                if name in ["olm", "nio.crypto", "nio.store"]:
-                    raise ImportError(f"No module named '{name}'")
-                return original_import(name, *args, **kwargs)
-
-            builtins.__import__ = mock_import
-
-            # Import and call function
+        with patch(
+            "mmrelay.matrix.compat.get_matrix_capabilities",
+            return_value=SimpleNamespace(encryption_available=False),
+        ):
             from mmrelay.cli import _analyze_e2ee_setup
 
             result = _analyze_e2ee_setup(self.base_config, self.config_path)
-
-        finally:
-            # Restore original state
-            if original_import is not None:
-                builtins.__import__ = original_import
-            sys.modules.update(original_modules)
 
         # Verify results
         self.assertIsInstance(result, dict)
@@ -3451,12 +3354,10 @@ class TestAnalyzeE2eeSetup(unittest.TestCase):
         # Setup mocks
         mock_exists.return_value = True  # Credentials file exists
 
-        # Mock successful E2EE dependencies
-        with patch.dict(
-            "sys.modules",
-            {"olm": MagicMock(), "nio.crypto": MagicMock(), "nio.store": MagicMock()},
+        with patch(
+            "mmrelay.matrix.compat.get_matrix_capabilities",
+            return_value=SimpleNamespace(encryption_available=True),
         ):
-            # Import and call function
             from mmrelay.cli import _analyze_e2ee_setup
 
             result = _analyze_e2ee_setup(self.base_config, self.config_path)
@@ -3475,22 +3376,20 @@ class TestAnalyzeE2eeSetup(unittest.TestCase):
     @patch("sys.platform", "darwin")
     @patch("os.path.exists")
     def test_analyze_e2ee_setup_macos_legacy_encryption_config(self, mock_exists):
-        """Test E2EE analysis on macOS with legacy encryption configuration."""
-        # Setup config with legacy encryption section
-        config = {
-            "matrix": {
-                "homeserver": "https://matrix.org",
-                "encryption": {"enabled": True},  # Legacy format
-            }
-        }
+        """Test E2EE analysis with legacy encryption config section."""
+        # Use macOS platform (should be supported)
         mock_exists.return_value = True  # Credentials file exists
 
-        # Mock successful E2EE dependencies
-        with patch.dict(
-            "sys.modules",
-            {"olm": MagicMock(), "nio.crypto": MagicMock(), "nio.store": MagicMock()},
+        config = {
+            "matrix": {
+                "encryption": {"enabled": True},  # Legacy encryption config
+            }
+        }
+
+        with patch(
+            "mmrelay.matrix.compat.get_matrix_capabilities",
+            return_value=SimpleNamespace(encryption_available=True),
         ):
-            # Import and call function
             from mmrelay.cli import _analyze_e2ee_setup
 
             result = _analyze_e2ee_setup(config, self.config_path)
@@ -3510,23 +3409,12 @@ class TestAnalyzeE2eeSetup(unittest.TestCase):
         self, mock_exists, mock_get_base_dir
     ):
         """Test E2EE analysis with standard credentials path."""
-        # Setup mocks
-        mock_get_base_dir.return_value = "/home/user/.mmrelay"
+        mock_exists.return_value = True
 
-        # Mock exists to return True for standard path but False for config dir path
-        def mock_exists_side_effect(path):
-            if path == "/home/user/.mmrelay/credentials.json":
-                return True  # Standard path exists
-            return False  # Config dir path doesn't exist
-
-        mock_exists.side_effect = mock_exists_side_effect
-
-        # Mock successful E2EE dependencies
-        with patch.dict(
-            "sys.modules",
-            {"olm": MagicMock(), "nio.crypto": MagicMock(), "nio.store": MagicMock()},
+        with patch(
+            "mmrelay.matrix.compat.get_matrix_capabilities",
+            return_value=SimpleNamespace(encryption_available=True),
         ):
-            # Import and call function
             from mmrelay.cli import _analyze_e2ee_setup
 
             result = _analyze_e2ee_setup(self.base_config, self.config_path)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3017,6 +3017,73 @@ class TestPrintEnvironmentSummary(unittest.TestCase):
         mock_print.assert_any_call("   E2EE Support: ✅ Available and installed")
 
 
+class TestProviderAwareE2EEGuidance(unittest.TestCase):
+    """Test CLI guidance changes by provider."""
+
+    def _make_caps(self, **overrides):
+        from mmrelay.matrix.compat import (
+            MatrixLibraryCapabilities,
+            detect_matrix_capabilities,
+            reset_matrix_capabilities_cache,
+        )
+
+        reset_matrix_capabilities_cache()
+        base = detect_matrix_capabilities()
+        from dataclasses import replace
+
+        return replace(base, **overrides)
+
+    @patch("sys.platform", "linux")
+    @patch("builtins.print")
+    def test_mindroom_missing_crypto_prints_mmrelay_e2e(self, mock_print):
+        """Mindroom missing E2EE recommends mmrelay[e2e]."""
+        from mmrelay.cli import _validate_e2ee_dependencies
+
+        caps = self._make_caps(
+            provider_distribution="mindroom-nio",
+            encryption_available=False,
+        )
+        with patch("mmrelay.matrix.compat.get_matrix_capabilities", return_value=caps):
+            _validate_e2ee_dependencies()
+
+        printed = [str(c.args[0]) for c in mock_print.call_args_list if c.args]
+        assert any("mmrelay[e2e]" in m for m in printed)
+
+    @patch("sys.platform", "linux")
+    @patch("builtins.print")
+    def test_matrix_nio_missing_crypto_no_mmrelay_e2e(self, mock_print):
+        """Matrix-nio missing E2EE does NOT recommend mmrelay[e2e]."""
+        from mmrelay.cli import _validate_e2ee_dependencies
+
+        caps = self._make_caps(
+            provider_distribution="matrix-nio",
+            encryption_available=False,
+        )
+        with patch("mmrelay.matrix.compat.get_matrix_capabilities", return_value=caps):
+            _validate_e2ee_dependencies()
+
+        printed = [str(c.args[0]) for c in mock_print.call_args_list if c.args]
+        assert not any("mmrelay[e2e]" in m for m in printed)
+        assert any("matrix-nio[e2e]" in m for m in printed)
+
+    @patch("sys.platform", "linux")
+    @patch("builtins.print")
+    def test_both_providers_installed_recommends_uninstall(self, mock_print):
+        """Both providers installed recommends uninstalling one."""
+        from mmrelay.cli import _validate_e2ee_dependencies
+
+        caps = self._make_caps(
+            provider_distribution="unknown",
+            both_known_providers_installed=True,
+            encryption_available=False,
+        )
+        with patch("mmrelay.matrix.compat.get_matrix_capabilities", return_value=caps):
+            _validate_e2ee_dependencies()
+
+        printed = [str(c.args[0]) for c in mock_print.call_args_list if c.args]
+        assert any("Uninstall" in m for m in printed)
+
+
 class TestValidateE2eeConfig(unittest.TestCase):
     """Test cases for _validate_e2ee_config function."""
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -20,7 +20,6 @@
 # See docs/dev/TESTING_GUIDE.md for comprehensive async mocking patterns.
 # ruff: noqa: E402
 
-import builtins
 import json
 import os
 import sys
@@ -3026,7 +3025,6 @@ class TestProviderAwareE2EEGuidance(unittest.TestCase):
 
     def _make_caps(self, **overrides):
         from mmrelay.matrix.compat import (
-            MatrixLibraryCapabilities,
             detect_matrix_capabilities,
             reset_matrix_capabilities_cache,
         )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -26,7 +26,6 @@ import sys
 import unittest
 import unittest.mock
 from types import SimpleNamespace
-from typing import Any
 from unittest.mock import MagicMock, mock_open, patch
 
 # Add repo root and src to path for imports
@@ -3025,7 +3024,7 @@ class TestPrintEnvironmentSummary(unittest.TestCase):
 class TestProviderAwareE2EEGuidance(unittest.TestCase):
     """Test CLI guidance changes by provider."""
 
-    def _make_caps(self, **overrides: Any) -> MatrixLibraryCapabilities:
+    def _make_caps(self, **overrides: object) -> MatrixLibraryCapabilities:
         from dataclasses import replace
 
         baseline = MatrixLibraryCapabilities(
@@ -3066,8 +3065,8 @@ class TestProviderAwareE2EEGuidance(unittest.TestCase):
 
         printed = [str(c.args[0]) for c in mock_print.call_args_list if c.args]
         install_line = [m for m in printed if "Install E2EE support" in m]
-        assert len(install_line) == 1
-        assert "mmrelay[e2e]" in install_line[0]
+        self.assertEqual(len(install_line), 1)
+        self.assertIn("mmrelay[e2e]", install_line[0])
 
     @patch("sys.platform", "linux")
     @patch("builtins.print")
@@ -3085,9 +3084,9 @@ class TestProviderAwareE2EEGuidance(unittest.TestCase):
 
         printed = [str(c.args[0]) for c in mock_print.call_args_list if c.args]
         install_line = [m for m in printed if "Install E2EE support" in m]
-        assert len(install_line) == 1
-        assert "matrix-nio[e2e]" in install_line[0]
-        assert "pipx install 'mmrelay[e2e]'" not in install_line[0]
+        self.assertEqual(len(install_line), 1)
+        self.assertIn("matrix-nio[e2e]", install_line[0])
+        self.assertNotIn("pipx install 'mmrelay[e2e]'", install_line[0])
 
     @patch("sys.platform", "linux")
     @patch("builtins.print")
@@ -3104,7 +3103,7 @@ class TestProviderAwareE2EEGuidance(unittest.TestCase):
             _validate_e2ee_dependencies()
 
         printed = [str(c.args[0]) for c in mock_print.call_args_list if c.args]
-        assert any("Uninstall" in m for m in printed)
+        self.assertTrue(any("Uninstall" in m for m in printed))
 
 
 class TestValidateE2eeConfig(unittest.TestCase):

--- a/tests/test_cli_system_health_coverage.py
+++ b/tests/test_cli_system_health_coverage.py
@@ -103,9 +103,6 @@ class TestPrintSystemHealthWindows(unittest.TestCase):
 
     def test_windows_platform_prints_not_supported(self):
         """On Windows, _print_system_health should print 'Not supported on Windows'."""
-        import tempfile
-        from pathlib import Path
-
         db_path = Path(tempfile.gettempdir()) / "health_test.db"
         paths_info = {
             "home": tempfile.gettempdir(),

--- a/tests/test_cli_system_health_coverage.py
+++ b/tests/test_cli_system_health_coverage.py
@@ -98,5 +98,31 @@ class TestPrintSystemHealthDatabase(unittest.TestCase):
                 assert mock_print.called
 
 
+class TestPrintSystemHealthWindows(unittest.TestCase):
+    """Tests for _print_system_health Windows platform branch."""
+
+    def test_windows_platform_prints_not_supported(self):
+        """On Windows, _print_system_health should print 'Not supported on Windows'."""
+        import tempfile
+        from pathlib import Path
+
+        db_path = Path(tempfile.gettempdir()) / "health_test.db"
+        paths_info = {
+            "home": tempfile.gettempdir(),
+            "database_dir": str(db_path.parent),
+        }
+
+        with (
+            patch("mmrelay.cli.sys.platform", "win32"),
+            patch("mmrelay.paths.get_database_path", return_value=db_path),
+            patch("mmrelay.cli._e2ee_dependencies_available", return_value=True),
+            patch("builtins.print") as mock_print,
+        ):
+            _print_system_health(paths_info)
+
+        printed = [str(c) for c in mock_print.call_args_list]
+        self.assertTrue(any("Not supported on Windows" in p for p in printed))
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_cli_windows_integration.py
+++ b/tests/test_cli_windows_integration.py
@@ -17,6 +17,7 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
 
 from mmrelay.cli import generate_sample_config, main
 from mmrelay.constants.cli import EXIT_CODE_SUCCESS
+from mmrelay.matrix.compat import reset_matrix_capabilities_cache
 
 
 class TestCLIWindowsConsoleSetup(unittest.TestCase):
@@ -301,18 +302,14 @@ class TestCLIE2EEValidation(unittest.TestCase):
     """Test cases for E2EE dependency validation improvements."""
 
     def setUp(self):
-        from mmrelay.matrix.compat import reset_matrix_capabilities_cache
-
         reset_matrix_capabilities_cache()
 
     def tearDown(self):
-        from mmrelay.matrix.compat import reset_matrix_capabilities_cache
-
         reset_matrix_capabilities_cache()
 
     @patch("builtins.print")
     def test_e2ee_validation_improved_error_message(self, mock_print):
-        """Test that E2EE validation shows improved error messages."""
+        """Test that E2EE validation shows improved error messages with default mindroom-nio guidance."""
         from mmrelay.cli import _validate_e2ee_dependencies
         from mmrelay.matrix.compat import MatrixLibraryCapabilities
 

--- a/tests/test_cli_windows_integration.py
+++ b/tests/test_cli_windows_integration.py
@@ -304,10 +304,36 @@ class TestCLIE2EEValidation(unittest.TestCase):
     def test_e2ee_validation_improved_error_message(self, mock_print):
         """Test that E2EE validation shows improved error messages."""
         from mmrelay.cli import _validate_e2ee_dependencies
+        from mmrelay.matrix.compat import (
+            MatrixLibraryCapabilities,
+            reset_matrix_capabilities_cache,
+        )
 
-        # Mock import to fail
+        reset_matrix_capabilities_cache()
+        caps = MatrixLibraryCapabilities(
+            provider_name="mindroom-nio",
+            provider_version="0.25.2",
+            provider_distribution="mindroom-nio",
+            crypto_backend="vodozemac",
+            encryption_available=False,
+            store_available=True,
+            sqlite_store_available=True,
+            olm_available=False,
+            vodozemac_available=False,
+            nio_crypto_available=True,
+            nio_crypto_encryption_enabled=True,
+            nio_crypto_olm_device_available=False,
+            recommended_e2ee_extra="mindroom-nio[e2e]",
+            install_hint="install mindroom-nio[e2e] / vodozemac",
+            both_known_providers_installed=False,
+            supports_stop_sync_forever=True,
+            supports_thread_receipts=True,
+            supports_authenticated_media=True,
+        )
+
         with patch(
-            "builtins.__import__", side_effect=ImportError("No module named 'olm'")
+            "mmrelay.matrix.compat.detect_matrix_capabilities",
+            return_value=caps,
         ):
             result = _validate_e2ee_dependencies()
 

--- a/tests/test_cli_windows_integration.py
+++ b/tests/test_cli_windows_integration.py
@@ -300,16 +300,22 @@ class TestCLIAuthLoginEnhancements(unittest.TestCase):
 class TestCLIE2EEValidation(unittest.TestCase):
     """Test cases for E2EE dependency validation improvements."""
 
+    def setUp(self):
+        from mmrelay.matrix.compat import reset_matrix_capabilities_cache
+
+        reset_matrix_capabilities_cache()
+
+    def tearDown(self):
+        from mmrelay.matrix.compat import reset_matrix_capabilities_cache
+
+        reset_matrix_capabilities_cache()
+
     @patch("builtins.print")
     def test_e2ee_validation_improved_error_message(self, mock_print):
         """Test that E2EE validation shows improved error messages."""
         from mmrelay.cli import _validate_e2ee_dependencies
-        from mmrelay.matrix.compat import (
-            MatrixLibraryCapabilities,
-            reset_matrix_capabilities_cache,
-        )
+        from mmrelay.matrix.compat import MatrixLibraryCapabilities
 
-        reset_matrix_capabilities_cache()
         caps = MatrixLibraryCapabilities(
             provider_name="mindroom-nio",
             provider_version="0.25.2",

--- a/tests/test_e2ee_unified.py
+++ b/tests/test_e2ee_unified.py
@@ -175,7 +175,12 @@ class TestUnifiedE2EEStatus(unittest.TestCase):
 
             self.assertEqual(status["overall_status"], "incomplete")
             self.assertFalse(status["dependencies_installed"])
-            self.assertIn("E2EE dependencies not installed", status["issues"][0])
+            self.assertTrue(
+                any(
+                    "E2EE dependencies not installed" in issue
+                    for issue in status["issues"]
+                )
+            )
 
     @patch("sys.platform", "linux")
     @patch("mmrelay.e2ee_utils.os.path.exists")
@@ -243,7 +248,12 @@ class TestUnifiedE2EEStatus(unittest.TestCase):
 
             self.assertFalse(status["dependencies_installed"])
             self.assertEqual(status["overall_status"], "incomplete")
-            self.assertIn("E2EE dependencies not installed", status["issues"][0])
+            self.assertTrue(
+                any(
+                    "E2EE dependencies not installed" in issue
+                    for issue in status["issues"]
+                )
+            )
 
     @patch("sys.platform", "linux")
     @patch("mmrelay.e2ee_utils.os.path.exists")
@@ -256,7 +266,12 @@ class TestUnifiedE2EEStatus(unittest.TestCase):
 
             self.assertFalse(status["dependencies_installed"])
             self.assertEqual(status["overall_status"], "incomplete")
-            self.assertIn("E2EE dependencies not installed", status["issues"][0])
+            self.assertTrue(
+                any(
+                    "E2EE dependencies not installed" in issue
+                    for issue in status["issues"]
+                )
+            )
 
 
 class TestRoomListFormatting(unittest.TestCase):

--- a/tests/test_e2ee_unified.py
+++ b/tests/test_e2ee_unified.py
@@ -483,8 +483,10 @@ class TestE2EEErrorMessages(unittest.TestCase):
         self.assertEqual(instructions[0], MSG_E2EE_WINDOWS_UNSUPPORTED)
         self.assertEqual(instructions[1], MSG_E2EE_WINDOWS_UNSUPPORTED_DETAIL)
 
-    def test_get_e2ee_warning_messages(self):
+    @patch("mmrelay.e2ee_utils.get_matrix_capabilities")
+    def test_get_e2ee_warning_messages(self, mock_get_caps):
         """Test that get_e2ee_warning_messages returns expected warning messages."""
+        mock_get_caps.return_value = _make_capabilities(encryption_available=True)
         warnings = get_e2ee_warning_messages()
 
         # Verify it's a dictionary

--- a/tests/test_e2ee_unified.py
+++ b/tests/test_e2ee_unified.py
@@ -14,6 +14,7 @@ import sys
 import tempfile
 import types
 import unittest
+from dataclasses import replace
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -26,6 +27,11 @@ from mmrelay.constants.messages import (
     MSG_E2EE_NO_AUTH,
     MSG_E2EE_WINDOWS_UNSUPPORTED,
     MSG_E2EE_WINDOWS_UNSUPPORTED_DETAIL,
+)
+from mmrelay.matrix.compat import (
+    MatrixLibraryCapabilities,
+    detect_matrix_capabilities,
+    reset_matrix_capabilities_cache,
 )
 
 try:
@@ -42,6 +48,13 @@ try:
 except ImportError:
     # Imports not available; dependent tests will be skipped.
     IMPORTS_AVAILABLE = False
+
+
+def _make_capabilities(**overrides) -> MatrixLibraryCapabilities:
+    """Build a capabilities instance from real detection with selective overrides."""
+    reset_matrix_capabilities_cache()
+    base = detect_matrix_capabilities()
+    return replace(base, **overrides)
 
 
 class MockRoom:
@@ -102,8 +115,9 @@ class TestUnifiedE2EEStatus(unittest.TestCase):
     @patch("mmrelay.e2ee_utils.os.path.exists")
     def test_e2ee_ready_status(self, mock_exists):
         """Test E2EE ready status when everything is configured"""
-        with patch("mmrelay.e2ee_utils.importlib.import_module") as mock_import:
-            mock_import.side_effect = lambda _: MagicMock()
+        mock_exists.return_value = True
+        caps = _make_capabilities(encryption_available=True)
+        with patch("mmrelay.e2ee_utils.get_matrix_capabilities", return_value=caps):
             status = get_e2ee_status(self.base_config, self.config_path)
 
             self.assertEqual(status["overall_status"], "ready")
@@ -114,12 +128,6 @@ class TestUnifiedE2EEStatus(unittest.TestCase):
             self.assertTrue(status["dependencies_installed"])
             self.assertTrue(status["credentials_available"])
             self.assertEqual(len(status["issues"]), 0)
-            imported_modules = {call.args[0] for call in mock_import.call_args_list}
-            assert {
-                "olm",
-                "nio.crypto",
-                "nio.store",
-            }.issubset(imported_modules)
 
     @patch("sys.platform", "win32")
     def test_e2ee_unavailable_windows(self):
@@ -147,38 +155,13 @@ class TestUnifiedE2EEStatus(unittest.TestCase):
     def test_e2ee_incomplete_missing_deps(self, mock_exists):
         """Test E2EE incomplete status when dependencies are missing"""
         mock_exists.return_value = True  # credentials.json exists
-
-        with patch("mmrelay.e2ee_utils.importlib.import_module") as mock_import:
-
-            def import_side_effect(name):
-                """
-                Mock import side effect used in tests.
-
-                Simulates Python's import behavior for use with import mocking: if the requested module name is "olm" it raises ImportError to emulate the dependency being missing; for any other module name it returns a MagicMock instance that stands in for the imported module.
-
-                Parameters:
-                    name (str): Full module name passed to the import (e.g., "olm", "nio.crypto").
-
-                Returns:
-                    unittest.mock.MagicMock: A mock object representing the imported module when the module is not "olm".
-
-                Raises:
-                    ImportError: If `name` is exactly "olm".
-                """
-                if name == "olm":
-                    raise ImportError("No module named 'olm'")
-                return MagicMock()
-
-            mock_import.side_effect = import_side_effect
-
+        caps = _make_capabilities(encryption_available=False)
+        with patch("mmrelay.e2ee_utils.get_matrix_capabilities", return_value=caps):
             status = get_e2ee_status(self.base_config, self.config_path)
 
             self.assertEqual(status["overall_status"], "incomplete")
             self.assertFalse(status["dependencies_installed"])
-            self.assertIn(
-                "E2EE dependencies not installed (python-olm)", status["issues"]
-            )
-            mock_import.assert_called_with("olm")
+            self.assertIn("E2EE dependencies not installed", status["issues"][0])
 
     @patch("sys.platform", "linux")
     @patch("mmrelay.e2ee_utils.os.path.exists")
@@ -186,23 +169,16 @@ class TestUnifiedE2EEStatus(unittest.TestCase):
         """
         Verify get_e2ee_status reports "incomplete" when Matrix credentials are missing.
 
-        Mocks E2EE-related modules ("olm", "nio.crypto", "nio.store") so dependencies appear installed, simulates a missing credentials file, calls get_e2ee_status with the test configuration, and asserts that the overall status is "incomplete", credentials_available is False, and an issue about Matrix authentication not being configured is present.
+        Mocks capabilities so dependencies appear installed, simulates a missing credentials file, calls get_e2ee_status with the test configuration, and asserts that the overall status is "incomplete", credentials_available is False, and an issue about Matrix authentication not being configured is present.
         """
         mock_exists.return_value = False  # credentials.json doesn't exist
-
-        with patch("mmrelay.e2ee_utils.importlib.import_module") as mock_import:
-            mock_import.side_effect = lambda _: MagicMock()
+        caps = _make_capabilities(encryption_available=True)
+        with patch("mmrelay.e2ee_utils.get_matrix_capabilities", return_value=caps):
             status = get_e2ee_status(self.base_config, self.config_path)
 
             self.assertEqual(status["overall_status"], "incomplete")
             self.assertFalse(status["credentials_available"])
             self.assertIn(MSG_E2EE_NO_AUTH, status["issues"])
-            imported_modules = {call.args[0] for call in mock_import.call_args_list}
-            assert {
-                "olm",
-                "nio.crypto",
-                "nio.store",
-            }.issubset(imported_modules)
 
     @patch("sys.platform", "linux")
     @patch("mmrelay.e2ee_utils.os.path.exists")
@@ -210,46 +186,12 @@ class TestUnifiedE2EEStatus(unittest.TestCase):
         """Ensure nio dependencies are checked even in test environments."""
 
         mock_exists.return_value = True
-
-        # We no longer patch MMRELAY_TESTING here, effectively testing "default" behavior
-        with patch("mmrelay.e2ee_utils.importlib.import_module") as mock_import:
-            # Mock successful imports for all required modules
-            mock_nio_crypto = MagicMock()
-            mock_nio_crypto.OlmDevice = MagicMock()
-            mock_nio_store = MagicMock()
-            mock_nio_store.SqliteStore = MagicMock()
-
-            def import_side_effect(name):
-                """
-                Provide a replacement for import_module that returns predefined mocks for specific module names.
-
-                Parameters:
-                    name (str): The fully qualified module name requested.
-
-                Returns:
-                    object: A mock object to stand in for the requested module:
-                      - a new MagicMock for "olm" and any unknown module name,
-                      - the value of `mock_nio_crypto` for "nio.crypto",
-                      - the value of `mock_nio_store` for "nio.store".
-                """
-                if name == "olm":
-                    return MagicMock()
-                if name == "nio.crypto":
-                    return mock_nio_crypto
-                if name == "nio.store":
-                    return mock_nio_store
-                return MagicMock()
-
-            mock_import.side_effect = import_side_effect
+        caps = _make_capabilities(encryption_available=True)
+        with patch("mmrelay.e2ee_utils.get_matrix_capabilities", return_value=caps):
             status = get_e2ee_status(self.base_config, self.config_path)
 
         self.assertTrue(status["dependencies_installed"])
         self.assertEqual(status["overall_status"], "ready")
-
-        # Verify that nio modules WERE imported/checked
-        mock_import.assert_any_call("olm")
-        mock_import.assert_any_call("nio.crypto")
-        mock_import.assert_any_call("nio.store")
 
     @patch("sys.platform", "linux")
     @patch("mmrelay.e2ee_utils.os.path.exists")
@@ -257,45 +199,15 @@ class TestUnifiedE2EEStatus(unittest.TestCase):
         """
         Verify that E2EE dependency attribute checks succeed when required attributes are present.
 
-        Asserts that the status reports dependencies_installed and overall_status "ready", and that the expected modules ("olm", "nio.crypto", "nio.store") were attempted to be imported.
+        Asserts that the status reports dependencies_installed and overall_status "ready".
         """
         mock_exists.return_value = True
-
-        with patch("mmrelay.e2ee_utils.importlib.import_module") as mock_import:
-            # Create mock modules with the required attributes
-            mock_olm = MagicMock()
-            mock_nio_crypto = MagicMock()
-            mock_nio_crypto.OlmDevice = MagicMock()
-            mock_nio_store = MagicMock()
-            mock_nio_store.SqliteStore = MagicMock()
-
-            def import_side_effect(name):
-                """
-                Provide a test-double module object corresponding to a requested import name.
-
-                Parameters:
-                    name (str): Module name being imported (e.g., "olm", "nio.crypto", "nio.store").
-
-                Returns:
-                    object: The corresponding mock module: `mock_olm` for "olm", `mock_nio_crypto` for "nio.crypto", `mock_nio_store` for "nio.store", or a new `MagicMock` for any other name.
-                """
-                if name == "olm":
-                    return mock_olm
-                elif name == "nio.crypto":
-                    return mock_nio_crypto
-                elif name == "nio.store":
-                    return mock_nio_store
-                return MagicMock()
-
-            mock_import.side_effect = import_side_effect
+        caps = _make_capabilities(encryption_available=True)
+        with patch("mmrelay.e2ee_utils.get_matrix_capabilities", return_value=caps):
             status = get_e2ee_status(self.base_config, self.config_path)
 
             self.assertTrue(status["dependencies_installed"])
             self.assertEqual(status["overall_status"], "ready")
-            # Verify all modules were imported
-            expected_imports = {"olm", "nio.crypto", "nio.store"}
-            actual_imports = {call.args[0] for call in mock_import.call_args_list}
-            self.assertTrue(expected_imports.issubset(actual_imports))
 
     @patch("sys.platform", "linux")
     @patch("mmrelay.e2ee_utils.os.path.exists")
@@ -303,86 +215,34 @@ class TestUnifiedE2EEStatus(unittest.TestCase):
         """
         Verify that get_e2ee_status reports missing dependencies when nio.crypto.OlmDevice is absent.
 
-        Sets up mocked imports where the `nio.crypto` module lacks the `OlmDevice` attribute and asserts that
+        Sets up mocked capabilities where encryption is not available and asserts that
         the returned status marks dependencies as not installed, sets overall status to "incomplete", and
-        includes an issue mentioning `python-olm`.
+        includes an issue mentioning E2EE dependencies not installed.
 
         Parameters:
             mock_exists (unittest.mock.Mock): Patch for os.path.exists controlling presence of credentials file.
         """
         mock_exists.return_value = True
-
-        with patch("mmrelay.e2ee_utils.importlib.import_module") as mock_import:
-            # Create simple namespace modules where nio.crypto lacks OlmDevice
-            mock_olm = types.SimpleNamespace()
-            mock_nio_crypto = types.SimpleNamespace()  # no OlmDevice attribute
-            mock_nio_store = types.SimpleNamespace(SqliteStore=MagicMock())
-
-            def import_side_effect(name):
-                """
-                Provide a test-double module object corresponding to a requested import name.
-
-                Parameters:
-                    name (str): Module name being imported (e.g., "olm", "nio.crypto", "nio.store").
-
-                Returns:
-                    object: The corresponding mock module: `mock_olm` for "olm", `mock_nio_crypto` for "nio.crypto", `mock_nio_store` for "nio.store", or a new `MagicMock` for any other name.
-                """
-                if name == "olm":
-                    return mock_olm
-                if name == "nio.crypto":
-                    return mock_nio_crypto
-                if name == "nio.store":
-                    return mock_nio_store
-                return MagicMock()
-
-            mock_import.side_effect = import_side_effect
+        caps = _make_capabilities(encryption_available=False)
+        with patch("mmrelay.e2ee_utils.get_matrix_capabilities", return_value=caps):
             status = get_e2ee_status(self.base_config, self.config_path)
 
             self.assertFalse(status["dependencies_installed"])
             self.assertEqual(status["overall_status"], "incomplete")
-            self.assertIn(
-                "E2EE dependencies not installed (python-olm)", status["issues"]
-            )
+            self.assertIn("E2EE dependencies not installed", status["issues"][0])
 
     @patch("sys.platform", "linux")
     @patch("mmrelay.e2ee_utils.os.path.exists")
     def test_e2ee_hasattr_checks_missing_sqlitestore(self, mock_exists):
         """Test hasattr check failure when nio.store.SqliteStore is missing"""
         mock_exists.return_value = True
-
-        with patch("mmrelay.e2ee_utils.importlib.import_module") as mock_import:
-            # Create mock modules where nio.store lacks SqliteStore
-            mock_olm = types.SimpleNamespace()
-            mock_nio_crypto = types.SimpleNamespace(OlmDevice=MagicMock())
-            mock_nio_store = types.SimpleNamespace()
-
-            def import_side_effect(name):
-                """
-                Return a test-double module object for a requested import name.
-
-                Parameters:
-                    name (str): Module name being imported (e.g., "olm", "nio.crypto", "nio.store").
-
-                Returns:
-                    object: A mock module corresponding to `name` (`mock_olm`, `mock_nio_crypto`, `mock_nio_store`), or a fresh `MagicMock` for any other module name.
-                """
-                if name == "olm":
-                    return mock_olm
-                if name == "nio.crypto":
-                    return mock_nio_crypto
-                if name == "nio.store":
-                    return mock_nio_store
-                return MagicMock()
-
-            mock_import.side_effect = import_side_effect
+        caps = _make_capabilities(encryption_available=False)
+        with patch("mmrelay.e2ee_utils.get_matrix_capabilities", return_value=caps):
             status = get_e2ee_status(self.base_config, self.config_path)
 
             self.assertFalse(status["dependencies_installed"])
             self.assertEqual(status["overall_status"], "incomplete")
-            self.assertIn(
-                "E2EE dependencies not installed (python-olm)", status["issues"]
-            )
+            self.assertIn("E2EE dependencies not installed", status["issues"][0])
 
 
 class TestRoomListFormatting(unittest.TestCase):

--- a/tests/test_e2ee_unified.py
+++ b/tests/test_e2ee_unified.py
@@ -27,11 +27,7 @@ from mmrelay.constants.messages import (
     MSG_E2EE_WINDOWS_UNSUPPORTED,
     MSG_E2EE_WINDOWS_UNSUPPORTED_DETAIL,
 )
-from mmrelay.matrix.compat import (
-    MatrixLibraryCapabilities,
-    detect_matrix_capabilities,
-    reset_matrix_capabilities_cache,
-)
+from mmrelay.matrix.compat import MatrixLibraryCapabilities
 
 try:
     from mmrelay.e2ee_utils import (
@@ -50,10 +46,29 @@ except ImportError:
 
 
 def _make_capabilities(**overrides) -> MatrixLibraryCapabilities:
-    """Build a capabilities instance from real detection with selective overrides."""
-    reset_matrix_capabilities_cache()
-    base = detect_matrix_capabilities()
-    return replace(base, **overrides)
+    """Build a capabilities instance from a deterministic baseline with selective overrides."""
+
+    baseline = MatrixLibraryCapabilities(
+        provider_name="mindroom-nio",
+        provider_version="0.25.2",
+        provider_distribution="mindroom-nio",
+        crypto_backend="vodozemac",
+        encryption_available=True,
+        store_available=True,
+        sqlite_store_available=True,
+        olm_available=False,
+        vodozemac_available=True,
+        nio_crypto_available=True,
+        nio_crypto_encryption_enabled=True,
+        nio_crypto_olm_device_available=False,
+        recommended_e2ee_extra="mindroom-nio[e2e]",
+        install_hint="install mindroom-nio[e2e] / vodozemac",
+        both_known_providers_installed=False,
+        supports_stop_sync_forever=True,
+        supports_thread_receipts=True,
+        supports_authenticated_media=True,
+    )
+    return replace(baseline, **overrides)
 
 
 class MockRoom:

--- a/tests/test_e2ee_unified.py
+++ b/tests/test_e2ee_unified.py
@@ -12,11 +12,10 @@ import logging
 import os
 import sys
 import tempfile
-import types
 import unittest
 from dataclasses import replace
 from pathlib import Path
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 # Add src to path for imports
 sys.path.insert(0, str(Path(__file__).parent.parent / "src"))

--- a/tests/test_e2ee_unified.py
+++ b/tests/test_e2ee_unified.py
@@ -45,7 +45,7 @@ except ImportError:
     IMPORTS_AVAILABLE = False
 
 
-def _make_capabilities(**overrides) -> MatrixLibraryCapabilities:
+def _make_capabilities(**overrides: object) -> MatrixLibraryCapabilities:
     """Build a capabilities instance from a deterministic baseline with selective overrides."""
 
     baseline = MatrixLibraryCapabilities(
@@ -537,6 +537,7 @@ class TestActualEncryptionVerification(unittest.TestCase):
         # Add handler to nio.crypto logger
         nio_crypto_logger = logging.getLogger("nio.crypto.log")
         test_handler = TestLogHandler()
+        previous_level = nio_crypto_logger.level
         nio_crypto_logger.addHandler(test_handler)
         nio_crypto_logger.setLevel(logging.INFO)
 
@@ -563,6 +564,7 @@ class TestActualEncryptionVerification(unittest.TestCase):
 
         finally:
             nio_crypto_logger.removeHandler(test_handler)
+            nio_crypto_logger.setLevel(previous_level)
 
     def test_encrypted_event_detection(self):
         """

--- a/tests/test_e2ee_utils.py
+++ b/tests/test_e2ee_utils.py
@@ -525,14 +525,16 @@ class TestGetE2eeErrorMessage:
         """Missing dependencies should return deps message."""
         from mmrelay.e2ee_utils import get_e2ee_error_message
 
-        result = get_e2ee_error_message(
-            {
-                "overall_status": "incomplete",
-                "enabled": True,
-                "platform_supported": True,
-                "dependencies_installed": False,
-            }
-        )
+        caps = _matrix_capabilities(encryption_available=False)
+        with patch("mmrelay.e2ee_utils.get_matrix_capabilities", return_value=caps):
+            result = get_e2ee_error_message(
+                {
+                    "overall_status": "incomplete",
+                    "enabled": True,
+                    "platform_supported": True,
+                    "dependencies_installed": False,
+                }
+            )
         assert "dependencies" in result.lower()
 
     def test_missing_credentials(self):

--- a/tests/test_e2ee_utils.py
+++ b/tests/test_e2ee_utils.py
@@ -9,7 +9,8 @@ This module tests lines 115-122 and 172-182 of e2ee_utils.py:
 import os
 import shutil
 import tempfile
-from unittest.mock import MagicMock, patch
+from types import SimpleNamespace
+from unittest.mock import patch
 
 import pytest
 
@@ -19,6 +20,24 @@ from mmrelay.e2ee_utils import (
     _check_credentials_available,
     get_e2ee_status,
 )
+
+
+def _matrix_capabilities(encryption_available: bool = True):
+    return SimpleNamespace(
+        encryption_available=encryption_available,
+        provider_distribution="matrix-nio",
+        provider_name="matrix-nio",
+        provider_version="0.25.2",
+        crypto_backend="olm",
+        install_hint="install matrix-nio[e2e] / python-olm",
+        recommended_e2ee_extra="matrix-nio[e2e]",
+        both_known_providers_installed=False,
+        olm_available=encryption_available,
+        vodozemac_available=False,
+        nio_crypto_available=True,
+        sqlite_store_available=encryption_available,
+        nio_crypto_encryption_enabled=None,
+    )
 
 
 @pytest.fixture
@@ -72,9 +91,10 @@ def test_credentials_found_in_legacy_location(
     _temp_dir, _config_path, _credentials_path, base_config = e2ee_test_config
 
     # Mock dependencies as installed
-    with patch("mmrelay.e2ee_utils.importlib.import_module") as mock_import:
-        mock_import.side_effect = lambda _: MagicMock()
-
+    with patch(
+        "mmrelay.e2ee_utils.get_matrix_capabilities",
+        return_value=_matrix_capabilities(),
+    ):
         mock_deprecation_active.return_value = True
 
         # Mock paths_info with legacy sources
@@ -150,9 +170,10 @@ def test_credentials_not_found_in_legacy_locations(
     _temp_dir, _config_path, _credentials_path, base_config = e2ee_test_config
 
     # Mock dependencies as installed
-    with patch("mmrelay.e2ee_utils.importlib.import_module") as mock_import:
-        mock_import.side_effect = lambda _: MagicMock()
-
+    with patch(
+        "mmrelay.e2ee_utils.get_matrix_capabilities",
+        return_value=_matrix_capabilities(),
+    ):
         mock_deprecation_active.return_value = True
 
         # Mock paths_info with legacy sources

--- a/tests/test_e2ee_utils.py
+++ b/tests/test_e2ee_utils.py
@@ -9,7 +9,6 @@ This module tests lines 115-122 and 172-182 of e2ee_utils.py:
 import os
 import shutil
 import tempfile
-from types import SimpleNamespace
 from unittest.mock import patch
 
 import pytest
@@ -20,23 +19,31 @@ from mmrelay.e2ee_utils import (
     _check_credentials_available,
     get_e2ee_status,
 )
+from mmrelay.matrix.compat import MatrixLibraryCapabilities
 
 
-def _matrix_capabilities(*, encryption_available: bool = True) -> SimpleNamespace:
-    return SimpleNamespace(
-        encryption_available=encryption_available,
-        provider_distribution="matrix-nio",
+def _matrix_capabilities(
+    *, encryption_available: bool = True
+) -> MatrixLibraryCapabilities:
+    return MatrixLibraryCapabilities(
         provider_name="matrix-nio",
         provider_version="0.25.2",
-        crypto_backend="olm",
-        install_hint="install matrix-nio[e2e] / python-olm",
-        recommended_e2ee_extra="matrix-nio[e2e]",
-        both_known_providers_installed=False,
+        provider_distribution="matrix-nio",
+        crypto_backend="olm" if encryption_available else "unavailable",
+        encryption_available=encryption_available,
+        store_available=encryption_available,
+        sqlite_store_available=encryption_available,
         olm_available=encryption_available,
         vodozemac_available=False,
         nio_crypto_available=True,
-        sqlite_store_available=encryption_available,
         nio_crypto_encryption_enabled=None,
+        nio_crypto_olm_device_available=encryption_available,
+        recommended_e2ee_extra="matrix-nio[e2e]",
+        install_hint="install matrix-nio[e2e] / python-olm",
+        both_known_providers_installed=False,
+        supports_stop_sync_forever=True,
+        supports_thread_receipts=False,
+        supports_authenticated_media=False,
     )
 
 

--- a/tests/test_e2ee_utils.py
+++ b/tests/test_e2ee_utils.py
@@ -22,7 +22,7 @@ from mmrelay.e2ee_utils import (
 )
 
 
-def _matrix_capabilities(encryption_available: bool = True):
+def _matrix_capabilities(*, encryption_available: bool = True) -> SimpleNamespace:
     return SimpleNamespace(
         encryption_available=encryption_available,
         provider_distribution="matrix-nio",

--- a/tests/test_matrix_compat.py
+++ b/tests/test_matrix_compat.py
@@ -159,28 +159,38 @@ def test_default_dependency_is_mindroom_not_matrix_nio():
     assert not any("matrix-nio" in dep for dep in deps)
 
 
+def test_only_e2e_extra_for_matrix_providers():
+    project = _read_pyproject_deps()
+    extras = project.get("optional-dependencies", {})
+    for name, deps in extras.items():
+        if name == "e2e":
+            continue
+        for dep in deps:
+            assert (
+                "matrix-nio" not in dep
+            ), f"extra {name} unexpectedly contains matrix-nio: {dep}"
+            assert (
+                "mindroom-nio" not in dep
+            ), f"extra {name} unexpectedly contains mindroom-nio: {dep}"
+
+
 def test_e2e_extra_points_to_mindroom():
     extras = _read_pyproject_deps().get("optional-dependencies", {})
     e2e_deps = extras.get("e2e", [])
     assert any("mindroom-nio[e2e]" in dep for dep in e2e_deps)
 
 
-def test_legacy_matrix_nio_extras_exist():
-    extras = _read_pyproject_deps().get("optional-dependencies", {})
-    matrix_nio_deps = extras.get("matrix-nio", [])
-    assert any("matrix-nio==" in dep for dep in matrix_nio_deps)
-    matrix_nio_e2e_deps = extras.get("matrix-nio-e2e", [])
-    assert any("matrix-nio[e2e]" in dep for dep in matrix_nio_e2e_deps)
+def test_no_extra_installs_both_providers_with_base():
+    project = _read_pyproject_deps()
+    base_deps = project.get("dependencies", [])
+    extras = project.get("optional-dependencies", {}).values()
 
-
-def test_no_extra_installs_both_providers():
-    extras = _read_pyproject_deps().get("optional-dependencies", {}).values()
-    for deps in extras:
+    for deps in list(extras) + [base_deps]:
         has_matrix = any("matrix-nio" in dep for dep in deps)
         has_mindroom = any("mindroom-nio" in dep for dep in deps)
         assert not (
             has_matrix and has_mindroom
-        ), f"extra {deps} installs both matrix-nio and mindroom-nio"
+        ), f"deps {deps} contain both matrix-nio and mindroom-nio"
 
 
 def test_both_providers_installed_disables_e2ee_even_with_crypto(monkeypatch):
@@ -214,3 +224,23 @@ def test_both_providers_installed_disables_e2ee_even_with_crypto(monkeypatch):
     assert capabilities.encryption_available is False
     assert capabilities.crypto_backend != "olm"
     assert capabilities.crypto_backend != "vodozemac"
+
+
+def test_matrix_nio_install_guidance_does_not_recommend_mmrelay_e2e(monkeypatch):
+    _patch_detection(
+        monkeypatch,
+        {"matrix-nio": "0.25.2"},
+        {
+            "nio": SimpleNamespace(AsyncClient=type("AsyncClient", (), {})),
+            "nio.crypto": SimpleNamespace(OlmDevice=object),
+            "nio.store": SimpleNamespace(SqliteStore=object),
+        },
+    )
+
+    capabilities = compat.detect_matrix_capabilities()
+    cmd = compat.format_e2ee_install_command(capabilities)
+
+    assert "pip install 'matrix-nio[e2e]==0.25.2'" in cmd
+    assert "controlled replacement" in cmd
+    assert "Do not install mmrelay[e2e]" in cmd
+    assert "mmrelay[e2e]" not in cmd.replace("Do not install mmrelay[e2e]", "")

--- a/tests/test_matrix_compat.py
+++ b/tests/test_matrix_compat.py
@@ -75,14 +75,28 @@ def test_e2e_extra_points_to_mindroom():
 def test_no_extra_installs_both_providers_with_base():
     project = _read_pyproject_deps()
     base_deps = project.get("dependencies", [])
-    extras = project.get("optional-dependencies", {}).values()
+    extras = project.get("optional-dependencies", {})
 
-    for deps in list(extras) + [base_deps]:
-        has_matrix = any("matrix-nio" in dep for dep in deps)
-        has_mindroom = any("mindroom-nio" in dep for dep in deps)
+    # For every optional extra, evaluate combined dependencies as base_deps + extra_deps
+    for extra_name, extra_deps in extras.items():
+        combined = base_deps + extra_deps
+        has_matrix = any("matrix-nio" in dep for dep in combined)
+        has_mindroom = any("mindroom-nio" in dep for dep in combined)
         assert not (
             has_matrix and has_mindroom
-        ), f"deps {deps} contain both matrix-nio and mindroom-nio"
+        ), f"extra '{extra_name}' combined deps contain both matrix-nio and mindroom-nio"
+
+    # Also verify no non-e2e extra introduces Matrix provider deps
+    for name, deps in extras.items():
+        if name == "e2e":
+            continue
+        for dep in deps:
+            assert (
+                "matrix-nio" not in dep
+            ), f"extra {name} unexpectedly contains matrix-nio: {dep}"
+            assert (
+                "mindroom-nio" not in dep
+            ), f"extra {name} unexpectedly contains mindroom-nio: {dep}"
 
 
 def test_both_providers_installed_disables_e2ee_even_with_crypto(monkeypatch):

--- a/tests/test_matrix_compat.py
+++ b/tests/test_matrix_compat.py
@@ -1,0 +1,127 @@
+from types import SimpleNamespace
+
+import pytest
+
+from mmrelay.matrix import compat
+
+
+@pytest.fixture(autouse=True)
+def reset_capability_cache():
+    compat.reset_matrix_capabilities_cache()
+    yield
+    compat.reset_matrix_capabilities_cache()
+
+
+def _patch_detection(monkeypatch, distributions, modules):
+    def fake_version(distribution_name):
+        if distribution_name in distributions:
+            return distributions[distribution_name]
+        raise compat.metadata.PackageNotFoundError(distribution_name)
+
+    def fake_import_module(module_name):
+        if module_name in modules:
+            module = modules[module_name]
+            if isinstance(module, BaseException):
+                raise module
+            return module
+        raise ImportError(f"No module named {module_name!r}")
+
+    monkeypatch.setattr(compat.metadata, "version", fake_version)
+    monkeypatch.setattr(compat.importlib, "import_module", fake_import_module)
+
+
+def test_detects_matrix_nio_olm_backend(monkeypatch):
+    _patch_detection(
+        monkeypatch,
+        {"matrix-nio": "0.25.2"},
+        {
+            "nio": SimpleNamespace(AsyncClient=type("AsyncClient", (), {})),
+            "nio.crypto": SimpleNamespace(OlmDevice=object),
+            "nio.store": SimpleNamespace(SqliteStore=object),
+            "olm": SimpleNamespace(),
+        },
+    )
+
+    capabilities = compat.detect_matrix_capabilities()
+
+    assert capabilities.provider_distribution == "matrix-nio"
+    assert capabilities.crypto_backend == "olm"
+    assert capabilities.encryption_available is True
+    assert capabilities.recommended_e2ee_extra == "matrix-nio[e2e]"
+    assert "python-olm" in capabilities.install_hint
+
+
+def test_detects_matrix_nio_without_olm(monkeypatch):
+    _patch_detection(
+        monkeypatch,
+        {"matrix-nio": "0.25.2"},
+        {
+            "nio": SimpleNamespace(AsyncClient=type("AsyncClient", (), {})),
+            "nio.crypto": SimpleNamespace(OlmDevice=object),
+            "nio.store": SimpleNamespace(SqliteStore=object),
+        },
+    )
+
+    capabilities = compat.detect_matrix_capabilities()
+
+    assert capabilities.provider_distribution == "matrix-nio"
+    assert capabilities.encryption_available is False
+    assert "python-olm" in compat.format_e2ee_unavailable_message(capabilities)
+
+
+def test_detects_mindroom_vodozemac_backend(monkeypatch):
+    _patch_detection(
+        monkeypatch,
+        {"mindroom-nio": "0.25.2"},
+        {
+            "nio": SimpleNamespace(AsyncClient=type("AsyncClient", (), {})),
+            "nio.crypto": SimpleNamespace(
+                ENCRYPTION_ENABLED=True,
+                OlmDevice=object,
+            ),
+            "nio.store": SimpleNamespace(SqliteStore=object),
+            "vodozemac": SimpleNamespace(),
+        },
+    )
+
+    capabilities = compat.detect_matrix_capabilities()
+
+    assert capabilities.provider_distribution == "mindroom-nio"
+    assert capabilities.crypto_backend == "vodozemac"
+    assert capabilities.encryption_available is True
+    assert capabilities.recommended_e2ee_extra == "mindroom-nio[e2e]"
+    assert "vodozemac" in capabilities.install_hint
+
+
+def test_detects_mindroom_without_vodozemac(monkeypatch):
+    _patch_detection(
+        monkeypatch,
+        {"mindroom-nio": "0.25.2"},
+        {
+            "nio": SimpleNamespace(AsyncClient=type("AsyncClient", (), {})),
+            "nio.crypto": SimpleNamespace(ENCRYPTION_ENABLED=False),
+            "nio.store": SimpleNamespace(),
+        },
+    )
+
+    capabilities = compat.detect_matrix_capabilities()
+
+    assert capabilities.provider_distribution == "mindroom-nio"
+    assert capabilities.encryption_available is False
+    assert "vodozemac" in compat.format_e2ee_unavailable_message(capabilities)
+    assert "python-olm" not in compat.format_e2ee_unavailable_message(capabilities)
+
+
+def test_reports_multiple_known_provider_distributions(monkeypatch):
+    _patch_detection(
+        monkeypatch,
+        {"matrix-nio": "0.25.2", "mindroom-nio": "0.25.2"},
+        {"nio": SimpleNamespace(AsyncClient=type("AsyncClient", (), {}))},
+    )
+
+    capabilities = compat.detect_matrix_capabilities()
+
+    assert capabilities.provider_distribution == "unknown"
+    assert capabilities.both_known_providers_installed is True
+    assert "matrix-nio=0.25.2" in capabilities.provider_version
+    assert "mindroom-nio=0.25.2" in capabilities.provider_version

--- a/tests/test_matrix_compat.py
+++ b/tests/test_matrix_compat.py
@@ -39,7 +39,7 @@ def _read_pyproject_deps():
         import tomli as tomllib
 
     pyproject_path = Path(__file__).resolve().parents[1] / "pyproject.toml"
-    with open(pyproject_path, "rb") as f:
+    with pyproject_path.open("rb") as f:
         data = tomllib.load(f)
     return data.get("project", {})
 

--- a/tests/test_matrix_compat.py
+++ b/tests/test_matrix_compat.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
@@ -30,115 +31,6 @@ def _patch_detection(monkeypatch, distributions, modules):
     monkeypatch.setattr(compat.importlib, "import_module", fake_import_module)
 
 
-def test_detects_matrix_nio_olm_backend(monkeypatch):
-    _patch_detection(
-        monkeypatch,
-        {"matrix-nio": "0.25.2"},
-        {
-            "nio": SimpleNamespace(AsyncClient=type("AsyncClient", (), {})),
-            "nio.crypto": SimpleNamespace(OlmDevice=object),
-            "nio.store": SimpleNamespace(SqliteStore=object),
-            "olm": SimpleNamespace(),
-        },
-    )
-
-    capabilities = compat.detect_matrix_capabilities()
-
-    assert capabilities.provider_distribution == "matrix-nio"
-    assert capabilities.crypto_backend == "olm"
-    assert capabilities.encryption_available is True
-    assert capabilities.recommended_e2ee_extra == "matrix-nio[e2e]"
-    assert "python-olm" in capabilities.install_hint
-
-
-def test_detects_matrix_nio_without_olm(monkeypatch):
-    _patch_detection(
-        monkeypatch,
-        {"matrix-nio": "0.25.2"},
-        {
-            "nio": SimpleNamespace(AsyncClient=type("AsyncClient", (), {})),
-            "nio.crypto": SimpleNamespace(OlmDevice=object),
-            "nio.store": SimpleNamespace(SqliteStore=object),
-        },
-    )
-
-    capabilities = compat.detect_matrix_capabilities()
-
-    assert capabilities.provider_distribution == "matrix-nio"
-    assert capabilities.encryption_available is False
-    message = compat.format_e2ee_unavailable_message(capabilities)
-    assert "python-olm" in message
-    assert "matrix-nio" in message
-
-
-def test_detects_mindroom_vodozemac_backend(monkeypatch):
-    _patch_detection(
-        monkeypatch,
-        {"mindroom-nio": "0.25.2"},
-        {
-            "nio": SimpleNamespace(AsyncClient=type("AsyncClient", (), {})),
-            "nio.crypto": SimpleNamespace(
-                ENCRYPTION_ENABLED=True,
-                OlmDevice=object,
-            ),
-            "nio.store": SimpleNamespace(SqliteStore=object),
-            "vodozemac": SimpleNamespace(),
-        },
-    )
-
-    capabilities = compat.detect_matrix_capabilities()
-
-    assert capabilities.provider_distribution == "mindroom-nio"
-    assert capabilities.crypto_backend == "vodozemac"
-    assert capabilities.encryption_available is True
-    assert capabilities.recommended_e2ee_extra == "mindroom-nio[e2e]"
-    assert "vodozemac" in capabilities.install_hint
-
-
-def test_detects_mindroom_without_vodozemac(monkeypatch):
-    _patch_detection(
-        monkeypatch,
-        {"mindroom-nio": "0.25.2"},
-        {
-            "nio": SimpleNamespace(AsyncClient=type("AsyncClient", (), {})),
-            "nio.crypto": SimpleNamespace(ENCRYPTION_ENABLED=False),
-            "nio.store": SimpleNamespace(),
-        },
-    )
-
-    capabilities = compat.detect_matrix_capabilities()
-
-    assert capabilities.provider_distribution == "mindroom-nio"
-    assert capabilities.encryption_available is False
-    message = compat.format_e2ee_unavailable_message(capabilities)
-    assert "vodozemac" in message
-    assert "mindroom" in message
-    assert "python-olm" not in message
-    assert "mindroom-nio[e2e]" in compat.format_e2ee_install_command(capabilities)
-    assert "mmrelay[e2e]" in compat.format_e2ee_install_command(capabilities)
-
-
-def test_reports_multiple_known_provider_distributions(monkeypatch):
-    _patch_detection(
-        monkeypatch,
-        {"matrix-nio": "0.25.2", "mindroom-nio": "0.25.2"},
-        {"nio": SimpleNamespace(AsyncClient=type("AsyncClient", (), {}))},
-    )
-
-    capabilities = compat.detect_matrix_capabilities()
-
-    assert capabilities.provider_distribution == "unknown"
-    assert capabilities.both_known_providers_installed is True
-    assert capabilities.encryption_available is False
-    assert "matrix-nio=0.25.2" in capabilities.provider_version
-    assert "mindroom-nio=0.25.2" in capabilities.provider_version
-    message = compat.format_e2ee_unavailable_message(capabilities)
-    install_command = compat.format_e2ee_install_command(capabilities)
-    assert "both installed" in message
-    assert "uninstall one nio namespace owner" in message
-    assert "Uninstall either matrix-nio or mindroom-nio first" in install_command
-
-
 def _read_pyproject_deps():
     """Read pyproject.toml and extract dependencies and optional-dependencies."""
     try:
@@ -146,7 +38,8 @@ def _read_pyproject_deps():
     except ImportError:
         import tomli as tomllib
 
-    with open("pyproject.toml", "rb") as f:
+    pyproject_path = Path(__file__).resolve().parents[1] / "pyproject.toml"
+    with open(pyproject_path, "rb") as f:
         data = tomllib.load(f)
     return data.get("project", {})
 

--- a/tests/test_matrix_compat.py
+++ b/tests/test_matrix_compat.py
@@ -13,13 +13,17 @@ def reset_capability_cache():
     compat.reset_matrix_capabilities_cache()
 
 
-def _patch_detection(monkeypatch, distributions, modules):
-    def fake_version(distribution_name):
+def _patch_detection(
+    monkeypatch: pytest.MonkeyPatch,
+    distributions: dict[str, str],
+    modules: dict[str, object],
+) -> None:
+    def fake_version(distribution_name: str) -> str:
         if distribution_name in distributions:
             return distributions[distribution_name]
         raise compat.metadata.PackageNotFoundError(distribution_name)
 
-    def fake_import_module(module_name):
+    def fake_import_module(module_name: str) -> object:
         if module_name in modules:
             module = modules[module_name]
             if isinstance(module, BaseException):
@@ -31,17 +35,18 @@ def _patch_detection(monkeypatch, distributions, modules):
     monkeypatch.setattr(compat.importlib, "import_module", fake_import_module)
 
 
-def _read_pyproject_deps():
+def _read_pyproject_deps() -> dict[str, object]:
     """Read pyproject.toml and extract dependencies and optional-dependencies."""
     try:
         import tomllib
     except ImportError:
-        import tomli as tomllib
+        import tomli as tomllib  # type: ignore[no-redef]
 
     pyproject_path = Path(__file__).resolve().parents[1] / "pyproject.toml"
     with pyproject_path.open("rb") as f:
         data = tomllib.load(f)
-    return data.get("project", {})
+    result = data.get("project", {})
+    return result if isinstance(result, dict) else {}
 
 
 def test_default_dependency_is_mindroom_not_matrix_nio():
@@ -85,18 +90,6 @@ def test_no_extra_installs_both_providers_with_base():
         assert not (
             has_matrix and has_mindroom
         ), f"extra '{extra_name}' combined deps contain both matrix-nio and mindroom-nio"
-
-    # Also verify no non-e2e extra introduces Matrix provider deps
-    for name, deps in extras.items():
-        if name == "e2e":
-            continue
-        for dep in deps:
-            assert (
-                "matrix-nio" not in dep
-            ), f"extra {name} unexpectedly contains matrix-nio: {dep}"
-            assert (
-                "mindroom-nio" not in dep
-            ), f"extra {name} unexpectedly contains mindroom-nio: {dep}"
 
 
 def test_both_providers_installed_disables_e2ee_even_with_crypto(monkeypatch):

--- a/tests/test_matrix_compat.py
+++ b/tests/test_matrix_compat.py
@@ -1,4 +1,3 @@
-import re
 from types import SimpleNamespace
 
 import pytest

--- a/tests/test_matrix_compat.py
+++ b/tests/test_matrix_compat.py
@@ -15,12 +15,13 @@ def reset_capability_cache():
 
 def _patch_detection(
     monkeypatch: pytest.MonkeyPatch,
-    distributions: dict[str, str],
+    distributions: dict[str, str | None],
     modules: dict[str, object],
 ) -> None:
     def fake_version(distribution_name: str) -> str:
-        if distribution_name in distributions:
-            return distributions[distribution_name]
+        version = distributions.get(distribution_name)
+        if version is not None:
+            return version
         raise compat.metadata.PackageNotFoundError(distribution_name)
 
     def fake_import_module(module_name: str) -> object:
@@ -166,12 +167,16 @@ def test_detect_provider_nio_fallback(monkeypatch):
 
 def test_detect_provider_unavailable(monkeypatch):
     """When no nio module or distribution is found, provider should be 'unavailable'."""
-    monkeypatch.setattr(compat.metadata, "version", lambda _: None)
-    monkeypatch.setattr(
-        compat.importlib,
-        "import_module",
-        lambda _: (_ for _ in ()).throw(ImportError("no module")),
-    )
+    from typing import NoReturn
+
+    def raise_not_found(name: str) -> NoReturn:
+        raise compat.metadata.PackageNotFoundError(name)
+
+    def raise_import_error(name: str) -> NoReturn:
+        raise ImportError(f"No module named {name!r}")
+
+    monkeypatch.setattr(compat.metadata, "version", raise_not_found)
+    monkeypatch.setattr(compat.importlib, "import_module", raise_import_error)
 
     caps = compat.detect_matrix_capabilities()
     assert caps.provider_name == "unavailable"

--- a/tests/test_matrix_compat.py
+++ b/tests/test_matrix_compat.py
@@ -1,3 +1,4 @@
+import re
 from types import SimpleNamespace
 
 import pytest
@@ -66,7 +67,9 @@ def test_detects_matrix_nio_without_olm(monkeypatch):
 
     assert capabilities.provider_distribution == "matrix-nio"
     assert capabilities.encryption_available is False
-    assert "python-olm" in compat.format_e2ee_unavailable_message(capabilities)
+    message = compat.format_e2ee_unavailable_message(capabilities)
+    assert "python-olm" in message
+    assert "matrix-nio" in message
 
 
 def test_detects_mindroom_vodozemac_backend(monkeypatch):
@@ -108,8 +111,10 @@ def test_detects_mindroom_without_vodozemac(monkeypatch):
 
     assert capabilities.provider_distribution == "mindroom-nio"
     assert capabilities.encryption_available is False
-    assert "vodozemac" in compat.format_e2ee_unavailable_message(capabilities)
-    assert "python-olm" not in compat.format_e2ee_unavailable_message(capabilities)
+    message = compat.format_e2ee_unavailable_message(capabilities)
+    assert "vodozemac" in message
+    assert "mindroom" in message
+    assert "python-olm" not in message
     assert "mindroom-nio[e2e]" in compat.format_e2ee_install_command(capabilities)
     assert "alongside matrix-nio" in compat.format_e2ee_install_command(capabilities)
 
@@ -125,6 +130,7 @@ def test_reports_multiple_known_provider_distributions(monkeypatch):
 
     assert capabilities.provider_distribution == "unknown"
     assert capabilities.both_known_providers_installed is True
+    assert capabilities.encryption_available is False
     assert "matrix-nio=0.25.2" in capabilities.provider_version
     assert "mindroom-nio=0.25.2" in capabilities.provider_version
     message = compat.format_e2ee_unavailable_message(capabilities)
@@ -132,3 +138,79 @@ def test_reports_multiple_known_provider_distributions(monkeypatch):
     assert "both installed" in message
     assert "uninstall one nio namespace owner" in message
     assert "Uninstall either matrix-nio or mindroom-nio first" in install_command
+
+
+def _read_pyproject_deps():
+    """Read pyproject.toml and extract dependencies and optional-dependencies."""
+    try:
+        import tomllib
+    except ImportError:
+        import tomli as tomllib
+
+    with open("pyproject.toml", "rb") as f:
+        data = tomllib.load(f)
+    return data.get("project", {})
+
+
+def test_default_dependency_is_mindroom_not_matrix_nio():
+    project = _read_pyproject_deps()
+    deps = project.get("dependencies", [])
+    assert any("mindroom-nio" in dep for dep in deps)
+    assert not any("matrix-nio" in dep for dep in deps)
+
+
+def test_e2e_extra_points_to_mindroom():
+    extras = _read_pyproject_deps().get("optional-dependencies", {})
+    e2e_deps = extras.get("e2e", [])
+    assert any("mindroom-nio[e2e]" in dep for dep in e2e_deps)
+
+
+def test_legacy_matrix_nio_extras_exist():
+    extras = _read_pyproject_deps().get("optional-dependencies", {})
+    matrix_nio_deps = extras.get("matrix-nio", [])
+    assert any("matrix-nio==" in dep for dep in matrix_nio_deps)
+    matrix_nio_e2e_deps = extras.get("matrix-nio-e2e", [])
+    assert any("matrix-nio[e2e]" in dep for dep in matrix_nio_e2e_deps)
+
+
+def test_no_extra_installs_both_providers():
+    extras = _read_pyproject_deps().get("optional-dependencies", {}).values()
+    for deps in extras:
+        has_matrix = any("matrix-nio" in dep for dep in deps)
+        has_mindroom = any("mindroom-nio" in dep for dep in deps)
+        assert not (
+            has_matrix and has_mindroom
+        ), f"extra {deps} installs both matrix-nio and mindroom-nio"
+
+
+def test_both_providers_installed_disables_e2ee_even_with_crypto(monkeypatch):
+    _patch_detection(
+        monkeypatch,
+        {"matrix-nio": "0.25.2", "mindroom-nio": "0.25.2"},
+        {
+            "nio": SimpleNamespace(
+                AsyncClient=type("AsyncClient", (), {}),
+                crypto=SimpleNamespace(
+                    ENCRYPTION_ENABLED=True,
+                    OlmDevice=object,
+                ),
+                api=SimpleNamespace(Api=type("Api_dummy", (), {})),
+                store=SimpleNamespace(SqliteStore=object),
+            ),
+            "nio.api": SimpleNamespace(Api=type("Api_dummy", (), {})),
+            "nio.crypto": SimpleNamespace(
+                ENCRYPTION_ENABLED=True,
+                OlmDevice=object,
+            ),
+            "nio.store": SimpleNamespace(SqliteStore=object),
+            "olm": SimpleNamespace(),
+            "vodozemac": SimpleNamespace(),
+        },
+    )
+
+    capabilities = compat.detect_matrix_capabilities()
+
+    assert capabilities.both_known_providers_installed is True
+    assert capabilities.encryption_available is False
+    assert capabilities.crypto_backend != "olm"
+    assert capabilities.crypto_backend != "vodozemac"

--- a/tests/test_matrix_compat.py
+++ b/tests/test_matrix_compat.py
@@ -116,7 +116,7 @@ def test_detects_mindroom_without_vodozemac(monkeypatch):
     assert "mindroom" in message
     assert "python-olm" not in message
     assert "mindroom-nio[e2e]" in compat.format_e2ee_install_command(capabilities)
-    assert "alongside matrix-nio" in compat.format_e2ee_install_command(capabilities)
+    assert "mmrelay[e2e]" in compat.format_e2ee_install_command(capabilities)
 
 
 def test_reports_multiple_known_provider_distributions(monkeypatch):

--- a/tests/test_matrix_compat.py
+++ b/tests/test_matrix_compat.py
@@ -110,6 +110,8 @@ def test_detects_mindroom_without_vodozemac(monkeypatch):
     assert capabilities.encryption_available is False
     assert "vodozemac" in compat.format_e2ee_unavailable_message(capabilities)
     assert "python-olm" not in compat.format_e2ee_unavailable_message(capabilities)
+    assert "mindroom-nio[e2e]" in compat.format_e2ee_install_command(capabilities)
+    assert "alongside matrix-nio" in compat.format_e2ee_install_command(capabilities)
 
 
 def test_reports_multiple_known_provider_distributions(monkeypatch):
@@ -125,3 +127,8 @@ def test_reports_multiple_known_provider_distributions(monkeypatch):
     assert capabilities.both_known_providers_installed is True
     assert "matrix-nio=0.25.2" in capabilities.provider_version
     assert "mindroom-nio=0.25.2" in capabilities.provider_version
+    message = compat.format_e2ee_unavailable_message(capabilities)
+    install_command = compat.format_e2ee_install_command(capabilities)
+    assert "both installed" in message
+    assert "uninstall one nio namespace owner" in message
+    assert "Uninstall either matrix-nio or mindroom-nio first" in install_command

--- a/tests/test_matrix_compat.py
+++ b/tests/test_matrix_compat.py
@@ -143,3 +143,562 @@ def test_matrix_nio_install_guidance_does_not_recommend_mmrelay_e2e(monkeypatch)
     assert "controlled replacement" in cmd
     assert "Do not install mmrelay[e2e]" in cmd
     assert "mmrelay[e2e]" not in cmd.replace("Do not install mmrelay[e2e]", "")
+
+
+def test_detect_provider_nio_fallback(monkeypatch):
+    """When only a bare 'nio' module is importable (no known dist), provider should be 'nio'."""
+    _patch_detection(
+        monkeypatch,
+        {"matrix-nio": None, "mindroom-nio": None},
+        {
+            "nio": SimpleNamespace(AsyncClient=type("AsyncClient", (), {})),
+            "nio.crypto": None,
+            "nio.store": None,
+            "nio.api": None,
+        },
+    )
+
+    caps = compat.detect_matrix_capabilities()
+    assert caps.provider_name == "nio"
+    assert caps.provider_distribution == "unknown"
+    assert caps.encryption_available is False
+
+
+def test_detect_provider_unavailable(monkeypatch):
+    """When no nio module or distribution is found, provider should be 'unavailable'."""
+    monkeypatch.setattr(compat.metadata, "version", lambda _: None)
+    monkeypatch.setattr(
+        compat.importlib,
+        "import_module",
+        lambda _: (_ for _ in ()).throw(ImportError("no module")),
+    )
+
+    caps = compat.detect_matrix_capabilities()
+    assert caps.provider_name == "unavailable"
+    assert caps.provider_distribution == "unknown"
+    assert caps.encryption_available is False
+
+
+def test_e2ee_install_guidance_fallback(monkeypatch):
+    """When provider is unknown and no crypto backend detected, should return generic guidance."""
+    _patch_detection(
+        monkeypatch,
+        {"matrix-nio": None, "mindroom-nio": None},
+        {
+            "nio": SimpleNamespace(AsyncClient=type("AsyncClient", (), {})),
+            "nio.crypto": None,
+            "nio.store": None,
+            "nio.api": None,
+        },
+    )
+
+    caps = compat.detect_matrix_capabilities()
+    cmd = compat.format_e2ee_install_command(caps)
+    assert "E2EE extra" in cmd
+
+
+def test_detect_matrix_capabilities_mindroom_nio_ready(monkeypatch):
+    """mindroom-nio with vodozemac ready should report encryption_available=True."""
+    _patch_detection(
+        monkeypatch,
+        {"mindroom-nio": "0.25.2"},
+        {
+            "nio": SimpleNamespace(
+                AsyncClient=type("AsyncClient", (), {}),
+                crypto=SimpleNamespace(ENCRYPTION_ENABLED=True),
+                store=SimpleNamespace(SqliteStore=object),
+            ),
+            "nio.crypto": SimpleNamespace(ENCRYPTION_ENABLED=True),
+            "nio.store": SimpleNamespace(SqliteStore=object),
+            "nio.api": SimpleNamespace(
+                Api=type(
+                    "Api_dummy",
+                    (),
+                    {
+                        "update_receipt_marker": lambda *a: None,
+                        "download": lambda *a, allow_remote=None: None,
+                    },
+                ),
+            ),
+            "vodozemac": SimpleNamespace(),
+        },
+    )
+
+    caps = compat.detect_matrix_capabilities()
+    assert caps.provider_distribution == "mindroom-nio"
+    assert caps.crypto_backend == "vodozemac"
+    assert caps.encryption_available is True
+
+
+def test_detect_matrix_capabilities_mindroom_nio_partial(monkeypatch):
+    """mindroom-nio with vodozemac present but not fully ready should report encryption_available=False."""
+    _patch_detection(
+        monkeypatch,
+        {"mindroom-nio": "0.25.2"},
+        {
+            "nio": SimpleNamespace(
+                AsyncClient=type("AsyncClient", (), {}),
+                crypto=SimpleNamespace(ENCRYPTION_ENABLED=False),
+                store=SimpleNamespace(SqliteStore=object),
+            ),
+            "nio.crypto": SimpleNamespace(ENCRYPTION_ENABLED=False),
+            "nio.store": SimpleNamespace(SqliteStore=object),
+            "nio.api": SimpleNamespace(
+                Api=type(
+                    "Api_dummy",
+                    (),
+                    {
+                        "update_receipt_marker": lambda *a: None,
+                        "download": lambda *a, allow_remote=None: None,
+                    },
+                ),
+            ),
+            "vodozemac": SimpleNamespace(),
+        },
+    )
+
+    caps = compat.detect_matrix_capabilities()
+    assert caps.provider_distribution == "mindroom-nio"
+    assert caps.crypto_backend == "vodozemac"
+    assert caps.encryption_available is False
+
+
+def test_detect_matrix_capabilities_mindroom_nio_no_crypto(monkeypatch):
+    """mindroom-nio without vodozemac but with nio.crypto should report backend=unavailable."""
+    _patch_detection(
+        monkeypatch,
+        {"mindroom-nio": "0.25.2"},
+        {
+            "nio": SimpleNamespace(
+                AsyncClient=type("AsyncClient", (), {}),
+                crypto=SimpleNamespace(),
+                store=SimpleNamespace(SqliteStore=object),
+            ),
+            "nio.crypto": SimpleNamespace(),
+            "nio.store": SimpleNamespace(SqliteStore=object),
+            "nio.api": SimpleNamespace(
+                Api=type(
+                    "Api_dummy",
+                    (),
+                    {
+                        "update_receipt_marker": lambda *a: None,
+                        "download": lambda *a, allow_remote=None: None,
+                    },
+                ),
+            ),
+        },
+    )
+
+    caps = compat.detect_matrix_capabilities()
+    assert caps.provider_distribution == "mindroom-nio"
+    assert caps.crypto_backend == "unavailable"
+    assert caps.encryption_available is False
+
+
+def test_detect_matrix_capabilities_mindroom_nio_nothing(monkeypatch):
+    """mindroom-nio without any crypto modules should report backend=unknown."""
+    _patch_detection(
+        monkeypatch,
+        {"mindroom-nio": "0.25.2"},
+        {
+            "nio": SimpleNamespace(AsyncClient=type("AsyncClient", (), {})),
+            "nio.api": SimpleNamespace(
+                Api=type(
+                    "Api_dummy",
+                    (),
+                    {
+                        "update_receipt_marker": lambda *a: None,
+                        "download": lambda *a, allow_remote=None: None,
+                    },
+                ),
+            ),
+        },
+    )
+
+    caps = compat.detect_matrix_capabilities()
+    assert caps.provider_distribution == "mindroom-nio"
+    assert caps.crypto_backend == "unknown"
+    assert caps.encryption_available is False
+
+
+def test_detect_matrix_capabilities_matrix_nio_ready(monkeypatch):
+    """matrix-nio with olm fully ready should report encryption_available=True."""
+    _patch_detection(
+        monkeypatch,
+        {"matrix-nio": "0.25.2"},
+        {
+            "nio": SimpleNamespace(
+                AsyncClient=type("AsyncClient", (), {}),
+                crypto=SimpleNamespace(OlmDevice=object),
+                store=SimpleNamespace(SqliteStore=object),
+            ),
+            "nio.crypto": SimpleNamespace(OlmDevice=object),
+            "nio.store": SimpleNamespace(SqliteStore=object),
+            "nio.api": SimpleNamespace(
+                Api=type(
+                    "Api_dummy",
+                    (),
+                    {
+                        "update_receipt_marker": lambda *a: None,
+                        "download": lambda *a, allow_remote=None: None,
+                    },
+                ),
+            ),
+            "olm": SimpleNamespace(),
+        },
+    )
+
+    caps = compat.detect_matrix_capabilities()
+    assert caps.provider_distribution == "matrix-nio"
+    assert caps.crypto_backend == "olm"
+    assert caps.encryption_available is True
+
+
+def test_detect_matrix_capabilities_matrix_nio_unavailable(monkeypatch):
+    """matrix-nio with nio.crypto but no olm/vodozemac should report backend=unavailable."""
+    _patch_detection(
+        monkeypatch,
+        {"matrix-nio": "0.25.2"},
+        {
+            "nio": SimpleNamespace(
+                AsyncClient=type("AsyncClient", (), {}),
+                crypto=SimpleNamespace(),
+                store=SimpleNamespace(SqliteStore=object),
+            ),
+            "nio.crypto": SimpleNamespace(),
+            "nio.store": SimpleNamespace(SqliteStore=object),
+            "nio.api": SimpleNamespace(
+                Api=type(
+                    "Api_dummy",
+                    (),
+                    {
+                        "update_receipt_marker": lambda *a: None,
+                        "download": lambda *a, allow_remote=None: None,
+                    },
+                ),
+            ),
+        },
+    )
+
+    caps = compat.detect_matrix_capabilities()
+    assert caps.provider_distribution == "matrix-nio"
+    assert caps.crypto_backend == "unavailable"
+    assert caps.encryption_available is False
+
+
+def test_detect_matrix_capabilities_matrix_nio_unknown(monkeypatch):
+    """matrix-nio with no nio.crypto module should report backend=unknown."""
+    _patch_detection(
+        monkeypatch,
+        {"matrix-nio": "0.25.2"},
+        {
+            "nio": SimpleNamespace(AsyncClient=type("AsyncClient", (), {})),
+            "nio.api": SimpleNamespace(
+                Api=type(
+                    "Api_dummy",
+                    (),
+                    {
+                        "update_receipt_marker": lambda *a: None,
+                        "download": lambda *a, allow_remote=None: None,
+                    },
+                ),
+            ),
+        },
+    )
+
+    caps = compat.detect_matrix_capabilities()
+    assert caps.provider_distribution == "matrix-nio"
+    assert caps.crypto_backend == "unknown"
+    assert caps.encryption_available is False
+
+
+def test_detect_matrix_capabilities_fallthrough_vodozemac_ready(monkeypatch):
+    """Unknown provider with vodozemac ready should fall through to vodozemac=True."""
+    _patch_detection(
+        monkeypatch,
+        {"matrix-nio": None, "mindroom-nio": None},
+        {
+            "nio": SimpleNamespace(
+                AsyncClient=type("AsyncClient", (), {}),
+                crypto=SimpleNamespace(ENCRYPTION_ENABLED=True),
+                store=SimpleNamespace(SqliteStore=object),
+            ),
+            "nio.crypto": SimpleNamespace(ENCRYPTION_ENABLED=True),
+            "nio.store": SimpleNamespace(SqliteStore=object),
+            "nio.api": SimpleNamespace(
+                Api=type(
+                    "Api_dummy",
+                    (),
+                    {
+                        "update_receipt_marker": lambda *a: None,
+                        "download": lambda *a, allow_remote=None: None,
+                    },
+                ),
+            ),
+            "vodozemac": SimpleNamespace(),
+        },
+    )
+
+    caps = compat.detect_matrix_capabilities()
+    assert caps.crypto_backend == "vodozemac"
+    assert caps.encryption_available is True
+
+
+def test_detect_matrix_capabilities_fallthrough_olm_ready(monkeypatch):
+    """Unknown provider with olm ready should fall through to olm=True."""
+    _patch_detection(
+        monkeypatch,
+        {"matrix-nio": None, "mindroom-nio": None},
+        {
+            "nio": SimpleNamespace(
+                AsyncClient=type("AsyncClient", (), {}),
+                crypto=SimpleNamespace(OlmDevice=object),
+                store=SimpleNamespace(SqliteStore=object),
+            ),
+            "nio.crypto": SimpleNamespace(OlmDevice=object),
+            "nio.store": SimpleNamespace(SqliteStore=object),
+            "nio.api": SimpleNamespace(
+                Api=type(
+                    "Api_dummy",
+                    (),
+                    {
+                        "update_receipt_marker": lambda *a: None,
+                        "download": lambda *a, allow_remote=None: None,
+                    },
+                ),
+            ),
+            "olm": SimpleNamespace(),
+        },
+    )
+
+    caps = compat.detect_matrix_capabilities()
+    assert caps.crypto_backend == "olm"
+    assert caps.encryption_available is True
+
+
+def test_detect_matrix_capabilities_fallthrough_partial_vodozemac(monkeypatch):
+    """Unknown provider with partial vodozemac should report encryption_available=False."""
+    _patch_detection(
+        monkeypatch,
+        {"matrix-nio": None, "mindroom-nio": None},
+        {
+            "nio": SimpleNamespace(
+                AsyncClient=type("AsyncClient", (), {}),
+                crypto=SimpleNamespace(ENCRYPTION_ENABLED=False),
+                store=SimpleNamespace(SqliteStore=object),
+            ),
+            "nio.crypto": SimpleNamespace(ENCRYPTION_ENABLED=False),
+            "nio.store": SimpleNamespace(SqliteStore=object),
+            "nio.api": SimpleNamespace(
+                Api=type(
+                    "Api_dummy",
+                    (),
+                    {
+                        "update_receipt_marker": lambda *a: None,
+                        "download": lambda *a, allow_remote=None: None,
+                    },
+                ),
+            ),
+            "vodozemac": SimpleNamespace(),
+        },
+    )
+
+    caps = compat.detect_matrix_capabilities()
+    assert caps.crypto_backend == "vodozemac"
+    assert caps.encryption_available is False
+
+
+def test_detect_matrix_capabilities_fallthrough_partial_olm(monkeypatch):
+    """Unknown provider with partial olm (no sqlite store) should report encryption_available=False."""
+    _patch_detection(
+        monkeypatch,
+        {"matrix-nio": None, "mindroom-nio": None},
+        {
+            "nio": SimpleNamespace(
+                AsyncClient=type("AsyncClient", (), {}),
+                crypto=SimpleNamespace(OlmDevice=object),
+            ),
+            "nio.crypto": SimpleNamespace(OlmDevice=object),
+            "nio.api": SimpleNamespace(
+                Api=type(
+                    "Api_dummy",
+                    (),
+                    {
+                        "update_receipt_marker": lambda *a: None,
+                        "download": lambda *a, allow_remote=None: None,
+                    },
+                ),
+            ),
+            "olm": SimpleNamespace(),
+        },
+    )
+
+    caps = compat.detect_matrix_capabilities()
+    assert caps.crypto_backend == "olm"
+    assert caps.encryption_available is False
+
+
+def test_detect_matrix_capabilities_fallthrough_unavailable(monkeypatch):
+    """Unknown provider with nio.crypto but no olm/vodozemac should report unavailable."""
+    _patch_detection(
+        monkeypatch,
+        {"matrix-nio": None, "mindroom-nio": None},
+        {
+            "nio": SimpleNamespace(
+                AsyncClient=type("AsyncClient", (), {}),
+                crypto=SimpleNamespace(),
+                store=SimpleNamespace(SqliteStore=object),
+            ),
+            "nio.crypto": SimpleNamespace(),
+            "nio.store": SimpleNamespace(SqliteStore=object),
+            "nio.api": SimpleNamespace(
+                Api=type(
+                    "Api_dummy",
+                    (),
+                    {
+                        "update_receipt_marker": lambda *a: None,
+                        "download": lambda *a, allow_remote=None: None,
+                    },
+                ),
+            ),
+        },
+    )
+
+    caps = compat.detect_matrix_capabilities()
+    assert caps.crypto_backend == "unavailable"
+    assert caps.encryption_available is False
+
+
+def test_detect_matrix_capabilities_fallthrough_unknown(monkeypatch):
+    """Unknown provider with no crypto modules should report unknown."""
+    _patch_detection(
+        monkeypatch,
+        {"matrix-nio": None, "mindroom-nio": None},
+        {
+            "nio": SimpleNamespace(AsyncClient=type("AsyncClient", (), {})),
+            "nio.api": SimpleNamespace(
+                Api=type(
+                    "Api_dummy",
+                    (),
+                    {
+                        "update_receipt_marker": lambda *a: None,
+                        "download": lambda *a, allow_remote=None: None,
+                    },
+                ),
+            ),
+        },
+    )
+
+    caps = compat.detect_matrix_capabilities()
+    assert caps.crypto_backend == "unknown"
+    assert caps.encryption_available is False
+
+
+def test_supports_authenticated_media_exception(monkeypatch):
+    """When inspect.signature raises TypeError/ValueError, supports_authenticated_media should be False."""
+
+    class BadApi:
+        @staticmethod
+        def download(*args, **kwargs):
+            pass
+
+    monkeypatch.setattr(
+        compat.inspect,
+        "signature",
+        lambda _: (_ for _ in ()).throw(TypeError("not callable")),
+    )
+
+    _patch_detection(
+        monkeypatch,
+        {"matrix-nio": "0.25.2"},
+        {
+            "nio": SimpleNamespace(AsyncClient=type("AsyncClient", (), {})),
+            "nio.crypto": SimpleNamespace(OlmDevice=object),
+            "nio.store": SimpleNamespace(SqliteStore=object),
+            "nio.api": SimpleNamespace(Api=BadApi),
+            "olm": SimpleNamespace(),
+        },
+    )
+
+    caps = compat.detect_matrix_capabilities()
+    assert caps.supports_authenticated_media is False
+
+
+def test_format_e2ee_unavailable_message_conflict(monkeypatch):
+    """format_e2ee_unavailable_message should return conflict message when both providers installed."""
+    _patch_detection(
+        monkeypatch,
+        {"matrix-nio": "0.25.2", "mindroom-nio": "0.25.2"},
+        {
+            "nio": SimpleNamespace(AsyncClient=type("AsyncClient", (), {})),
+            "nio.crypto": SimpleNamespace(OlmDevice=object),
+            "nio.store": SimpleNamespace(SqliteStore=object),
+            "nio.api": SimpleNamespace(Api=type("Api_dummy", (), {})),
+            "olm": SimpleNamespace(),
+            "vodozemac": SimpleNamespace(),
+        },
+    )
+
+    msg = compat.format_e2ee_unavailable_message()
+    assert "both installed" in msg
+    assert "matrix-nio and mindroom-nio" in msg
+
+
+def test_format_e2ee_install_command_fallback(monkeypatch):
+    """format_e2ee_install_command should return generic guidance for unknown providers."""
+    _patch_detection(
+        monkeypatch,
+        {"matrix-nio": None, "mindroom-nio": None},
+        {
+            "nio": SimpleNamespace(AsyncClient=type("AsyncClient", (), {})),
+            "nio.crypto": SimpleNamespace(),
+            "nio.store": SimpleNamespace(SqliteStore=object),
+            "nio.api": SimpleNamespace(
+                Api=type(
+                    "Api_dummy",
+                    (),
+                    {
+                        "update_receipt_marker": lambda *a: None,
+                        "download": lambda *a, allow_remote=None: None,
+                    },
+                ),
+            ),
+        },
+    )
+
+    caps = compat.detect_matrix_capabilities()
+    cmd = compat.format_e2ee_install_command(caps)
+    assert "E2EE extra" in cmd
+
+
+def test_format_e2ee_install_command_mindroom_nio(monkeypatch):
+    """format_e2ee_install_command should return mindroom-nio guidance for mindroom-nio provider."""
+    _patch_detection(
+        monkeypatch,
+        {"mindroom-nio": "0.25.2"},
+        {
+            "nio": SimpleNamespace(
+                AsyncClient=type("AsyncClient", (), {}),
+                crypto=SimpleNamespace(ENCRYPTION_ENABLED=True),
+                store=SimpleNamespace(SqliteStore=object),
+            ),
+            "nio.crypto": SimpleNamespace(ENCRYPTION_ENABLED=True),
+            "nio.store": SimpleNamespace(SqliteStore=object),
+            "nio.api": SimpleNamespace(
+                Api=type(
+                    "Api_dummy",
+                    (),
+                    {
+                        "update_receipt_marker": lambda *a: None,
+                        "download": lambda *a, allow_remote=None: None,
+                    },
+                ),
+            ),
+            "vodozemac": SimpleNamespace(),
+        },
+    )
+
+    caps = compat.detect_matrix_capabilities()
+    cmd = compat.format_e2ee_install_command(caps)
+    assert "mmrelay[e2e]" in cmd
+    assert "pipx" in cmd

--- a/tests/test_matrix_utils_auth_e2ee.py
+++ b/tests/test_matrix_utils_auth_e2ee.py
@@ -1171,3 +1171,243 @@ async def test_login_matrix_bot_e2ee_config_load_exception_disables_e2ee(
         "E2EE disabled in configuration" in call.args[0]
         for call in mock_logger.debug.call_args_list
     )
+
+
+@pytest.mark.asyncio
+async def test_connect_matrix_e2ee_makedirs_oserror_disables(
+    mock_logger,
+    mock_async_client,
+    mock_ssl_context,
+    _mock_makedirs,
+):
+    """OSError from makedirs should disable E2EE and set store_path to None."""
+    mock_ssl_context.return_value = MagicMock()
+    _mock_makedirs.side_effect = OSError("Permission denied")
+
+    mock_client_instance = MagicMock()
+    mock_client_instance.rooms = {}
+    mock_client_instance.sync = AsyncMock(return_value=MagicMock())
+    mock_client_instance.whoami = AsyncMock(
+        return_value=SimpleNamespace(device_id="DEV")
+    )
+    mock_client_instance.should_upload_keys = False
+    mock_client_instance.get_displayname = AsyncMock(
+        return_value=SimpleNamespace(displayname="Bot")
+    )
+    mock_async_client.return_value = mock_client_instance
+
+    test_config = {
+        "matrix": {
+            "homeserver": "https://matrix.example.org",
+            "access_token": "test_token",
+            "bot_user_id": "@bot:example.org",
+            "encryption": {"enabled": True, "store_path": "/test/store"},
+        },
+        "matrix_rooms": [{"id": "!room:matrix.org", "meshtastic_channel": 0}],
+    }
+
+    with (
+        patch("mmrelay.config.is_e2ee_enabled", return_value=True),
+        patch(
+            "mmrelay.e2ee_utils.get_e2ee_status", return_value={"overall_status": "ok"}
+        ),
+        patch("mmrelay.e2ee_utils.get_room_encryption_warnings", return_value=[]),
+        patch(
+            "mmrelay.matrix_utils._resolve_aliases_in_mapping",
+            new_callable=AsyncMock,
+            return_value=None,
+        ),
+        patch(
+            "mmrelay.matrix_utils._display_room_channel_mappings",
+            return_value=None,
+        ),
+        patch("mmrelay.matrix_utils.matrix_client", None),
+    ):
+        await connect_matrix(test_config)
+
+    assert any(
+        "Could not create E2EE store directory" in call.args[0]
+        for call in mock_logger.error.call_args_list
+    )
+
+
+@pytest.mark.asyncio
+async def test_connect_matrix_e2ee_store_inspection_oserror_disables(
+    mock_logger,
+    mock_async_client,
+    mock_ssl_context,
+    _mock_makedirs,
+    mock_exists,
+    mock_listdir,
+):
+    """OSError from store inspection should disable E2EE."""
+    mock_ssl_context.return_value = MagicMock()
+    mock_exists.return_value = True
+    mock_listdir.side_effect = OSError("I/O error")
+
+    mock_client_instance = MagicMock()
+    mock_client_instance.rooms = {}
+    mock_client_instance.sync = AsyncMock(return_value=MagicMock())
+    mock_client_instance.whoami = AsyncMock(
+        return_value=SimpleNamespace(device_id="DEV")
+    )
+    mock_client_instance.should_upload_keys = False
+    mock_client_instance.get_displayname = AsyncMock(
+        return_value=SimpleNamespace(displayname="Bot")
+    )
+    mock_async_client.return_value = mock_client_instance
+
+    test_config = {
+        "matrix": {
+            "homeserver": "https://matrix.example.org",
+            "access_token": "test_token",
+            "bot_user_id": "@bot:example.org",
+            "encryption": {"enabled": True, "store_path": "/test/store"},
+        },
+        "matrix_rooms": [{"id": "!room:matrix.org", "meshtastic_channel": 0}],
+    }
+
+    with (
+        patch("mmrelay.config.is_e2ee_enabled", return_value=True),
+        patch(
+            "mmrelay.e2ee_utils.get_e2ee_status", return_value={"overall_status": "ok"}
+        ),
+        patch("mmrelay.e2ee_utils.get_room_encryption_warnings", return_value=[]),
+        patch(
+            "mmrelay.matrix_utils._resolve_aliases_in_mapping",
+            new_callable=AsyncMock,
+            return_value=None,
+        ),
+        patch(
+            "mmrelay.matrix_utils._display_room_channel_mappings",
+            return_value=None,
+        ),
+        patch("mmrelay.matrix_utils.matrix_client", None),
+    ):
+        await connect_matrix(test_config)
+
+    assert any(
+        "Could not inspect E2EE store" in call.args[0]
+        for call in mock_logger.error.call_args_list
+    )
+
+
+@pytest.mark.asyncio
+async def test_connect_matrix_e2ee_missing_device_id_logs(
+    mock_logger,
+    mock_async_client,
+    mock_ssl_context,
+    mock_exists,
+    mock_listdir,
+    _mock_makedirs,
+):
+    """Missing device_id in credentials should log a debug message."""
+    mock_ssl_context.return_value = MagicMock()
+    mock_exists.return_value = False
+    mock_listdir.return_value = []
+
+    mock_client_instance = MagicMock()
+    mock_client_instance.rooms = {}
+    mock_client_instance.sync = AsyncMock(return_value=MagicMock())
+    mock_client_instance.whoami = AsyncMock(
+        return_value=SimpleNamespace(device_id="DEV")
+    )
+    mock_client_instance.should_upload_keys = False
+    mock_client_instance.get_displayname = AsyncMock(
+        return_value=SimpleNamespace(displayname="Bot")
+    )
+    mock_async_client.return_value = mock_client_instance
+
+    test_config = {
+        "matrix": {
+            "homeserver": "https://matrix.example.org",
+            "access_token": "test_token",
+            "bot_user_id": "@bot:example.org",
+            "encryption": {"enabled": True, "store_path": "/test/store"},
+        },
+        "matrix_rooms": [{"id": "!room:matrix.org", "meshtastic_channel": 0}],
+    }
+
+    with (
+        patch("mmrelay.config.is_e2ee_enabled", return_value=True),
+        patch(
+            "mmrelay.e2ee_utils.get_e2ee_status", return_value={"overall_status": "ok"}
+        ),
+        patch("mmrelay.e2ee_utils.get_room_encryption_warnings", return_value=[]),
+        patch(
+            "mmrelay.matrix_utils._resolve_aliases_in_mapping",
+            new_callable=AsyncMock,
+            return_value=None,
+        ),
+        patch(
+            "mmrelay.matrix_utils._display_room_channel_mappings",
+            return_value=None,
+        ),
+        patch("mmrelay.matrix_utils.matrix_client", None),
+        patch(
+            "mmrelay.matrix_utils.async_load_credentials",
+            new=AsyncMock(return_value={"homeserver": "https://matrix.example.org"}),
+        ),
+    ):
+        await connect_matrix(test_config)
+
+    assert any(
+        "No device_id in credentials" in call.args[0]
+        for call in mock_logger.debug.call_args_list
+    )
+
+
+@pytest.mark.asyncio
+async def test_connect_matrix_e2ee_config_keyerror_handler(
+    mock_logger,
+    mock_async_client,
+    mock_ssl_context,
+):
+    """KeyError in config processing should log warning and disable E2EE."""
+    mock_ssl_context.return_value = MagicMock()
+
+    mock_client_instance = MagicMock()
+    mock_client_instance.rooms = {}
+    mock_client_instance.sync = AsyncMock(return_value=MagicMock())
+    mock_client_instance.whoami = AsyncMock(
+        return_value=SimpleNamespace(device_id="DEV")
+    )
+    mock_client_instance.should_upload_keys = False
+    mock_client_instance.get_displayname = AsyncMock(
+        return_value=SimpleNamespace(displayname="Bot")
+    )
+    mock_async_client.return_value = mock_client_instance
+
+    test_config = {
+        "matrix": {
+            "homeserver": "https://matrix.example.org",
+            "access_token": "test_token",
+            "bot_user_id": "@bot:example.org",
+            "encryption": {"enabled": True, "store_path": "/test/store"},
+        },
+        "matrix_rooms": [{"id": "!room:matrix.org", "meshtastic_channel": 0}],
+    }
+
+    with (
+        patch("mmrelay.config.is_e2ee_enabled", side_effect=KeyError("missing")),
+        patch(
+            "mmrelay.e2ee_utils.get_e2ee_status", return_value={"overall_status": "ok"}
+        ),
+        patch("mmrelay.e2ee_utils.get_room_encryption_warnings", return_value=[]),
+        patch(
+            "mmrelay.matrix_utils._resolve_aliases_in_mapping",
+            new_callable=AsyncMock,
+            return_value=None,
+        ),
+        patch(
+            "mmrelay.matrix_utils._display_room_channel_mappings",
+            return_value=None,
+        ),
+        patch("mmrelay.matrix_utils.matrix_client", None),
+    ):
+        await connect_matrix(test_config)
+
+    assert any(
+        "Failed to determine E2EE status from config" in call.args[0]
+        for call in mock_logger.warning.call_args_list
+    )

--- a/tests/test_matrix_utils_auth_e2ee.py
+++ b/tests/test_matrix_utils_auth_e2ee.py
@@ -20,6 +20,37 @@ from mmrelay.matrix_utils import (
 pytestmark = pytest.mark.asyncio
 
 
+def _matrix_capabilities(
+    *,
+    encryption_available: bool = True,
+    provider_distribution: str = "matrix-nio",
+    crypto_backend: str = "olm",
+    install_hint: str = "install matrix-nio[e2e] / python-olm",
+    recommended_e2ee_extra: str = "matrix-nio[e2e]",
+    both_known_providers_installed: bool = False,
+):
+    return SimpleNamespace(
+        encryption_available=encryption_available,
+        provider_distribution=provider_distribution,
+        provider_name=provider_distribution,
+        provider_version="0.25.2",
+        crypto_backend=crypto_backend,
+        install_hint=install_hint,
+        recommended_e2ee_extra=recommended_e2ee_extra,
+        both_known_providers_installed=both_known_providers_installed,
+    )
+
+
+@pytest.fixture(autouse=True)
+def matrix_capabilities_available(monkeypatch):
+    """Keep E2EE auth tests independent from the developer environment."""
+
+    monkeypatch.setattr(
+        "mmrelay.matrix.auth.get_matrix_capabilities",
+        lambda: _matrix_capabilities(),
+    )
+
+
 async def test_on_decryption_failure():
     """Test on_decryption_failure handles decryption failures with retry logic."""
 
@@ -494,21 +525,9 @@ async def test_connect_matrix_e2ee_store_path_from_config(monkeypatch):
         return_value=SimpleNamespace(displayname="Bot")
     )
 
-    def fake_import(name):
-        if name == "nio.crypto":
-            return SimpleNamespace(OlmDevice=True)
-        if name == "nio.store":
-            return SimpleNamespace(SqliteStore=True)
-        if name == "olm":
-            return MagicMock()
-        return MagicMock()
-
     monkeypatch.setattr("mmrelay.matrix_utils.sys.platform", "linux", raising=False)
     monkeypatch.setattr(
         "mmrelay.config.is_e2ee_enabled", lambda _cfg: True, raising=False
-    )
-    monkeypatch.setattr(
-        "mmrelay.matrix_utils.importlib.import_module", fake_import, raising=False
     )
     monkeypatch.setattr(
         "mmrelay.matrix_utils._create_ssl_context", lambda: MagicMock(), raising=False
@@ -571,21 +590,9 @@ async def test_connect_matrix_e2ee_store_path_precedence_encryption(monkeypatch)
         return_value=SimpleNamespace(displayname="Bot")
     )
 
-    def fake_import(name):
-        if name == "nio.crypto":
-            return SimpleNamespace(OlmDevice=True)
-        if name == "nio.store":
-            return SimpleNamespace(SqliteStore=True)
-        if name == "olm":
-            return MagicMock()
-        return MagicMock()
-
     monkeypatch.setattr("mmrelay.matrix_utils.sys.platform", "linux", raising=False)
     monkeypatch.setattr(
         "mmrelay.config.is_e2ee_enabled", lambda _cfg: True, raising=False
-    )
-    monkeypatch.setattr(
-        "mmrelay.matrix_utils.importlib.import_module", fake_import, raising=False
     )
     monkeypatch.setattr(
         "mmrelay.matrix_utils._create_ssl_context", lambda: MagicMock(), raising=False
@@ -650,21 +657,9 @@ async def test_connect_matrix_e2ee_store_path_uses_e2ee_section(monkeypatch):
         return_value=SimpleNamespace(displayname="Bot")
     )
 
-    def fake_import(name):
-        if name == "nio.crypto":
-            return SimpleNamespace(OlmDevice=True)
-        if name == "nio.store":
-            return SimpleNamespace(SqliteStore=True)
-        if name == "olm":
-            return MagicMock()
-        return MagicMock()
-
     monkeypatch.setattr("mmrelay.matrix_utils.sys.platform", "linux", raising=False)
     monkeypatch.setattr(
         "mmrelay.config.is_e2ee_enabled", lambda _cfg: True, raising=False
-    )
-    monkeypatch.setattr(
-        "mmrelay.matrix_utils.importlib.import_module", fake_import, raising=False
     )
     monkeypatch.setattr(
         "mmrelay.matrix_utils._create_ssl_context", lambda: MagicMock(), raising=False
@@ -727,21 +722,9 @@ async def test_connect_matrix_e2ee_store_path_default(monkeypatch, tmp_path):
         return_value=SimpleNamespace(displayname="Bot")
     )
 
-    def fake_import(name):
-        if name == "nio.crypto":
-            return SimpleNamespace(OlmDevice=True)
-        if name == "nio.store":
-            return SimpleNamespace(SqliteStore=True)
-        if name == "olm":
-            return MagicMock()
-        return MagicMock()
-
     monkeypatch.setattr("mmrelay.matrix_utils.sys.platform", "linux", raising=False)
     monkeypatch.setattr(
         "mmrelay.config.is_e2ee_enabled", lambda _cfg: True, raising=False
-    )
-    monkeypatch.setattr(
-        "mmrelay.matrix_utils.importlib.import_module", fake_import, raising=False
     )
     monkeypatch.setattr(
         "mmrelay.matrix_utils._create_ssl_context", lambda: MagicMock(), raising=False
@@ -880,30 +863,8 @@ async def test_connect_matrix_e2ee_store_missing_db_files_warns(
         "matrix_rooms": [{"id": "!room:matrix.org", "meshtastic_channel": 0}],
     }
 
-    mock_olm = MagicMock()
-    import importlib as _importlib
-
-    real_import_module = _importlib.import_module
-
-    def mock_import_side_effect(module_name, *args, **kwargs):
-        if module_name == "olm":
-            return mock_olm
-        if module_name == "nio.crypto":
-            mock_crypto = MagicMock()
-            mock_crypto.OlmDevice = MagicMock()
-            return mock_crypto
-        if module_name == "nio.store":
-            mock_store = MagicMock()
-            mock_store.SqliteStore = MagicMock()
-            return mock_store
-        return real_import_module(module_name, *args, **kwargs)
-
     with (
         patch("mmrelay.config.is_e2ee_enabled", return_value=True),
-        patch(
-            "mmrelay.matrix_utils.importlib.import_module",
-            side_effect=mock_import_side_effect,
-        ),
         patch(
             "mmrelay.e2ee_utils.get_e2ee_status", return_value={"overall_status": "ok"}
         ),
@@ -967,31 +928,9 @@ async def test_connect_matrix_e2ee_key_sharing_delay(monkeypatch, tmp_path):
     )
     monkeypatch.setattr("mmrelay.matrix_utils.matrix_client", None, raising=False)
 
-    mock_olm = MagicMock()
-    import importlib as _importlib
-
-    real_import_module = _importlib.import_module
-
-    def mock_import_side_effect(module_name, *args, **kwargs):
-        if module_name == "olm":
-            return mock_olm
-        if module_name == "nio.crypto":
-            mock_crypto = MagicMock()
-            mock_crypto.OlmDevice = MagicMock()
-            return mock_crypto
-        if module_name == "nio.store":
-            mock_store = MagicMock()
-            mock_store.SqliteStore = MagicMock()
-            return mock_store
-        return real_import_module(module_name, *args, **kwargs)
-
     sleep_mock = AsyncMock()
     with (
         patch("mmrelay.config.is_e2ee_enabled", return_value=True),
-        patch(
-            "mmrelay.matrix_utils.importlib.import_module",
-            side_effect=mock_import_side_effect,
-        ),
         patch(
             "mmrelay.e2ee_utils.get_e2ee_status", return_value={"overall_status": "ok"}
         ),
@@ -1040,27 +979,16 @@ async def test_connect_matrix_e2ee_missing_nio_crypto():
         patch("mmrelay.matrix_utils.AsyncClient") as mock_async_client,
         patch("mmrelay.matrix_utils.logger") as mock_logger,
         patch("mmrelay.matrix_utils._create_ssl_context"),
-        patch("mmrelay.matrix_utils.importlib.import_module") as mock_import,
+        patch(
+            "mmrelay.matrix.auth.get_matrix_capabilities",
+            return_value=_matrix_capabilities(encryption_available=False),
+        ),
         patch(
             "mmrelay.matrix_utils.async_load_credentials",
             new=AsyncMock(return_value=None),
         ),
         patch("mmrelay.matrix_utils.os.path.isfile", return_value=False),
     ):
-        # Mock importlib to simulate missing nio.crypto
-        def mock_import_side_effect(module_name):
-            if module_name == "olm":
-                return MagicMock()  # olm is available
-            elif module_name == "nio.crypto":
-                mock_crypto = MagicMock()
-                mock_crypto.OlmDevice = MagicMock()
-                # Remove OlmDevice attribute
-                del mock_crypto.OlmDevice
-                return mock_crypto
-            return MagicMock()
-
-        mock_import.side_effect = mock_import_side_effect
-
         # Mock AsyncClient instance
         mock_client_instance = MagicMock()
         mock_client_instance.rooms = {}
@@ -1102,31 +1030,16 @@ async def test_connect_matrix_e2ee_missing_sqlite_store():
         patch("mmrelay.matrix_utils.AsyncClient") as mock_async_client,
         patch("mmrelay.matrix_utils.logger") as mock_logger,
         patch("mmrelay.matrix_utils._create_ssl_context"),
-        patch("mmrelay.matrix_utils.importlib.import_module") as mock_import,
+        patch(
+            "mmrelay.matrix.auth.get_matrix_capabilities",
+            return_value=_matrix_capabilities(encryption_available=False),
+        ),
         patch(
             "mmrelay.matrix_utils.async_load_credentials",
             new=AsyncMock(return_value=None),
         ),
         patch("mmrelay.matrix_utils.os.path.isfile", return_value=False),
     ):
-        # Mock importlib to simulate missing nio.store.SqliteStore
-        def mock_import_side_effect(module_name):
-            if module_name == "olm":
-                return MagicMock()  # olm is available
-            elif module_name == "nio.crypto":
-                mock_crypto = MagicMock()
-                mock_crypto.OlmDevice = MagicMock()
-                return mock_crypto
-            elif module_name == "nio.store":
-                mock_store = MagicMock()
-                mock_store.SqliteStore = MagicMock()
-                # Remove SqliteStore attribute
-                del mock_store.SqliteStore
-                return mock_store
-            return MagicMock()
-
-        mock_import.side_effect = mock_import_side_effect
-
         # Mock AsyncClient instance
         mock_client_instance = MagicMock()
         mock_client_instance.rooms = {}

--- a/tests/test_matrix_utils_auth_e2ee.py
+++ b/tests/test_matrix_utils_auth_e2ee.py
@@ -1223,8 +1223,9 @@ async def test_connect_matrix_e2ee_makedirs_oserror_disables(
         ),
         patch("mmrelay.matrix_utils.matrix_client", None),
     ):
-        await connect_matrix(test_config)
+        result = await connect_matrix(test_config)
 
+    assert result == mock_client_instance
     assert any(
         "Could not create E2EE store directory" in call.args[0]
         for call in mock_logger.error.call_args_list
@@ -1284,8 +1285,9 @@ async def test_connect_matrix_e2ee_store_inspection_oserror_disables(
         ),
         patch("mmrelay.matrix_utils.matrix_client", None),
     ):
-        await connect_matrix(test_config)
+        result = await connect_matrix(test_config)
 
+    assert result == mock_client_instance
     assert any(
         "Could not inspect E2EE store" in call.args[0]
         for call in mock_logger.error.call_args_list
@@ -1362,6 +1364,7 @@ async def test_connect_matrix_e2ee_config_keyerror_handler(
     mock_logger,
     mock_async_client,
     mock_ssl_context,
+    _mock_makedirs,
 ):
     """KeyError in config processing should log warning and disable E2EE."""
     mock_ssl_context.return_value = MagicMock()
@@ -1405,8 +1408,9 @@ async def test_connect_matrix_e2ee_config_keyerror_handler(
         ),
         patch("mmrelay.matrix_utils.matrix_client", None),
     ):
-        await connect_matrix(test_config)
+        result = await connect_matrix(test_config)
 
+    assert result == mock_client_instance
     assert any(
         "Failed to determine E2EE status from config" in call.args[0]
         for call in mock_logger.warning.call_args_list

--- a/tests/test_matrix_utils_auth_e2ee.py
+++ b/tests/test_matrix_utils_auth_e2ee.py
@@ -1080,7 +1080,7 @@ async def test_connect_matrix_e2ee_missing_nio_crypto():
         # Should still create client but with E2EE disabled
         assert result == mock_client_instance
         # Should log exception about missing nio.crypto.OlmDevice
-        mock_logger.exception.assert_called_with("Missing E2EE dependency")
+        mock_logger.error.assert_any_call("Missing E2EE dependency")
 
 
 async def test_connect_matrix_e2ee_missing_sqlite_store():
@@ -1146,7 +1146,7 @@ async def test_connect_matrix_e2ee_missing_sqlite_store():
         # Should still create client but with E2EE disabled
         assert result == mock_client_instance
         # Should log exception about missing nio.store.SqliteStore
-        mock_logger.exception.assert_called_with("Missing E2EE dependency")
+        mock_logger.error.assert_any_call("Missing E2EE dependency")
 
 
 TEST_HOMESERVER = "https://matrix.org"

--- a/tests/test_matrix_utils_auth_e2ee.py
+++ b/tests/test_matrix_utils_auth_e2ee.py
@@ -28,7 +28,7 @@ def _matrix_capabilities(
     install_hint: str = "install matrix-nio[e2e] / python-olm",
     recommended_e2ee_extra: str = "matrix-nio[e2e]",
     both_known_providers_installed: bool = False,
-):
+) -> SimpleNamespace:
     return SimpleNamespace(
         encryption_available=encryption_available,
         provider_distribution=provider_distribution,
@@ -580,8 +580,8 @@ async def test_connect_matrix_e2ee_store_path_from_config(monkeypatch):
     assert client_calls[0]["store_path"] == store_path
 
 
-async def test_connect_matrix_e2ee_store_path_precedence_encryption(monkeypatch):
-    """Encryption store_path should take precedence over e2ee store_path."""
+async def test_connect_matrix_e2ee_store_path_precedence_e2ee(monkeypatch):
+    """e2ee store_path should take precedence over encryption store_path."""
     mock_client = MagicMock()
     mock_client.rooms = {}
     mock_client.sync = AsyncMock(return_value=SimpleNamespace())
@@ -644,7 +644,7 @@ async def test_connect_matrix_e2ee_store_path_precedence_encryption(monkeypatch)
         await connect_matrix(config)
 
     assert client_calls
-    assert client_calls[0]["store_path"] == encryption_path
+    assert client_calls[0]["store_path"] == e2ee_path
 
 
 async def test_connect_matrix_e2ee_store_path_uses_e2ee_section(monkeypatch):

--- a/tests/test_matrix_utils_connect_e2ee.py
+++ b/tests/test_matrix_utils_connect_e2ee.py
@@ -619,7 +619,7 @@ class TestMatrixE2EEHasAttrChecks:
             await connect_matrix(e2ee_config)
 
             # Verify ImportError was logged and E2EE was disabled
-            mock_logger.exception.assert_called_with("Missing E2EE dependency")
+            mock_logger.error.assert_any_call("Missing E2EE dependency")
             mock_logger.error.assert_called_with(
                 "Please reinstall with: pipx install 'mmrelay[e2e]'"
             )
@@ -681,7 +681,7 @@ class TestMatrixE2EEHasAttrChecks:
             await connect_matrix(e2ee_config)
 
             # Verify ImportError was logged and E2EE was disabled
-            mock_logger.exception.assert_called_with("Missing E2EE dependency")
+            mock_logger.error.assert_any_call("Missing E2EE dependency")
             mock_logger.error.assert_called_with(
                 "Please reinstall with: pipx install 'mmrelay[e2e]'"
             )

--- a/tests/test_matrix_utils_connect_e2ee.py
+++ b/tests/test_matrix_utils_connect_e2ee.py
@@ -22,7 +22,7 @@ def _matrix_capabilities(
     install_hint: str = "install matrix-nio[e2e] / python-olm",
     recommended_e2ee_extra: str = "matrix-nio[e2e]",
     both_known_providers_installed: bool = False,
-):
+) -> SimpleNamespace:
     return SimpleNamespace(
         encryption_available=encryption_available,
         provider_distribution=provider_distribution,

--- a/tests/test_matrix_utils_connect_e2ee.py
+++ b/tests/test_matrix_utils_connect_e2ee.py
@@ -14,6 +14,37 @@ from mmrelay.constants.app import CREDENTIALS_FILENAME
 from mmrelay.matrix_utils import connect_matrix
 
 
+def _matrix_capabilities(
+    *,
+    encryption_available: bool = True,
+    provider_distribution: str = "matrix-nio",
+    crypto_backend: str = "olm",
+    install_hint: str = "install matrix-nio[e2e] / python-olm",
+    recommended_e2ee_extra: str = "matrix-nio[e2e]",
+    both_known_providers_installed: bool = False,
+):
+    return SimpleNamespace(
+        encryption_available=encryption_available,
+        provider_distribution=provider_distribution,
+        provider_name=provider_distribution,
+        provider_version="0.25.2",
+        crypto_backend=crypto_backend,
+        install_hint=install_hint,
+        recommended_e2ee_extra=recommended_e2ee_extra,
+        both_known_providers_installed=both_known_providers_installed,
+    )
+
+
+@pytest.fixture(autouse=True)
+def matrix_capabilities_available(monkeypatch):
+    """Keep E2EE connect tests independent from the developer environment."""
+
+    monkeypatch.setattr(
+        "mmrelay.matrix.auth.get_matrix_capabilities",
+        lambda: _matrix_capabilities(),
+    )
+
+
 @pytest.mark.asyncio
 @patch("mmrelay.matrix_utils.os.makedirs")
 @patch("mmrelay.matrix_utils.os.listdir")
@@ -161,30 +192,6 @@ async def test_connect_matrix_uploads_keys_when_needed(monkeypatch):
         raising=False,
     )
 
-    def fake_import(name):
-        """Return a fake module-like object used to simulate imports of nio/olm modules in tests.
-
-        Parameters:
-            name (str): Module name being imported.
-
-        Returns:
-            object: A module-like object:
-              - For "nio.crypto": a SimpleNamespace with attribute `OlmDevice` set to True.
-              - For "nio.store": a SimpleNamespace with attribute `SqliteStore` set to True.
-              - For "olm": a MagicMock instance.
-              - For any other name: a MagicMock instance.
-        """
-        if name == "nio.crypto":
-            return SimpleNamespace(OlmDevice=True)
-        if name == "nio.store":
-            return SimpleNamespace(SqliteStore=True)
-        if name == "olm":
-            return MagicMock()
-        return MagicMock()
-
-    monkeypatch.setattr(
-        "mmrelay.matrix_utils.importlib.import_module", fake_import, raising=False
-    )
     monkeypatch.setattr(
         "mmrelay.matrix_utils.get_room_encryption_warnings",
         lambda *_args, **_kwargs: [],
@@ -419,18 +426,6 @@ async def test_connect_matrix_keys_upload_failure_logs(monkeypatch):
         return_value=SimpleNamespace(displayname="Bot")
     )
 
-    def fake_import(name):
-        if name == "nio.crypto":
-            return SimpleNamespace(OlmDevice=True)
-        if name == "nio.store":
-            return SimpleNamespace(SqliteStore=True)
-        if name == "olm":
-            return MagicMock()
-        return MagicMock()
-
-    monkeypatch.setattr(
-        "mmrelay.matrix_utils.importlib.import_module", fake_import, raising=False
-    )
     monkeypatch.setattr(
         "mmrelay.config.is_e2ee_enabled", lambda _cfg: True, raising=False
     )
@@ -512,7 +507,10 @@ class TestMatrixE2EEHasAttrChecks:
             patch("mmrelay.matrix_utils.matrix_client", None),
             patch("mmrelay.matrix_utils.AsyncClient") as mock_async_client,
             patch("mmrelay.matrix_utils.logger"),
-            patch("mmrelay.matrix_utils.importlib.import_module") as mock_import,
+            patch(
+                "mmrelay.matrix.auth.get_matrix_capabilities",
+                return_value=_matrix_capabilities(),
+            ) as mock_capabilities,
         ):
             # Mock AsyncClient instance with proper async methods
             mock_client_instance = MagicMock()
@@ -527,43 +525,12 @@ class TestMatrixE2EEHasAttrChecks:
             mock_client_instance.keys_upload = AsyncMock()
             mock_async_client.return_value = mock_client_instance
 
-            # Create mock modules with required attributes
-            mock_olm = SimpleNamespace()
-            mock_nio_crypto = SimpleNamespace(OlmDevice=MagicMock())
-            mock_nio_store = SimpleNamespace(SqliteStore=MagicMock())
-
-            def import_side_effect(name):
-                """Return a mock module object for the specified import name to simulate E2EE dependencies in tests.
-
-                Parameters:
-                    name (str): Fully qualified module name ('olm', 'nio.crypto', or 'nio.store').
-
-                Returns:
-                    object: The mock module corresponding to the requested name.
-
-                Raises:
-                    ImportError: If the requested name is not a supported mock module.
-                """
-                if name == "olm":
-                    return mock_olm
-                elif name == "nio.crypto":
-                    return mock_nio_crypto
-                elif name == "nio.store":
-                    return mock_nio_store
-                else:
-                    # For any other import, raise ImportError to simulate missing dependency
-                    raise ImportError(f"No module named '{name}'")
-
-            mock_import.side_effect = import_side_effect
-
             # Run the async function
             await connect_matrix(e2ee_config)
 
             # Verify client was created and E2EE dependencies were checked
             mock_async_client.assert_called_once()
-            expected_imports = {"olm", "nio.crypto", "nio.store"}
-            actual_imports = {call.args[0] for call in mock_import.call_args_list}
-            assert expected_imports.issubset(actual_imports)
+            mock_capabilities.assert_called()
 
     async def test_connect_matrix_hasattr_checks_missing_olmdevice(self, e2ee_config):
         """Test hasattr check failure when nio.crypto.OlmDevice is missing"""
@@ -571,7 +538,10 @@ class TestMatrixE2EEHasAttrChecks:
             patch("mmrelay.matrix_utils.matrix_client", None),
             patch("mmrelay.matrix_utils.AsyncClient") as mock_async_client,
             patch("mmrelay.matrix_utils.logger") as mock_logger,
-            patch("mmrelay.matrix_utils.importlib.import_module") as mock_import,
+            patch(
+                "mmrelay.matrix.auth.get_matrix_capabilities",
+                return_value=_matrix_capabilities(encryption_available=False),
+            ),
         ):
             # Mock AsyncClient instance with proper async methods
             mock_client_instance = MagicMock()
@@ -585,43 +555,13 @@ class TestMatrixE2EEHasAttrChecks:
             )
             mock_async_client.return_value = mock_client_instance
 
-            # Create mock modules where nio.crypto lacks OlmDevice
-            mock_olm = SimpleNamespace()
-            mock_nio_crypto = SimpleNamespace()
-            # Simulate missing OlmDevice attribute to exercise hasattr failure
-            mock_nio_store = SimpleNamespace(SqliteStore=MagicMock())
-
-            def import_side_effect(name):
-                """Return a mock module object for the specified import name to simulate E2EE dependencies in tests.
-
-                Parameters:
-                    name (str): Fully qualified module name ('olm', 'nio.crypto', or 'nio.store').
-
-                Returns:
-                    object: The mock module corresponding to the requested name.
-
-                Raises:
-                    ImportError: If the requested name is not a supported mock module.
-                """
-                if name == "olm":
-                    return mock_olm
-                elif name == "nio.crypto":
-                    return mock_nio_crypto
-                elif name == "nio.store":
-                    return mock_nio_store
-                else:
-                    # For any other import, raise ImportError to simulate missing dependency
-                    raise ImportError(f"No module named '{name}'")
-
-            mock_import.side_effect = import_side_effect
-
             # Run the async function
             await connect_matrix(e2ee_config)
 
             # Verify ImportError was logged and E2EE was disabled
             mock_logger.error.assert_any_call("Missing E2EE dependency")
-            mock_logger.error.assert_called_with(
-                "Please reinstall with: pipx install 'mmrelay[e2e]'"
+            mock_logger.error.assert_any_call(
+                "Install E2EE support: pipx install 'mmrelay[e2e]'"
             )
             mock_logger.warning.assert_called_with(
                 "E2EE will be disabled for this session."
@@ -633,7 +573,10 @@ class TestMatrixE2EEHasAttrChecks:
             patch("mmrelay.matrix_utils.matrix_client", None),
             patch("mmrelay.matrix_utils.AsyncClient") as mock_async_client,
             patch("mmrelay.matrix_utils.logger") as mock_logger,
-            patch("mmrelay.matrix_utils.importlib.import_module") as mock_import,
+            patch(
+                "mmrelay.matrix.auth.get_matrix_capabilities",
+                return_value=_matrix_capabilities(encryption_available=False),
+            ),
         ):
             # Mock AsyncClient instance with proper async methods
             mock_client_instance = MagicMock()
@@ -647,43 +590,13 @@ class TestMatrixE2EEHasAttrChecks:
             )
             mock_async_client.return_value = mock_client_instance
 
-            # Create mock modules where nio.store lacks SqliteStore
-            mock_olm = SimpleNamespace()
-            mock_nio_crypto = SimpleNamespace(OlmDevice=MagicMock())
-            # Simulate missing SqliteStore attribute to exercise hasattr failure
-            mock_nio_store = SimpleNamespace()
-
-            def import_side_effect(name):
-                """Provide a mock module for simulating E2EE dependencies during tests.
-
-                Parameters:
-                    name (str): Fully qualified module name to mock (e.g., 'olm', 'nio.crypto', or 'nio.store').
-
-                Returns:
-                    object: The mock module corresponding to the requested name.
-
-                Raises:
-                    ImportError: If the requested name is not a supported mock module.
-                """
-                if name == "olm":
-                    return mock_olm
-                elif name == "nio.crypto":
-                    return mock_nio_crypto
-                elif name == "nio.store":
-                    return mock_nio_store
-                else:
-                    # For any other import, raise ImportError to simulate missing dependency
-                    raise ImportError(f"No module named '{name}'")
-
-            mock_import.side_effect = import_side_effect
-
             # Run the async function
             await connect_matrix(e2ee_config)
 
             # Verify ImportError was logged and E2EE was disabled
             mock_logger.error.assert_any_call("Missing E2EE dependency")
-            mock_logger.error.assert_called_with(
-                "Please reinstall with: pipx install 'mmrelay[e2e]'"
+            mock_logger.error.assert_any_call(
+                "Install E2EE support: pipx install 'mmrelay[e2e]'"
             )
             mock_logger.warning.assert_called_with(
                 "E2EE will be disabled for this session."

--- a/tests/test_matrix_utils_connect_e2ee.py
+++ b/tests/test_matrix_utils_connect_e2ee.py
@@ -561,7 +561,9 @@ class TestMatrixE2EEHasAttrChecks:
             # Verify ImportError was logged and E2EE was disabled
             mock_logger.error.assert_any_call("Missing E2EE dependency")
             mock_logger.error.assert_any_call(
-                "Install E2EE support: pipx install 'mmrelay[e2e]'"
+                "Install matrix-nio E2EE in a controlled replacement environment: "
+                "pip install 'matrix-nio[e2e]==0.25.2'. "
+                "Do not install mmrelay[e2e] (it uses mindroom-nio)."
             )
             mock_logger.warning.assert_called_with(
                 "E2EE will be disabled for this session."
@@ -596,7 +598,9 @@ class TestMatrixE2EEHasAttrChecks:
             # Verify ImportError was logged and E2EE was disabled
             mock_logger.error.assert_any_call("Missing E2EE dependency")
             mock_logger.error.assert_any_call(
-                "Install E2EE support: pipx install 'mmrelay[e2e]'"
+                "Install matrix-nio E2EE in a controlled replacement environment: "
+                "pip install 'matrix-nio[e2e]==0.25.2'. "
+                "Do not install mmrelay[e2e] (it uses mindroom-nio)."
             )
             mock_logger.warning.assert_called_with(
                 "E2EE will be disabled for this session."


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Overview

This PR introduces a Matrix compatibility layer and switches the default E2EE provider from matrix-nio (python-olm) to mindroom-nio (vodozemac). It centralizes provider detection and capability reporting in mmrelay.matrix.compat, replaces scattered runtime import probing with capability-driven checks, updates packaging and documentation to reflect the new default, and updates CLI, diagnostics and tests to be provider-aware and to handle dual-provider conflicts.

Key changes

Features
- Compatibility layer: src/mmrelay/matrix/compat.py
  - New MatrixLibraryCapabilities dataclass and detection API: detect_matrix_capabilities(), get_matrix_capabilities(), reset_matrix_capabilities_cache().
  - Provider and backend typing (ProviderDistribution, CryptoBackend) and many capability flags (encryption_available, store/sqlite availability, olm/vodozemac presence, nio_crypto flags, supports_stop_sync_forever, supports_thread_receipts, supports_authenticated_media).
  - Deterministic handling when both known providers are installed (conflict result).
  - Formatting helpers: format_e2ee_unavailable_message() and format_e2ee_install_command() to produce provider-aware guidance.
- Default provider and packaging update:
  - pyproject.toml now declares mindroom-nio==0.25.2 as the default Matrix SDK and updates the e2e extra to mindroom-nio[e2e]==0.25.2.
- Documentation:
  - docs/dev/MATRIX_DUAL_LIBRARY_COMPATIBILITY_PLAN.md (compatibility contract, testing checklist).
  - docs/E2EE.md and docs/MIGRATION_1.3.md updated to document default provider, legacy workflow, namespace-conflict warnings, Windows native-lib notes, and compat-driven troubleshooting.
- Tests:
  - New tests/test_matrix_compat.py and many updates across tests to mock the compat layer (instead of patching imports), assert packaging constraints, and verify provider-aware guidance and conflict behavior.

Refactors
- Replace ad-hoc import probing with capability API across codebase:
  - src/mmrelay/cli.py: use get_matrix_capabilities() for E2EE readiness checks, provider-agnostic messaging, and formatted install commands; update environment/system-health output.
  - src/mmrelay/e2ee_utils.py: compute dependency/credential status and messages from MatrixLibraryCapabilities; use compat formatters for user guidance.
  - src/mmrelay/matrix/auth.py: decide E2EE enablement from capabilities; improved logging, provider/version/backend reporting, move filesystem store inspection to asyncio.to_thread, and explicit OSError handling that can disable E2EE.
- Tests refactored to patch capability objects or detection functions instead of manipulating import state/sys.modules; added helper factories and autouse fixtures for deterministic test scenarios.

Fixes / Improvements
- Provider-aware error/guidance messages when crypto dependencies are missing or when both providers are present.
- CLI/system-health output standardized to "Installed / Not installed" and includes compat-generated install commands.
- Dual-provider detection: when both matrix-nio and mindroom-nio are present, encryption is disabled and users receive deterministic conflict diagnostics and uninstall guidance.
- Logging and tests updated to expect error-level diagnostics (instead of exception traces) for missing E2EE dependencies.

Breaking changes / migration notes
- Default dependency change: mmrelay now targets mindroom-nio==0.25.2 and mindroom-nio[e2e]==0.25.2 in pyproject.toml.
- Do not install both matrix-nio and mindroom-nio in the same environment — having both installed disables E2EE and the runtime will emit conflict diagnostics. If you require the legacy matrix-nio provider, install matrix-nio[e2e] manually in a separate environment and follow the documented controlled-replacement guidance.
- Windows: native C crypto libraries are required for E2EE backends; messaging clarifies platform limitations but behavior is unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->