### PR TITLE
Update documentation for MMRelay v1.3.7 E2EE changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ A powerful and easy-to-use relay between Meshtastic devices and Matrix chat room
 - Supports encrypted Matrix rooms 🔐 (Matrix E2EE)
 - Unified directory structure 📁 (New in v1.3)
 
-> **Encryption note (v1.3.7)**: MMRelay now uses **mindroom-nio** with **vodozemac** for Matrix E2EE. Everything works the same — your encrypted rooms will continue to work after upgrading. See the [E2EE Setup Guide](docs/E2EE.md).
+> **Encryption note (v1.3.7)**: MMRelay now uses **mindroom-nio** with **vodozemac** for Matrix E2EE. Most encrypted-room setups should continue to work after upgrading, but existing installs may need to uninstall the old matrix-nio package so it does not conflict with mindroom-nio. See the [E2EE Setup Guide](docs/E2EE.md) and the [v1.3 Migration Guide](docs/MIGRATION_1.3.md).
 >
 > **Improved BLE stability (v1.3.3)**: The Meshtastic Python library has been replaced with [mtjk](https://github.com/jeremiah-k/mtjk), a fork with BLE reliability improvements (auto-reconnection, state management, notification recovery) along with thread-safety and connection handling fixes. Changes may be upstreamed selectively once they've been battle-tested here. See the [Refactor Program](https://github.com/jeremiah-k/mtjk/blob/develop/REFACTOR_PROGRAM.md) for scope and rationale.
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ A powerful and easy-to-use relay between Meshtastic devices and Matrix chat room
 - Supports encrypted Matrix rooms 🔐 (Matrix E2EE)
 - Unified directory structure 📁 (New in v1.3)
 
-> **Encryption note**: MMRelay supports encrypted Matrix rooms (Matrix E2EE). For details on how this works and its security implications, see the [E2EE Setup Guide](docs/E2EE.md).
+> **Encryption note (v1.3.7)**: MMRelay now uses **mindroom-nio** with **vodozemac** for Matrix E2EE. Everything works the same — your encrypted rooms will continue to work after upgrading. See the [E2EE Setup Guide](docs/E2EE.md).
 >
 > **Improved BLE stability (v1.3.3)**: The Meshtastic Python library has been replaced with [mtjk](https://github.com/jeremiah-k/mtjk), a fork with BLE reliability improvements (auto-reconnection, state management, notification recovery) along with thread-safety and connection handling fixes. Changes may be upstreamed selectively once they've been battle-tested here. See the [Refactor Program](https://github.com/jeremiah-k/mtjk/blob/develop/REFACTOR_PROGRAM.md) for scope and rationale.
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ A powerful and easy-to-use relay between Meshtastic devices and Matrix chat room
 - Supports encrypted Matrix rooms 🔐 (Matrix E2EE)
 - Unified directory structure 📁 (New in v1.3)
 
-> **Encryption note (v1.3.7)**: MMRelay now uses **mindroom-nio** with **vodozemac** for Matrix E2EE. Most users, including Docker deployments and clean pipx/PyPI installs, should not need to do anything special. If you maintain a developer venv/editable install or an older in-place upgraded Python environment, verify that matrix-nio is not still installed alongside mindroom-nio. See the [E2EE Setup Guide](docs/E2EE.md) and the [v1.3 Migration Guide](docs/MIGRATION_1.3.md).
+> **Encryption note (v1.3.7)**: MMRelay now uses [**mindroom-nio**](https://github.com/mindroom-ai/mindroom-nio) with **vodozemac** for Matrix E2EE. Most users, including Docker deployments and clean pipx/PyPI installs, should not need to do anything special. If you maintain a developer venv/editable install or an older in-place upgraded Python environment, verify that matrix-nio is not still installed alongside mindroom-nio. See the [E2EE Setup Guide](docs/E2EE.md) and the [v1.3 Migration Guide](docs/MIGRATION_1.3.md).
 >
 > **Improved BLE stability (v1.3.3)**: The Meshtastic Python library has been replaced with [mtjk](https://github.com/jeremiah-k/mtjk), a fork with BLE reliability improvements (auto-reconnection, state management, notification recovery) along with thread-safety and connection handling fixes. Changes may be upstreamed selectively once they've been battle-tested here. See the [Refactor Program](https://github.com/jeremiah-k/mtjk/blob/develop/REFACTOR_PROGRAM.md) for scope and rationale.
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ A powerful and easy-to-use relay between Meshtastic devices and Matrix chat room
 - Supports encrypted Matrix rooms 🔐 (Matrix E2EE)
 - Unified directory structure 📁 (New in v1.3)
 
-> **Encryption note (v1.3.7)**: MMRelay now uses **mindroom-nio** with **vodozemac** for Matrix E2EE. Most encrypted-room setups should continue to work after upgrading, but existing installs may need to uninstall the old matrix-nio package so it does not conflict with mindroom-nio. See the [E2EE Setup Guide](docs/E2EE.md) and the [v1.3 Migration Guide](docs/MIGRATION_1.3.md).
+> **Encryption note (v1.3.7)**: MMRelay now uses **mindroom-nio** with **vodozemac** for Matrix E2EE. Most users, including Docker deployments and clean pipx/PyPI installs, should not need to do anything special. If you maintain a developer venv/editable install or an older in-place upgraded Python environment, verify that matrix-nio is not still installed alongside mindroom-nio. See the [E2EE Setup Guide](docs/E2EE.md) and the [v1.3 Migration Guide](docs/MIGRATION_1.3.md).
 >
 > **Improved BLE stability (v1.3.3)**: The Meshtastic Python library has been replaced with [mtjk](https://github.com/jeremiah-k/mtjk), a fork with BLE reliability improvements (auto-reconnection, state management, notification recovery) along with thread-safety and connection handling fixes. Changes may be upstreamed selectively once they've been battle-tested here. See the [Refactor Program](https://github.com/jeremiah-k/mtjk/blob/develop/REFACTOR_PROGRAM.md) for scope and rationale.
 

--- a/docs/E2EE.md
+++ b/docs/E2EE.md
@@ -13,8 +13,8 @@ Encryption (E2EE).
 
 MMRelay uses [**mindroom-nio**](https://github.com/mindroom-ai/mindroom-nio) as
 its Matrix SDK with **vodozemac** (a Rust cryptographic library) for E2EE. Vodozemac is the successor to the deprecated
-libolm and is distributed as precompiled wheels — no additional system
-libraries are needed.
+libolm and is distributed as precompiled wheels for Linux and macOS — no
+additional system libraries are needed on supported platforms.
 
 The legacy `matrix-nio` provider (with `python-olm`) is still technically
 usable if you manually replace mindroom-nio, but upstream matrix-nio is mostly
@@ -169,7 +169,8 @@ pipx install 'mmrelay[e2e]'
 
 The `mmrelay[e2e]` extra installs **mindroom-nio[e2e]** which includes the
 **vodozemac** crypto backend (Rust-based, distributed as precompiled wheels
-requiring no additional system libraries).
+for Linux and macOS — no additional system libraries needed on supported
+platforms).
 
 ### Windows limitation
 

--- a/docs/E2EE.md
+++ b/docs/E2EE.md
@@ -9,21 +9,20 @@ Encryption (E2EE).
 > rooms** (like any other Matrix client), not that messages stay end-to-end
 > encrypted across the entire Meshtastic <-> Matrix path.
 
-## Libolm deprecation status
+## E2EE provider
 
-The Olm/Megolm encryption library (`libolm`) was deprecated in July 2024.
-Matrix.org considers it
-[safe for practical use](https://matrix.org/blog/2024/08/libolm-deprecation/)
-but recommends migrating to vodozemac.
+MMRelay uses [**mindroom-nio**](https://github.com/mindroom-ai/mindroom-nio) as
+its Matrix SDK with **vodozemac** (a Rust cryptographic library) for E2EE. Vodozemac is the successor to the deprecated
+libolm and is distributed as precompiled wheels — no additional system
+libraries are needed.
 
-MMRelay now uses **mindroom-nio** as its default Matrix provider, which uses
-**vodozemac** (the Rust successor to libolm) for E2EE. The legacy
-`matrix-nio` provider with `python-olm` is still supported by manually
-installing matrix-nio instead of mindroom-nio but is no longer the default.
+The legacy `matrix-nio` provider (with `python-olm`) is still technically
+usable if you manually replace mindroom-nio, but matrix-nio is effectively
+unmaintained at this point and mindroom-nio is recommended for all deployments.
 
 ## Index
 
-- [Libolm deprecation status](#libolm-deprecation-status)
+- [E2EE provider](#e2ee-provider)
 - [What E2EE means in MMRelay](#what-e2ee-means-in-mmrelay)
 - [How MMRelay handles encrypted rooms](#how-mmrelay-handles-encrypted-rooms)
 - [Security considerations](#security-considerations)
@@ -49,8 +48,8 @@ When E2EE is enabled:
 
 ### What this means
 
-- On the **Matrix side**, messages are protected using Matrix E2EE
-  (Olm/Megolm) between MMRelay and other Matrix clients in the room.
+- On the **Matrix side**, messages are encrypted using the Olm/Megolm protocol
+  (backed by vodozemac) between MMRelay and other Matrix clients in the room.
 - MMRelay behaves like a normal Matrix client in encrypted rooms: it stores
   keys, requests keys when needed, and decrypts/encrypts messages as needed.
 
@@ -159,9 +158,8 @@ requiring no additional system libraries).
 ### Windows limitation
 
 **E2EE is not available on Windows** due to technical limitations with required
-cryptographic libraries. The default vodozemac backend and the legacy
-python-olm backend both depend on native libraries that are not straightforward
-to install on Windows.
+cryptographic libraries. Vodozemac and the legacy python-olm backend both
+depend on native libraries that are not straightforward to install on Windows.
 
 Windows users can still use MMRelay for regular (unencrypted) Matrix
 communication.
@@ -179,12 +177,6 @@ pip install 'mmrelay[e2e]'
 
 This installs **mindroom-nio** with the **vodozemac** crypto backend as the
 default E2EE provider.
-
-> **Legacy matrix-nio users**: If you are manually replacing mindroom-nio with
-> `matrix-nio` (uninstall mindroom-nio first, then install matrix-nio), use
-> `pip install 'matrix-nio[e2e]==0.25.2'` instead. Do **not** install
-> `mmrelay[e2e]` — it pulls in mindroom-nio. Never install both providers in
-> the same Python environment.
 
 ### 2. Enable E2EE in config
 
@@ -291,7 +283,7 @@ expected to show a red shield warning:
 
 This is expected because:
 
-- Messages **are encrypted** using Matrix E2EE (Olm/Megolm)
+- Messages **are encrypted** using Matrix E2EE (Olm/Megolm via vodozemac)
 - The nio library does not support interactive device verification
   (emoji/QR verification)
 - MMRelay devices cannot be cross-signed through the standard Matrix client
@@ -307,8 +299,8 @@ that as a real issue (usually configuration/version related) and troubleshoot.
 **Problem**: E2EE features do not work on Windows.
 
 **Explanation**: E2EE requires native cryptographic libraries (vodozemac for
-the default mindroom-nio provider, or python-olm for legacy matrix-nio). Both
-have native dependencies that are difficult to install on Windows.
+mindroom-nio). Both vodozemac and the legacy python-olm have native
+dependencies that are difficult to install on Windows.
 
 **What to do**:
 
@@ -327,8 +319,7 @@ pip install 'mmrelay[e2e]'
 ```
 
 This installs mindroom-nio with the vodozemac crypto backend. Vodozemac is
-Rust-based and distributed as precompiled wheels requiring no extra system
-libraries.
+distributed as precompiled Rust wheels requiring no extra system libraries.
 
 If running from a local checkout:
 
@@ -336,18 +327,8 @@ If running from a local checkout:
 pip install -e '.[e2e]'
 ```
 
-If you are using the legacy matrix-nio provider instead of the default
-mindroom-nio (by manually uninstalling mindroom-nio and installing matrix-nio),
-install its E2EE extra separately:
-
-```bash
-pip install 'matrix-nio[e2e]==0.25.2'
-```
-
 > **Warning**: Do not install both mindroom-nio and matrix-nio in the same
 > environment. They both provide the `nio` namespace and will conflict.
-> Do **not** install `mmrelay[e2e]` when using legacy matrix-nio — it will
-> reinstall mindroom-nio.
 
 ### "Failed to decrypt event" in logs
 
@@ -393,10 +374,10 @@ E2EE support is backward compatible:
 
 ### Implementation
 
-- Uses **mindroom-nio** (default) with the **vodozemac** crypto backend, or
-  **matrix-nio** (legacy) with the **python-olm/libolm** crypto backend.
-- Both providers use the Matrix **Olm/Megolm** encryption protocols; they differ
-  only in the underlying cryptographic library.
+- Uses **mindroom-nio** with the **vodozemac** crypto backend (the legacy
+  matrix-nio / python-olm stack is also technically supported but unmaintained).
+- Both providers implement the same Matrix **Olm/Megolm** encryption protocols;
+  they differ only in the underlying cryptographic library.
 - Loads E2EE store before sync operations
 - Uses automatic key management with `ignore_unverified_devices=True`
 - Provider detection and capability reporting via `mmrelay.matrix.compat`

--- a/docs/E2EE.md
+++ b/docs/E2EE.md
@@ -17,8 +17,24 @@ libolm and is distributed as precompiled wheels — no additional system
 libraries are needed.
 
 The legacy `matrix-nio` provider (with `python-olm`) is still technically
-usable if you manually replace mindroom-nio, but matrix-nio is effectively
-unmaintained at this point and mindroom-nio is recommended for all deployments.
+usable if you manually replace mindroom-nio, but upstream matrix-nio is mostly
+inactive and mindroom-nio is recommended for all deployments.
+
+### Legacy matrix-nio provider
+
+mindroom-nio is the default and recommended provider. Legacy matrix-nio
+remains supported only by manually replacing mindroom-nio.
+
+**Do not install both providers in the same Python environment.** They both
+provide the `nio` namespace and will conflict. Do not use `mmrelay[e2e]` for
+legacy matrix-nio, because the `e2e` extra always installs mindroom-nio.
+
+To switch to the legacy provider:
+
+```bash
+pip uninstall mindroom-nio
+pip install 'matrix-nio[e2e]==0.25.2'
+```
 
 ## Index
 

--- a/docs/E2EE.md
+++ b/docs/E2EE.md
@@ -382,7 +382,7 @@ INFO Matrix: Initial sync completed. Found X rooms.
 
 E2EE support is backward compatible:
 
-- Existing setups continue to work
+- Existing setups generally continue to work, but upgraded environments may need to uninstall old matrix-nio packages so they do not conflict with mindroom-nio
 - Mixed encrypted/unencrypted room setups are supported
 - E2EE remains optional via `e2ee.enabled: false`
 
@@ -391,7 +391,8 @@ E2EE support is backward compatible:
 ### Implementation
 
 - Uses **mindroom-nio** with the **vodozemac** crypto backend (the legacy
-  matrix-nio / python-olm stack is also technically supported but unmaintained).
+  matrix-nio / python-olm stack is also technically supported, but upstream
+  matrix-nio is mostly inactive).
 - Both providers implement the same Matrix **Olm/Megolm** encryption protocols;
   they differ only in the underlying cryptographic library.
 - Loads E2EE store before sync operations

--- a/docs/E2EE.md
+++ b/docs/E2EE.md
@@ -382,7 +382,7 @@ INFO Matrix: Initial sync completed. Found X rooms.
 
 E2EE support is backward compatible:
 
-- Existing setups generally continue to work, but upgraded environments may need to uninstall old matrix-nio packages so they do not conflict with mindroom-nio
+- Existing setups generally continue to work. Manual cleanup is only expected if an in-place Python environment still has both matrix-nio and mindroom-nio installed
 - Mixed encrypted/unencrypted room setups are supported
 - E2EE remains optional via `e2ee.enabled: false`
 

--- a/docs/E2EE.md
+++ b/docs/E2EE.md
@@ -64,8 +64,8 @@ When E2EE is enabled:
 
 ### What this means
 
-- On the **Matrix side**, messages are encrypted using the Olm/Megolm protocol
-  (backed by vodozemac) between MMRelay and other Matrix clients in the room.
+- On the **Matrix side**, messages are encrypted using the Matrix Olm/Megolm
+  protocol between MMRelay and other Matrix clients in the room.
 - MMRelay behaves like a normal Matrix client in encrypted rooms: it stores
   keys, requests keys when needed, and decrypts/encrypts messages as needed.
 
@@ -300,7 +300,7 @@ expected to show a red shield warning:
 
 This is expected because:
 
-- Messages **are encrypted** using Matrix E2EE (Olm/Megolm via vodozemac)
+- Messages **are encrypted** using Matrix E2EE (Olm/Megolm)
 - The nio library does not support interactive device verification
   (emoji/QR verification)
 - MMRelay devices cannot be cross-signed through the standard Matrix client

--- a/docs/MIGRATION_1.3.md
+++ b/docs/MIGRATION_1.3.md
@@ -11,14 +11,18 @@ vodozemac support) as the Matrix SDK provider. The legacy **matrix-nio** provide
 is still supported by manually uninstalling mindroom-nio and installing matrix-nio,
 but is no longer the default.
 
-**Critical upgrade note for encrypted deployments:**
+**Provider cleanup note for in-place Python environments:**
 
-A `pip install --upgrade mmrelay` may leave the old `matrix-nio` package installed
-alongside the new `mindroom-nio` dependency. Having **both** installed disables
-E2EE by design — the relay will report that E2EE is unavailable until one provider
-is removed.
+Docker images pick up the new dependency set when rebuilt or pulled. Fresh
+pipx/PyPI installs use mindroom-nio with no extra steps. The main conflict
+risk is **in-place upgraded Python environments** — developer venv/editable
+installs and pipx environments upgraded in place where old `matrix-nio` was
+previously installed.
 
-**Before upgrading** an E2EE-enabled deployment, uninstall the old provider:
+Having **both** `matrix-nio` and `mindroom-nio` in the same environment
+disables E2EE by design — the relay will report that E2EE is unavailable.
+
+If `mmrelay doctor` reports a dual-provider conflict:
 
 ```bash
 pip uninstall matrix-nio
@@ -30,7 +34,7 @@ Or, if using pipx:
 pipx runpip mmrelay uninstall matrix-nio
 ```
 
-After upgrading, run `mmrelay doctor` to verify E2EE readiness.
+After cleanup, run `mmrelay doctor` again to verify E2EE readiness.
 See [docs/E2EE.md](E2EE.md) for full provider guidance and troubleshooting.
 
 ### Unified HOME Model

--- a/docs/MIGRATION_1.3.md
+++ b/docs/MIGRATION_1.3.md
@@ -4,41 +4,6 @@ This guide helps you upgrade from any legacy layout to the v1.3 unified HOME mod
 
 ## What Changed in 1.3
 
-### Matrix Provider Change: mindroom-nio Now Default
-
-MMRelay v1.3 defaults to **mindroom-nio** (a maintained fork of matrix-nio with
-vodozemac support) as the Matrix SDK provider. The legacy **matrix-nio** provider
-is still supported by manually uninstalling mindroom-nio and installing matrix-nio,
-but is no longer the default.
-
-**Provider cleanup note for in-place Python environments:**
-
-Docker images pick up the new dependency set when rebuilt or pulled. Fresh
-pipx/PyPI installs use mindroom-nio with no extra steps. The main conflict
-risk is **in-place upgraded Python environments** — developer venv/editable
-installs and pipx environments upgraded in place where old `matrix-nio` was
-previously installed.
-
-Having **both** `matrix-nio` and `mindroom-nio` in the same environment
-disables E2EE by design — the relay will report that E2EE is unavailable.
-
-If `mmrelay doctor` reports a dual-provider conflict:
-
-```bash
-pip uninstall matrix-nio
-```
-
-Or, if using pipx:
-
-```bash
-pipx runpip mmrelay uninstall matrix-nio
-```
-
-After cleanup, run `mmrelay doctor` again to verify E2EE readiness.
-See [docs/E2EE.md](E2EE.md) for full provider guidance and troubleshooting.
-
-### Unified HOME Model
-
 MMRelay now uses a single MMRELAY_HOME root for all runtime state:
 
 > **Deprecation Note**: Legacy credential/location fallback is supported until v1.4; warnings will be emitted until you migrate. Plan to migrate before upgrading to v1.4.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview
This PR updates the project documentation to reflect the switch from the legacy matrix-nio provider to mindroom-nio with vodozemac as the primary E2EE (end-to-end encryption) solution for MMRelay. The changes emphasize the new recommended approach, clarify installation instructions, and address namespace/package conflicts that may occur during upgrades.

## Key Changes

**Documentation Updates**
- Updated README.md to specify that MMRelay (v1.3.7) uses mindroom-nio with vodozemac for Matrix E2EE support
- Substantially revised docs/E2EE.md to make mindroom-nio + vodozemac the primary recommended approach with explicit guidance on setup
- Clarified the relationship between different encryption protocols: Olm/Megolm (Matrix standard) and their implementation via either vodozemac or the legacy libolm backend
- Expanded Windows limitation documentation to note that both E2EE backends depend on native libraries
- Refined troubleshooting and installation instructions to distinguish between `mmrelay[e2e]` (installs mindroom-nio) and manual legacy matrix-nio installation

**Migration & Compatibility Guidance**
- Added upgrade notes warning that existing installations may need to uninstall the old matrix-nio package to avoid namespace conflicts with mindroom-nio
- Updated backward compatibility section to explicitly document the need to remove old matrix-nio packages to prevent conflicts
- Documented the maintenance status difference between the new and legacy providers
- Provided clear instructions for users who prefer to continue using the legacy matrix-nio stack

## Migration Steps
Users upgrading from the legacy matrix-nio provider should uninstall the old matrix-nio package before installing the new mindroom-nio provider to avoid namespace conflicts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->