### PR TITLE
Add reply-ID-aware reaction relaying and message ID parsing

### DIFF
--- a/src/mmrelay/matrix/events.py
+++ b/src/mmrelay/matrix/events.py
@@ -30,6 +30,7 @@ except ImportError:
 from nio.events.room_events import RoomMemberEvent
 
 import mmrelay.matrix_utils as facade
+from mmrelay.constants.formats import MATRIX_SUPPRESS_KEY
 
 __all__ = [
     "on_decryption_failure",
@@ -313,7 +314,7 @@ async def on_room_message(
     shortname = event.source["content"].get("meshtastic_shortname", None)
     meshnet_name = event.source["content"].get("meshtastic_meshnet")
     meshtastic_replyId = event.source["content"].get("meshtastic_replyId")
-    suppress = event.source["content"].get("mmrelay_suppress")
+    suppress = event.source["content"].get(MATRIX_SUPPRESS_KEY)
 
     text = ""
 
@@ -432,19 +433,18 @@ async def on_room_message(
 
             if isinstance(meshtastic_id_raw, int):
                 meshtastic_reply_id = meshtastic_id_raw
+            elif isinstance(meshtastic_id_raw, str) and meshtastic_id_raw.isdigit():
+                meshtastic_reply_id = int(meshtastic_id_raw)
             elif isinstance(meshtastic_id_raw, str):
-                try:
-                    meshtastic_reply_id = int(meshtastic_id_raw, 0)
-                except ValueError:
-                    facade.logger.warning(
-                        "Message map meshtastic_id %r is not numeric; sending reaction as regular message",
-                        meshtastic_id_raw,
-                    )
-                    meshtastic_reply_id = None
-            else:
                 facade.logger.warning(
                     "Message map meshtastic_id %r is not numeric; sending reaction as regular message",
                     meshtastic_id_raw,
+                )
+                meshtastic_reply_id = None
+            else:
+                facade.logger.warning(
+                    "Message map meshtastic_id has unexpected type %s; sending reaction as regular message",
+                    type(meshtastic_id_raw).__name__,
                 )
                 meshtastic_reply_id = None
 

--- a/src/mmrelay/matrix/events.py
+++ b/src/mmrelay/matrix/events.py
@@ -424,11 +424,23 @@ async def on_room_message(
                 return
 
             (
-                _meshtastic_id,
+                meshtastic_id_raw,
                 _matrix_room_id,
                 meshtastic_text_db,
                 _meshtastic_meshnet_db,
             ) = orig
+
+            if isinstance(meshtastic_id_raw, int):
+                meshtastic_reply_id = meshtastic_id_raw
+            elif isinstance(meshtastic_id_raw, str) and meshtastic_id_raw.isdigit():
+                meshtastic_reply_id = int(meshtastic_id_raw)
+            else:
+                facade.logger.warning(
+                    "Message map meshtastic_id %r is not numeric; sending reaction as regular message",
+                    meshtastic_id_raw,
+                )
+                meshtastic_reply_id = None
+
             full_display_name = await facade.get_user_display_name(room, event)
 
             prefix = facade.get_meshtastic_prefix(facade.config, full_display_name)
@@ -462,18 +474,34 @@ async def on_room_message(
                 facade.DEFAULT_BROADCAST_ENABLED,
                 required=False,
             ):
-                meshtastic_logger.info(
-                    f"Relaying reaction from {full_display_name} to radio broadcast"
-                )
-                facade.logger.debug(
-                    f"Sending reaction to Meshtastic with meshnet={local_meshnet_name}: {reaction_message}"
-                )
-                success = facade.queue_message(
-                    meshtastic_interface.sendText,
-                    text=reaction_message,
-                    channelIndex=meshtastic_channel,
-                    description=f"Local reaction from {full_display_name}",
-                )
+                if meshtastic_reply_id is not None:
+                    meshtastic_logger.info(
+                        f"Relaying reaction from {full_display_name} to radio broadcast as reply"
+                    )
+                    facade.logger.debug(
+                        f"Sending reaction reply to Meshtastic message {meshtastic_reply_id}: {reaction_message}"
+                    )
+                    success = facade.queue_message(
+                        facade.send_text_reply,
+                        meshtastic_interface,
+                        text=reaction_message,
+                        reply_id=meshtastic_reply_id,
+                        channelIndex=meshtastic_channel,
+                        description=f"Local reaction from {full_display_name} (reply to {meshtastic_reply_id})",
+                    )
+                else:
+                    meshtastic_logger.info(
+                        f"Relaying reaction from {full_display_name} to radio broadcast"
+                    )
+                    facade.logger.debug(
+                        f"Sending reaction to Meshtastic with meshnet={local_meshnet_name}: {reaction_message}"
+                    )
+                    success = facade.queue_message(
+                        meshtastic_interface.sendText,
+                        text=reaction_message,
+                        channelIndex=meshtastic_channel,
+                        description=f"Local reaction from {full_display_name}",
+                    )
 
                 if success:
                     facade.logger.debug(

--- a/src/mmrelay/matrix/events.py
+++ b/src/mmrelay/matrix/events.py
@@ -432,8 +432,15 @@ async def on_room_message(
 
             if isinstance(meshtastic_id_raw, int):
                 meshtastic_reply_id = meshtastic_id_raw
-            elif isinstance(meshtastic_id_raw, str) and meshtastic_id_raw.isdigit():
-                meshtastic_reply_id = int(meshtastic_id_raw)
+            elif isinstance(meshtastic_id_raw, str):
+                try:
+                    meshtastic_reply_id = int(meshtastic_id_raw, 0)
+                except ValueError:
+                    facade.logger.warning(
+                        "Message map meshtastic_id %r is not numeric; sending reaction as regular message",
+                        meshtastic_id_raw,
+                    )
+                    meshtastic_reply_id = None
             else:
                 facade.logger.warning(
                     "Message map meshtastic_id %r is not numeric; sending reaction as regular message",
@@ -483,7 +490,7 @@ async def on_room_message(
                     )
                     success = facade.queue_message(
                         facade.send_text_reply,
-                        meshtastic_interface,
+                        interface=meshtastic_interface,
                         text=reaction_message,
                         reply_id=meshtastic_reply_id,
                         channelIndex=meshtastic_channel,

--- a/src/mmrelay/plugins/base_plugin.py
+++ b/src/mmrelay/plugins/base_plugin.py
@@ -33,6 +33,7 @@ from mmrelay.constants.database import (
     DEFAULT_TEXT_TRUNCATION_LENGTH,
 )
 from mmrelay.constants.domain import MATRIX_EVENT_TYPE_ROOM_MESSAGE
+from mmrelay.constants.formats import MATRIX_SUPPRESS_KEY
 from mmrelay.constants.plugins import (
     DEFAULT_PLUGIN_PRIORITY,
     PLUGIN_TYPE_COMMUNITY,
@@ -792,7 +793,7 @@ class BasePlugin(ABC):
                 "event_id": event_id,
                 "key": emoji,
             },
-            "mmrelay_suppress": True,
+            MATRIX_SUPPRESS_KEY: True,
         }
         try:
             await matrix_client.room_send(

--- a/src/mmrelay/plugins/base_plugin.py
+++ b/src/mmrelay/plugins/base_plugin.py
@@ -791,7 +791,8 @@ class BasePlugin(ABC):
                 "rel_type": "m.annotation",
                 "event_id": event_id,
                 "key": emoji,
-            }
+            },
+            "mmrelay_suppress": True,
         }
         try:
             await matrix_client.room_send(

--- a/tests/test_base_plugin.py
+++ b/tests/test_base_plugin.py
@@ -1816,6 +1816,7 @@ class TestBasePlugin(unittest.TestCase):
                 call_kwargs["content"]["m.relates_to"]["event_id"], "$event_id"
             )
             self.assertEqual(call_kwargs["content"]["m.relates_to"]["key"], "✅")
+            self.assertTrue(call_kwargs["content"]["mmrelay_suppress"])
 
         asyncio.run(run_test())
 

--- a/tests/test_base_plugin.py
+++ b/tests/test_base_plugin.py
@@ -29,6 +29,7 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
 from mmrelay.constants.config import CONFIG_KEY_REQUIRE_BOT_MENTION
 from mmrelay.constants.database import DEFAULT_MAX_DATA_ROWS_PER_NODE_BASE
 from mmrelay.constants.domain import MATRIX_EVENT_TYPE_ROOM_MESSAGE
+from mmrelay.constants.formats import MATRIX_SUPPRESS_KEY
 from mmrelay.constants.network import MINIMUM_MESSAGE_DELAY
 from mmrelay.constants.plugins import DEFAULT_PLUGIN_PRIORITY
 from mmrelay.plugins.base_plugin import BasePlugin
@@ -1816,7 +1817,7 @@ class TestBasePlugin(unittest.TestCase):
                 call_kwargs["content"]["m.relates_to"]["event_id"], "$event_id"
             )
             self.assertEqual(call_kwargs["content"]["m.relates_to"]["key"], "✅")
-            self.assertTrue(call_kwargs["content"]["mmrelay_suppress"])
+            self.assertTrue(call_kwargs["content"][MATRIX_SUPPRESS_KEY])
 
         asyncio.run(run_test())
 

--- a/tests/test_matrix_utils_relay.py
+++ b/tests/test_matrix_utils_relay.py
@@ -1,6 +1,7 @@
 import asyncio
 import contextlib
 from types import SimpleNamespace
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import nio
@@ -23,6 +24,7 @@ from mmrelay.matrix_utils import (
     bot_command,
     matrix_relay,
     on_room_message,
+    send_text_reply,
 )
 from tests.constants import (
     TEST_BOT_USER_ID,
@@ -1227,15 +1229,7 @@ async def test_on_room_message_reaction_enabled(mock_room, test_config):
     from nio import ReactionEvent
 
     class MockReactionEvent(ReactionEvent):
-        def __init__(self, source, sender, server_timestamp):
-            """
-            Create a wrapper for a Matrix event that stores its raw payload, sender MXID, and server timestamp.
-
-            Parameters:
-                source (dict): Raw Matrix event JSON payload as received from the client/server.
-                sender (str): Sender Matrix user ID (MXID), e.g. "@alice:example.org".
-                server_timestamp (int | float): Server timestamp in milliseconds since the UNIX epoch.
-            """
+        def __init__(self, source: dict, sender: str, server_timestamp: int) -> None:
             self.source = source
             self.sender = sender
             self.server_timestamp = server_timestamp
@@ -1259,46 +1253,16 @@ async def test_on_room_message_reaction_enabled(mock_room, test_config):
     real_loop = asyncio.get_running_loop()
 
     class DummyLoop:
-        def __init__(self, loop):
-            """
-            Create an instance bound to the given asyncio event loop.
-
-            Parameters:
-                loop (asyncio.AbstractEventLoop): Event loop used to schedule and run the instance's asynchronous tasks.
-            """
+        def __init__(self, loop: asyncio.AbstractEventLoop) -> None:
             self._loop = loop
 
-        def is_running(self):
-            """
-            Indicates whether the component is running.
-
-            Returns:
-                `True` since this implementation always reports the component as running.
-            """
+        def is_running(self) -> bool:
             return True
 
-        def create_task(self, coro):
-            """
-            Schedule an awaitable on this instance's event loop and return the created Task.
-
-            Parameters:
-                coro: An awaitable or coroutine to schedule on this object's event loop.
-
-            Returns:
-                asyncio.Task: The Task object wrapping the scheduled coroutine.
-            """
+        def create_task(self, coro: Any) -> asyncio.Task[Any]:
             return self._loop.create_task(coro)
 
-        async def run_in_executor(self, _executor, func, *args):
-            """
-            Invoke a callable synchronously and return its result.
-
-            _executor is accepted for API compatibility but ignored.
-            func is the callable to invoke; any positional args are forwarded to it.
-
-            Returns:
-                The value returned by `func(*args)`.
-            """
+        async def run_in_executor(self, _executor: Any, func: Any, *args: Any) -> Any:
             return func(*args)
 
     dummy_queue = MagicMock()
@@ -1338,7 +1302,7 @@ async def test_on_room_message_reaction_enabled(mock_room, test_config):
         assert queued_kwargs["description"].startswith("Local reaction")
         assert queued_kwargs["reply_id"] == 12345
         assert "reacted" in queued_kwargs["text"]
-        assert queued_args[0].__name__ == "send_text_reply"
+        assert queued_args[0] is send_text_reply
 
 
 async def test_on_room_message_reaction_non_numeric_meshtastic_id(
@@ -1348,7 +1312,7 @@ async def test_on_room_message_reaction_non_numeric_meshtastic_id(
     from nio import ReactionEvent
 
     class MockReactionEvent(ReactionEvent):
-        def __init__(self, source, sender, server_timestamp):
+        def __init__(self, source: dict, sender: str, server_timestamp: int) -> None:
             self.source = source
             self.sender = sender
             self.server_timestamp = server_timestamp
@@ -1372,16 +1336,16 @@ async def test_on_room_message_reaction_non_numeric_meshtastic_id(
     real_loop = asyncio.get_running_loop()
 
     class DummyLoop:
-        def __init__(self, loop):
+        def __init__(self, loop: asyncio.AbstractEventLoop) -> None:
             self._loop = loop
 
-        def is_running(self):
+        def is_running(self) -> bool:
             return True
 
-        def create_task(self, coro):
+        def create_task(self, coro: Any) -> asyncio.Task[Any]:
             return self._loop.create_task(coro)
 
-        async def run_in_executor(self, _executor, func, *args):
+        async def run_in_executor(self, _executor: Any, func: Any, *args: Any) -> Any:
             return func(*args)
 
     dummy_queue = MagicMock()
@@ -2012,7 +1976,7 @@ async def test_on_room_message_local_reaction_queue_failure_logs(
         patch("mmrelay.plugin_loader.load_plugins", return_value=[]),
         patch(
             "mmrelay.matrix_utils.get_message_map_by_matrix_event_id",
-            return_value=(12345, mock_room.room_id, "text", "meshnet"),
+            return_value=("12345", mock_room.room_id, "text", "meshnet"),
         ),
         patch(
             "mmrelay.matrix_utils._get_meshtastic_interface_and_channel",

--- a/tests/test_matrix_utils_relay.py
+++ b/tests/test_matrix_utils_relay.py
@@ -1293,9 +1293,8 @@ async def test_on_room_message_reaction_enabled(mock_room, test_config):
             """
             Invoke a callable synchronously and return its result.
 
-            _executor: Ignored; present for API compatibility.
-            func: Callable to invoke.
-            *args: Positional arguments forwarded to `func`.
+            _executor is accepted for API compatibility but ignored.
+            func is the callable to invoke; any positional args are forwarded to it.
 
             Returns:
                 The value returned by `func(*args)`.
@@ -1311,7 +1310,7 @@ async def test_on_room_message_reaction_enabled(mock_room, test_config):
         patch(
             "mmrelay.matrix_utils.get_message_map_by_matrix_event_id",
             return_value=(
-                12345,
+                "12345",
                 TEST_ROOM_ID,
                 "original_text",
                 "test_mesh",
@@ -1334,10 +1333,99 @@ async def test_on_room_message_reaction_enabled(mock_room, test_config):
         await on_room_message(mock_room, mock_event)
 
         mock_queue_message.assert_called_once()
+        queued_args = mock_queue_message.call_args.args
         queued_kwargs = mock_queue_message.call_args.kwargs
         assert queued_kwargs["description"].startswith("Local reaction")
         assert queued_kwargs["reply_id"] == 12345
         assert "reacted" in queued_kwargs["text"]
+        assert queued_args[0].__name__ == "send_text_reply"
+
+
+async def test_on_room_message_reaction_non_numeric_meshtastic_id(
+    mock_room, test_config
+):
+    """Non-numeric mapped meshtastic_id should send as normal message, not reply."""
+    from nio import ReactionEvent
+
+    class MockReactionEvent(ReactionEvent):
+        def __init__(self, source, sender, server_timestamp):
+            self.source = source
+            self.sender = sender
+            self.server_timestamp = server_timestamp
+
+    mock_event = MockReactionEvent(
+        source={
+            "content": {
+                "m.relates_to": {
+                    "event_id": "original_event_id",
+                    "key": "👍",
+                    "rel_type": "m.annotation",
+                }
+            }
+        },
+        sender="@user:matrix.org",
+        server_timestamp=1234567890,
+    )
+
+    test_config["meshtastic"]["message_interactions"]["reactions"] = True
+
+    real_loop = asyncio.get_running_loop()
+
+    class DummyLoop:
+        def __init__(self, loop):
+            self._loop = loop
+
+        def is_running(self):
+            return True
+
+        def create_task(self, coro):
+            return self._loop.create_task(coro)
+
+        async def run_in_executor(self, _executor, func, *args):
+            return func(*args)
+
+    dummy_queue = MagicMock()
+    dummy_queue.get_queue_size.return_value = 0
+    mock_meshtastic = MagicMock()
+
+    with (
+        patch("mmrelay.plugin_loader.load_plugins", return_value=[]),
+        patch("mmrelay.matrix_utils.get_user_display_name", return_value="MockUser"),
+        patch(
+            "mmrelay.matrix_utils.get_message_map_by_matrix_event_id",
+            return_value=(
+                "mesh_id",
+                TEST_ROOM_ID,
+                "original_text",
+                "test_mesh",
+            ),
+        ),
+        patch(
+            "mmrelay.matrix_utils.asyncio.get_running_loop",
+            return_value=DummyLoop(real_loop),
+        ),
+        patch("mmrelay.matrix_utils.get_message_queue", return_value=dummy_queue),
+        patch(
+            "mmrelay.matrix_utils.queue_message", return_value=True
+        ) as mock_queue_message,
+        patch("mmrelay.matrix_utils.connect_meshtastic", return_value=mock_meshtastic),
+        patch("mmrelay.matrix_utils.bot_start_time", 1234567880),
+        patch("mmrelay.matrix_utils.config", test_config),
+        patch("mmrelay.matrix_utils.matrix_rooms", test_config["matrix_rooms"]),
+        patch("mmrelay.matrix_utils.bot_user_id", test_config["matrix"]["bot_user_id"]),
+        patch("mmrelay.matrix_utils.logger") as mock_logger,
+    ):
+        await on_room_message(mock_room, mock_event)
+
+        mock_queue_message.assert_called_once()
+        queued_args = mock_queue_message.call_args.args
+        queued_kwargs = mock_queue_message.call_args.kwargs
+        assert "reacted" in queued_kwargs["text"]
+        assert "reply_id" not in queued_kwargs
+        assert queued_args[0] is mock_meshtastic.sendText
+    assert any(
+        "is not numeric" in call.args[0] for call in mock_logger.warning.call_args_list
+    )
 
 
 @patch("mmrelay.matrix_utils.connect_meshtastic")

--- a/tests/test_matrix_utils_relay.py
+++ b/tests/test_matrix_utils_relay.py
@@ -1311,7 +1311,7 @@ async def test_on_room_message_reaction_enabled(mock_room, test_config):
         patch(
             "mmrelay.matrix_utils.get_message_map_by_matrix_event_id",
             return_value=(
-                "meshtastic_id",
+                12345,
                 TEST_ROOM_ID,
                 "original_text",
                 "test_mesh",
@@ -1336,6 +1336,7 @@ async def test_on_room_message_reaction_enabled(mock_room, test_config):
         mock_queue_message.assert_called_once()
         queued_kwargs = mock_queue_message.call_args.kwargs
         assert queued_kwargs["description"].startswith("Local reaction")
+        assert queued_kwargs["reply_id"] == 12345
         assert "reacted" in queued_kwargs["text"]
 
 
@@ -1923,7 +1924,7 @@ async def test_on_room_message_local_reaction_queue_failure_logs(
         patch("mmrelay.plugin_loader.load_plugins", return_value=[]),
         patch(
             "mmrelay.matrix_utils.get_message_map_by_matrix_event_id",
-            return_value=("mesh_id", mock_room.room_id, "text", "meshnet"),
+            return_value=(12345, mock_room.room_id, "text", "meshnet"),
         ),
         patch(
             "mmrelay.matrix_utils._get_meshtastic_interface_and_channel",

--- a/tests/test_matrix_utils_relay.py
+++ b/tests/test_matrix_utils_relay.py
@@ -1,7 +1,9 @@
 import asyncio
 import contextlib
+from collections.abc import Callable, Coroutine
+from concurrent.futures import Executor
 from types import SimpleNamespace
-from typing import Any
+from typing import TypeVar
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import nio
@@ -31,6 +33,8 @@ from tests.constants import (
     TEST_ROOM_ID,
     TEST_USER_ID,
 )
+
+T = TypeVar("T")
 
 pytestmark = pytest.mark.asyncio
 
@@ -1259,10 +1263,14 @@ async def test_on_room_message_reaction_enabled(mock_room, test_config):
         def is_running(self) -> bool:
             return True
 
-        def create_task(self, coro: Any) -> asyncio.Task[Any]:
+        def create_task(
+            self, coro: Coroutine[object, object, object]
+        ) -> asyncio.Task[object]:
             return self._loop.create_task(coro)
 
-        async def run_in_executor(self, _executor: Any, func: Any, *args: Any) -> Any:
+        async def run_in_executor(
+            self, _executor: Executor | None, func: Callable[..., T], *args: object
+        ) -> T:
             return func(*args)
 
     dummy_queue = MagicMock()
@@ -1342,10 +1350,14 @@ async def test_on_room_message_reaction_non_numeric_meshtastic_id(
         def is_running(self) -> bool:
             return True
 
-        def create_task(self, coro: Any) -> asyncio.Task[Any]:
+        def create_task(
+            self, coro: Coroutine[object, object, object]
+        ) -> asyncio.Task[object]:
             return self._loop.create_task(coro)
 
-        async def run_in_executor(self, _executor: Any, func: Any, *args: Any) -> Any:
+        async def run_in_executor(
+            self, _executor: Executor | None, func: Callable[..., T], *args: object
+        ) -> T:
             return func(*args)
 
     dummy_queue = MagicMock()

--- a/tests/test_matrix_utils_relay.py
+++ b/tests/test_matrix_utils_relay.py
@@ -1404,6 +1404,171 @@ async def test_on_room_message_reaction_non_numeric_meshtastic_id(
     )
 
 
+async def test_on_room_message_reaction_mapped_int_id(mock_room, test_config):
+    """An int meshtastic_id from the DB should be accepted as a valid reply ID."""
+    from nio import ReactionEvent
+
+    class MockReactionEvent(ReactionEvent):
+        def __init__(self, source: dict, sender: str, server_timestamp: int) -> None:
+            self.source = source
+            self.sender = sender
+            self.server_timestamp = server_timestamp
+
+    mock_event = MockReactionEvent(
+        source={
+            "content": {
+                "m.relates_to": {
+                    "event_id": "original_event_id",
+                    "key": "👍",
+                    "rel_type": "m.annotation",
+                }
+            }
+        },
+        sender="@user:matrix.org",
+        server_timestamp=1234567890,
+    )
+
+    test_config["meshtastic"]["message_interactions"]["reactions"] = True
+    real_loop = asyncio.get_running_loop()
+
+    class DummyLoop:
+        def __init__(self, loop: asyncio.AbstractEventLoop) -> None:
+            self._loop = loop
+
+        def is_running(self) -> bool:
+            return True
+
+        def create_task(
+            self, coro: Coroutine[object, object, object]
+        ) -> asyncio.Task[object]:
+            return self._loop.create_task(coro)
+
+        async def run_in_executor(
+            self, _executor: Executor | None, func: Callable[..., T], *args: object
+        ) -> T:
+            return func(*args)
+
+    dummy_queue = MagicMock()
+    dummy_queue.get_queue_size.return_value = 0
+
+    with (
+        patch("mmrelay.plugin_loader.load_plugins", return_value=[]),
+        patch("mmrelay.matrix_utils.get_user_display_name", return_value="MockUser"),
+        patch(
+            "mmrelay.matrix_utils.get_message_map_by_matrix_event_id",
+            return_value=(12345, TEST_ROOM_ID, "original_text", "test_mesh"),
+        ),
+        patch(
+            "mmrelay.matrix_utils.asyncio.get_running_loop",
+            return_value=DummyLoop(real_loop),
+        ),
+        patch("mmrelay.matrix_utils.get_message_queue", return_value=dummy_queue),
+        patch(
+            "mmrelay.matrix_utils.queue_message", return_value=True
+        ) as mock_queue_message,
+        patch("mmrelay.matrix_utils.connect_meshtastic", return_value=MagicMock()),
+        patch("mmrelay.matrix_utils.bot_start_time", 1234567880),
+        patch("mmrelay.matrix_utils.config", test_config),
+        patch("mmrelay.matrix_utils.matrix_rooms", test_config["matrix_rooms"]),
+        patch("mmrelay.matrix_utils.bot_user_id", test_config["matrix"]["bot_user_id"]),
+    ):
+        await on_room_message(mock_room, mock_event)
+
+        mock_queue_message.assert_called_once()
+        queued_args = mock_queue_message.call_args.args
+        queued_kwargs = mock_queue_message.call_args.kwargs
+        assert queued_kwargs["description"].startswith("Local reaction")
+        assert queued_kwargs["reply_id"] == 12345
+        assert "reacted" in queued_kwargs["text"]
+        assert queued_args[0] is send_text_reply
+
+
+async def test_on_room_message_reaction_unexpected_type_logs_warning(
+    mock_room, test_config
+):
+    """A non-int, non-str meshtastic_id should log a type warning and fall back to sendText."""
+    from nio import ReactionEvent
+
+    class MockReactionEvent(ReactionEvent):
+        def __init__(self, source: dict, sender: str, server_timestamp: int) -> None:
+            self.source = source
+            self.sender = sender
+            self.server_timestamp = server_timestamp
+
+    mock_event = MockReactionEvent(
+        source={
+            "content": {
+                "m.relates_to": {
+                    "event_id": "original_event_id",
+                    "key": "👍",
+                    "rel_type": "m.annotation",
+                }
+            }
+        },
+        sender="@user:matrix.org",
+        server_timestamp=1234567890,
+    )
+
+    test_config["meshtastic"]["message_interactions"]["reactions"] = True
+    real_loop = asyncio.get_running_loop()
+
+    class DummyLoop:
+        def __init__(self, loop: asyncio.AbstractEventLoop) -> None:
+            self._loop = loop
+
+        def is_running(self) -> bool:
+            return True
+
+        def create_task(
+            self, coro: Coroutine[object, object, object]
+        ) -> asyncio.Task[object]:
+            return self._loop.create_task(coro)
+
+        async def run_in_executor(
+            self, _executor: Executor | None, func: Callable[..., T], *args: object
+        ) -> T:
+            return func(*args)
+
+    dummy_queue = MagicMock()
+    dummy_queue.get_queue_size.return_value = 0
+    mock_meshtastic = MagicMock()
+
+    with (
+        patch("mmrelay.plugin_loader.load_plugins", return_value=[]),
+        patch("mmrelay.matrix_utils.get_user_display_name", return_value="MockUser"),
+        patch(
+            "mmrelay.matrix_utils.get_message_map_by_matrix_event_id",
+            return_value=(12.5, TEST_ROOM_ID, "original_text", "test_mesh"),
+        ),
+        patch(
+            "mmrelay.matrix_utils.asyncio.get_running_loop",
+            return_value=DummyLoop(real_loop),
+        ),
+        patch("mmrelay.matrix_utils.get_message_queue", return_value=dummy_queue),
+        patch(
+            "mmrelay.matrix_utils.queue_message", return_value=True
+        ) as mock_queue_message,
+        patch("mmrelay.matrix_utils.connect_meshtastic", return_value=mock_meshtastic),
+        patch("mmrelay.matrix_utils.bot_start_time", 1234567880),
+        patch("mmrelay.matrix_utils.config", test_config),
+        patch("mmrelay.matrix_utils.matrix_rooms", test_config["matrix_rooms"]),
+        patch("mmrelay.matrix_utils.bot_user_id", test_config["matrix"]["bot_user_id"]),
+        patch("mmrelay.matrix_utils.logger") as mock_logger,
+    ):
+        await on_room_message(mock_room, mock_event)
+
+        mock_queue_message.assert_called_once()
+        queued_args = mock_queue_message.call_args.args
+        queued_kwargs = mock_queue_message.call_args.kwargs
+        assert "reacted" in queued_kwargs["text"]
+        assert "reply_id" not in queued_kwargs
+        assert queued_args[0] is mock_meshtastic.sendText
+    assert any(
+        "has unexpected type" in call.args[0]
+        for call in mock_logger.warning.call_args_list
+    )
+
+
 @patch("mmrelay.matrix_utils.connect_meshtastic")
 @patch("mmrelay.matrix_utils.queue_message")
 @patch("mmrelay.matrix_utils.bot_start_time", 1234567880)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview

This PR improves reaction relaying and message ID handling so Matrix reactions can be relayed as replies to their original Meshtastic messages when a mapped Meshtastic message ID is available. It also ensures plugin-generated Matrix reaction events include the configured suppression marker to avoid feedback loops.

## Key Changes

**Features**
- When relaying Matrix reactions, the relay now reads the stored Meshtastic mapping and, when the mapped ID is numeric, forwards the reaction as a Meshtastic reply by calling the facade reply path (send_text_reply) with a parsed reply_id.
- Message-mapping lookups (used by tests) now include a leading reply_id in the mapping shape so the relay can attempt reply linking.

**Fixes**
- BasePlugin.send_matrix_reaction adds the configured suppression key (MATRIX_SUPPRESS_KEY) to the Matrix reaction content so plugin-generated reactions are marked and less likely to be re-relayed back into the bridge.

**Refactors / Internal behavior**
- on_room_message reaction handling now parses meshtastic_id_raw more conservatively: it accepts ints directly, converts numeric strings using str.isdigit() → int(...), and logs a warning and falls back to no reply linkage when parsing fails (non-numeric strings result in no reply_id).
- Reaction relay logic conditionally uses facade.send_text_reply with reply_id when available; otherwise it falls back to the existing broadcast/sendText path.
- Message suppression check now uses the MATRIX_SUPPRESS_KEY constant instead of a hard-coded key.
- Unit tests updated to reflect the new mapping shape and to assert the suppression key presence.

## Testing

- Unit tests updated: reaction-relay tests now expect reply_id to be passed when the mapping contains a numeric ID and to be omitted when the mapped ID is non-numeric. The BasePlugin reaction test now asserts MATRIX_SUPPRESS_KEY is set to True in the reaction payload.

## Breaking changes / Migration

- No public API or exported symbol changes. Internally, message-mapping consumers should be aware mappings may include a leading reply_id field and that numeric Meshtastic IDs stored as strings will be parsed into integers. No user migration steps required.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Closes #551 