### PR TITLE
Handle BLE shutdown interruptions and add daemon thread executor

### DIFF
--- a/src/mmrelay/meshtastic/async_utils.py
+++ b/src/mmrelay/meshtastic/async_utils.py
@@ -18,12 +18,17 @@ __all__ = [
     "_coerce_positive_int",
     "_coerce_positive_int_id",
     "_fire_and_forget",
+    "FutureWaitShutdownError",
     "_make_awaitable",
     "_run_blocking_with_timeout",
     "_submit_coro",
     "_wait_for_future_result_with_shutdown",
     "_wait_for_result",
 ]
+
+
+class FutureWaitShutdownError(RuntimeError):
+    """Raised when a blocking future wait is aborted because shutdown started."""
 
 
 def _coerce_nonnegative_float(value: Any, default: float) -> float:
@@ -601,7 +606,7 @@ def _wait_for_future_result_with_shutdown(
 
     while True:
         if facade.shutting_down:
-            raise TimeoutError("Shutdown in progress")
+            raise FutureWaitShutdownError("Shutdown in progress")
 
         remaining = deadline - facade.time.monotonic()
         if remaining <= 0:

--- a/src/mmrelay/meshtastic/connection.py
+++ b/src/mmrelay/meshtastic/connection.py
@@ -1313,6 +1313,9 @@ def _connect_meshtastic_impl(
                                 "Skipping BLE connect() for %s (shutting down)",
                                 ble_address,
                             )
+                            # Hand ownership of the pre-client interface to the
+                            # shared rollback path so shutdown disposes it.
+                            client = iface
                             raise facade.FutureWaitShutdownError(
                                 f"BLE connect cancelled for {ble_address} (shutting down)."
                             )
@@ -1347,6 +1350,9 @@ def _connect_meshtastic_impl(
                                 )
                             except RuntimeError as exc:
                                 if facade.shutting_down:
+                                    # No task was scheduled; hand the published
+                                    # interface to the shared rollback path.
+                                    client = iface
                                     raise facade.FutureWaitShutdownError(
                                         "BLE connect() submission interrupted by shutdown"
                                     ) from exc
@@ -1403,6 +1409,10 @@ def _connect_meshtastic_impl(
                                     and connect_future.cancel()
                                 ):
                                     facade._clear_ble_future(connect_future)
+                                    # The connect task never ran and the interface
+                                    # is still published. Hand it to the shared
+                                    # rollback path so shutdown disposes it.
+                                    client = iface
                                 elif connect_future is not None:
                                     facade._schedule_ble_future_cleanup(
                                         connect_future,
@@ -1416,8 +1426,10 @@ def _connect_meshtastic_impl(
                                         fallback_iface=shutdown_iface,
                                         generation=connect_generation,
                                     )
-                                iface = None
-                                facade.meshtastic_iface = None
+                                    # A worker may still finish the connect;
+                                    # unpublish so the late disposer owns it.
+                                    iface = None
+                                    facade.meshtastic_iface = None
                             else:
                                 # Use logger.exception so timeouts include stack context (TRY400),
                                 # but raise a short error and keep operator guidance in logs (TRY003).

--- a/src/mmrelay/meshtastic/connection.py
+++ b/src/mmrelay/meshtastic/connection.py
@@ -960,7 +960,7 @@ def _connect_meshtastic_impl(
                                 facade._disconnect_ble_by_address(ble_address)
 
                             # Create BLE interface with timeout protection to prevent indefinite hangs
-                            # Use ThreadPoolExecutor to run with timeout, as BLEInterface.__init__
+                            # Run on the shared BLE executor with timeout protection, as BLEInterface.__init__
                             # can potentially block indefinitely if BlueZ is in a bad state.
                             def create_ble_interface(
                                 kwargs: dict[str, Any],
@@ -988,7 +988,7 @@ def _connect_meshtastic_impl(
                                     "Skipping BLE interface creation for %s (shutting down)",
                                     ble_address,
                                 )
-                                raise TimeoutError(
+                                raise facade.FutureWaitShutdownError(
                                     f"BLE interface creation cancelled for {ble_address} (shutting down)."
                                 )
 
@@ -1028,8 +1028,10 @@ def _connect_meshtastic_impl(
                                             create_ble_interface, ble_kwargs
                                         )
                                     except RuntimeError as exc:
-                                        # The shared executor can be shutting down during interpreter
-                                        # teardown; treat this as a timeout so retry logic applies.
+                                        if facade.shutting_down:
+                                            raise facade.FutureWaitShutdownError(
+                                                "BLE interface creation submission interrupted by shutdown"
+                                            ) from exc
                                         facade.logger.exception(
                                             "BLE interface creation submission failed for %s",
                                             ble_address,
@@ -1102,6 +1104,27 @@ def _connect_meshtastic_impl(
                                         facade.reset_executor_degraded_state(
                                             ble_address=ble_address
                                         )
+                                except facade.FutureWaitShutdownError:
+                                    facade.logger.debug(
+                                        "BLE interface creation interrupted by shutdown for %s",
+                                        ble_address,
+                                    )
+                                    if future is not None and future.cancel():
+                                        facade._clear_ble_future(future)
+                                    elif future is not None:
+                                        facade._schedule_ble_future_cleanup(
+                                            future,
+                                            ble_address,
+                                            reason="interface creation shutdown cancellation",
+                                        )
+                                        facade._attach_late_ble_interface_disposer(
+                                            future,
+                                            ble_address,
+                                            reason="interface creation shutdown cancellation",
+                                            generation=connect_generation,
+                                        )
+                                    facade.meshtastic_iface = None
+                                    raise
                                 except facade.FuturesTimeoutError as err:
                                     facade.logger.error(
                                         "BLE interface creation timed out after %.1f seconds for %s.",
@@ -1146,10 +1169,7 @@ def _connect_meshtastic_impl(
                                         f"BLE connection attempt timed out for {ble_address}."
                                     ) from err
                             except TimeoutError as err:
-                                if (
-                                    facade.shutting_down
-                                    or str(err) == "Shutdown in progress"
-                                ):
+                                if facade.shutting_down:
                                     if future is not None and future.cancel():
                                         facade._clear_ble_future(future)
                                     elif future is not None:
@@ -1277,7 +1297,7 @@ def _connect_meshtastic_impl(
                         )
 
                         # Add timeout protection for connect() call to prevent indefinite hangs
-                        # Use ThreadPoolExecutor with 30-second timeout (same as CONNECTION_TIMEOUT)
+                        # Use the shared BLE executor with a 30-second timeout (same as CONNECTION_TIMEOUT)
                         def connect_iface(iface_param: Any) -> None:
                             """
                             Establishes the given interface by invoking its no-argument `connect()` method.
@@ -1293,7 +1313,7 @@ def _connect_meshtastic_impl(
                                 "Skipping BLE connect() for %s (shutting down)",
                                 ble_address,
                             )
-                            raise TimeoutError(
+                            raise facade.FutureWaitShutdownError(
                                 f"BLE connect cancelled for {ble_address} (shutting down)."
                             )
 
@@ -1326,6 +1346,10 @@ def _connect_meshtastic_impl(
                                     connect_iface, iface
                                 )
                             except RuntimeError as exc:
+                                if facade.shutting_down:
+                                    raise facade.FutureWaitShutdownError(
+                                        "BLE connect() submission interrupted by shutdown"
+                                    ) from exc
                                 facade.logger.exception(
                                     "BLE connect() submission failed for %s",
                                     ble_address,
@@ -1360,10 +1384,14 @@ def _connect_meshtastic_impl(
                             facade.reset_executor_degraded_state(
                                 ble_address=ble_address
                             )
-                        except (TimeoutError, facade.FuturesTimeoutError) as err:
+                        except (
+                            facade.FutureWaitShutdownError,
+                            TimeoutError,
+                            facade.FuturesTimeoutError,
+                        ) as err:
                             if (
-                                facade.shutting_down
-                                or str(err) == "Shutdown in progress"
+                                isinstance(err, facade.FutureWaitShutdownError)
+                                or facade.shutting_down
                             ):
                                 facade.logger.debug(
                                     "BLE connect() interrupted by shutdown for %s",
@@ -1773,6 +1801,17 @@ def _connect_meshtastic_impl(
             successful = False
             facade.logger.exception("Critical connection error")
             return None
+        except facade.FutureWaitShutdownError:
+            successful = False
+            client_assigned_for_this_connect = facade._rollback_connect_attempt_state(
+                client=client,
+                client_assigned_for_this_connect=client_assigned_for_this_connect,
+                startup_drain_armed_for_this_connect=startup_drain_armed_for_this_connect,
+                startup_drain_applied_for_this_connect=startup_drain_applied_for_this_connect,
+                reconnect_bootstrap_armed_for_this_connect=reconnect_bootstrap_armed_for_this_connect,
+            )
+            facade.logger.debug("Shutdown in progress. Aborting connection attempts.")
+            break
         except BLEDiscoveryTransientError as e:
             successful = False
             client_assigned_for_this_connect = facade._rollback_connect_attempt_state(

--- a/src/mmrelay/meshtastic/connection.py
+++ b/src/mmrelay/meshtastic/connection.py
@@ -1168,7 +1168,7 @@ def _connect_meshtastic_impl(
                                     raise TimeoutError(
                                         f"BLE connection attempt timed out for {ble_address}."
                                     ) from err
-                            except TimeoutError as err:
+                            except TimeoutError:
                                 if facade.shutting_down:
                                     if future is not None and future.cancel():
                                         facade._clear_ble_future(future)

--- a/src/mmrelay/meshtastic/daemon_executor.py
+++ b/src/mmrelay/meshtastic/daemon_executor.py
@@ -1,0 +1,109 @@
+"""Small daemon-thread executor for blocking operations that may never return."""
+
+from __future__ import annotations
+
+import queue
+import threading
+from concurrent.futures import Executor, Future
+from typing import Any, Callable
+
+_WorkItem = tuple[Future[Any], Callable[..., Any], tuple[Any, ...], dict[str, Any]]
+
+
+class DaemonThreadExecutor(Executor):
+    """Execute submitted callables on daemon worker threads.
+
+    ``ThreadPoolExecutor`` deliberately uses non-daemon workers and CPython waits
+    for those workers during interpreter shutdown. That is desirable for normal
+    jobs, but not for best-effort BLE calls into BlueZ/DBus that can wedge below
+    Python and never return. This executor keeps the familiar ``Future`` API while
+    ensuring a stuck worker cannot prevent the relay process from exiting.
+
+    The implementation intentionally uses only public ``concurrent.futures``
+    primitives so it does not depend on private CPython thread-pool internals.
+    """
+
+    def __init__(self, max_workers: int = 1, *, thread_name_prefix: str = "daemon"):
+        if max_workers <= 0:
+            raise ValueError("max_workers must be greater than 0")
+        self._max_workers = max_workers
+        self._thread_name_prefix = thread_name_prefix
+        self._work_queue: queue.Queue[_WorkItem | None] = queue.Queue()
+        self._threads: set[threading.Thread] = set()
+        self._lock = threading.Lock()
+        self._shutdown = False
+        self._thread_counter = 0
+
+    def submit(  # type: ignore[override]
+        self,
+        fn: Callable[..., Any],
+        /,
+        *args: Any,
+        **kwargs: Any,
+    ) -> Future[Any]:
+        with self._lock:
+            if self._shutdown:
+                raise RuntimeError("cannot schedule new futures after shutdown")
+            future: Future[Any] = Future()
+            self._work_queue.put((future, fn, args, kwargs))
+            self._start_worker_if_needed_locked()
+            return future
+
+    def _start_worker_if_needed_locked(self) -> None:
+        alive_threads = {thread for thread in self._threads if thread.is_alive()}
+        self._threads = alive_threads
+        if len(alive_threads) >= self._max_workers:
+            return
+
+        self._thread_counter += 1
+        worker = threading.Thread(
+            target=self._worker,
+            name=f"{self._thread_name_prefix}_{self._thread_counter}",
+            daemon=True,
+        )
+        self._threads.add(worker)
+        worker.start()
+
+    def _worker(self) -> None:
+        current = threading.current_thread()
+        try:
+            while True:
+                work_item = self._work_queue.get()
+                if work_item is None:
+                    return
+
+                future, fn, args, kwargs = work_item
+                if not future.set_running_or_notify_cancel():
+                    continue
+                try:
+                    result = fn(*args, **kwargs)
+                except BaseException as exc:  # Future must preserve task failures.
+                    future.set_exception(exc)
+                else:
+                    future.set_result(result)
+        finally:
+            with self._lock:
+                self._threads.discard(current)
+
+    def shutdown(self, wait: bool = True, *, cancel_futures: bool = False) -> None:
+        with self._lock:
+            first_shutdown = not self._shutdown
+            self._shutdown = True
+            threads = list(self._threads)
+
+            if cancel_futures:
+                while True:
+                    try:
+                        work_item = self._work_queue.get_nowait()
+                    except queue.Empty:
+                        break
+                    if work_item is not None:
+                        work_item[0].cancel()
+
+            if first_shutdown:
+                for _ in threads:
+                    self._work_queue.put(None)
+
+        if wait:
+            for thread in threads:
+                thread.join()

--- a/src/mmrelay/meshtastic/daemon_executor.py
+++ b/src/mmrelay/meshtastic/daemon_executor.py
@@ -23,7 +23,9 @@ class DaemonThreadExecutor(Executor):
     primitives so it does not depend on private CPython thread-pool internals.
     """
 
-    def __init__(self, max_workers: int = 1, *, thread_name_prefix: str = "daemon"):
+    def __init__(
+        self, max_workers: int = 1, *, thread_name_prefix: str = "daemon"
+    ) -> None:
         if max_workers <= 0:
             raise ValueError("max_workers must be greater than 0")
         self._max_workers = max_workers
@@ -87,7 +89,6 @@ class DaemonThreadExecutor(Executor):
 
     def shutdown(self, wait: bool = True, *, cancel_futures: bool = False) -> None:
         with self._lock:
-            first_shutdown = not self._shutdown
             self._shutdown = True
             threads = list(self._threads)
 
@@ -100,9 +101,11 @@ class DaemonThreadExecutor(Executor):
                     if work_item is not None:
                         work_item[0].cancel()
 
-            if first_shutdown:
-                for _ in threads:
-                    self._work_queue.put(None)
+            # Queue an exit signal for every currently live worker on every call.
+            # A repeated shutdown(cancel_futures=True) may have drained sentinels
+            # left by an earlier non-waiting shutdown.
+            for _ in threads:
+                self._work_queue.put(None)
 
         if wait:
             for thread in threads:

--- a/src/mmrelay/meshtastic/events.py
+++ b/src/mmrelay/meshtastic/events.py
@@ -138,7 +138,10 @@ def _clear_stale_ble_future_for_reconnect(
             facade._ble_future_timeout_secs = None
             if facade._ble_executor is not None:
                 stale_executor = facade._ble_executor
-                facade._ble_executor = facade.ThreadPoolExecutor(max_workers=1)
+                # Leave replacement lazy so every BLE worker is created through
+                # _get_ble_executor(), which uses daemon threads that cannot hold
+                # interpreter shutdown hostage if BlueZ/DBus wedges.
+                facade._ble_executor = None
     return ble_future_to_cancel, stale_executor, stale_ble_address
 
 

--- a/src/mmrelay/meshtastic/executors.py
+++ b/src/mmrelay/meshtastic/executors.py
@@ -1,9 +1,10 @@
 import threading
-from concurrent.futures import Future, ThreadPoolExecutor
+from concurrent.futures import Executor, Future, ThreadPoolExecutor
 from concurrent.futures import TimeoutError as FuturesTimeoutError
 from typing import Any, Callable
 
 import mmrelay.meshtastic_utils as facade
+from mmrelay.meshtastic.daemon_executor import DaemonThreadExecutor
 
 __all__ = [
     "_clear_ble_future",
@@ -207,7 +208,7 @@ def reset_executor_degraded_state(
     return reset_any
 
 
-def _get_ble_executor() -> ThreadPoolExecutor:
+def _get_ble_executor() -> Executor:
     """
     Get or create a BLE executor thread pool.
 
@@ -216,12 +217,14 @@ def _get_ble_executor() -> ThreadPoolExecutor:
     Note: Caller must hold _ble_executor_lock to avoid race conditions.
 
     Returns:
-        ThreadPoolExecutor: The shared BLE executor instance.
+        Executor: The shared BLE executor instance.
     """
     if facade._ble_executor is None or getattr(
         facade._ble_executor, "_shutdown", False
     ):
-        facade._ble_executor = facade.ThreadPoolExecutor(max_workers=1)
+        facade._ble_executor = DaemonThreadExecutor(
+            max_workers=1, thread_name_prefix="mmrelay-ble"
+        )
     return facade._ble_executor
 
 
@@ -616,7 +619,7 @@ def _maybe_reset_ble_executor(ble_address: str, timeout_count: int) -> None:
     # Capture future ref inside lock, cancel outside to avoid deadlock with done callbacks
     ble_future_to_cancel = None
     orphaned_workers = 0
-    stale_executor: ThreadPoolExecutor | None = None
+    stale_executor: Executor | None = None
     with facade._ble_executor_lock:
         if ble_address in facade._ble_executor_degraded_addresses:
             facade.logger.debug(
@@ -673,7 +676,9 @@ def _maybe_reset_ble_executor(ble_address: str, timeout_count: int) -> None:
                 orphaned_workers,
                 facade.EXECUTOR_ORPHAN_THRESHOLD,
             )
-            facade._ble_executor = facade.ThreadPoolExecutor(max_workers=1)
+            facade._ble_executor = DaemonThreadExecutor(
+                max_workers=1, thread_name_prefix="mmrelay-ble"
+            )
             facade._ble_future = None
             facade._ble_future_address = None
             facade._ble_future_started_at = None

--- a/src/mmrelay/meshtastic_utils.py
+++ b/src/mmrelay/meshtastic_utils.py
@@ -17,7 +17,7 @@ import math
 import sys
 import threading
 import time
-from concurrent.futures import Future, ThreadPoolExecutor
+from concurrent.futures import Executor, Future, ThreadPoolExecutor
 from concurrent.futures import TimeoutError as FuturesTimeoutError
 from typing import Any, Awaitable, Callable, Coroutine, cast
 
@@ -310,7 +310,7 @@ _health_probe_request_lock = threading.Lock()
 
 # Shared executor for BLE init/connect to avoid leaking threads across retries.
 # BLE setup is inherently sequential, so a single worker keeps things predictable.
-_ble_executor: ThreadPoolExecutor | None = ThreadPoolExecutor(max_workers=1)
+_ble_executor: Executor | None = None
 _ble_executor_lock = threading.Lock()
 _ble_future: Future[Any] | None = None
 _ble_future_address: str | None = None
@@ -360,6 +360,7 @@ from mmrelay.meshtastic.async_utils import (
     _coerce_positive_int,
     _coerce_positive_int_id,
     _fire_and_forget,
+    FutureWaitShutdownError,
     _make_awaitable,
     _run_blocking_with_timeout,
     _submit_coro,

--- a/tests/test_meshtastic_async_utils.py
+++ b/tests/test_meshtastic_async_utils.py
@@ -331,13 +331,13 @@ class TestRunBlockingWithTimeout:
 
 @pytest.mark.usefixtures("reset_meshtastic_globals")
 class TestWaitForFutureResultWithShutdown:
-    def test_raises_on_shutdown(self):
+    def test_raises_on_shutdown(self, monkeypatch: pytest.MonkeyPatch):
         from mmrelay.meshtastic.async_utils import (
             FutureWaitShutdownError,
             _wait_for_future_result_with_shutdown,
         )
 
-        mu.shutting_down = True
+        monkeypatch.setattr(mu, "shutting_down", True)
         fut = Future()
         with pytest.raises(FutureWaitShutdownError, match="Shutdown"):
             _wait_for_future_result_with_shutdown(fut, timeout_seconds=5)

--- a/tests/test_meshtastic_async_utils.py
+++ b/tests/test_meshtastic_async_utils.py
@@ -333,12 +333,13 @@ class TestRunBlockingWithTimeout:
 class TestWaitForFutureResultWithShutdown:
     def test_raises_on_shutdown(self):
         from mmrelay.meshtastic.async_utils import (
+            FutureWaitShutdownError,
             _wait_for_future_result_with_shutdown,
         )
 
         mu.shutting_down = True
         fut = Future()
-        with pytest.raises(TimeoutError, match="Shutdown"):
+        with pytest.raises(FutureWaitShutdownError, match="Shutdown"):
             _wait_for_future_result_with_shutdown(fut, timeout_seconds=5)
 
     def test_raises_on_deadline(self):

--- a/tests/test_meshtastic_connection.py
+++ b/tests/test_meshtastic_connection.py
@@ -606,8 +606,7 @@ class TestConnectMeshtasticTimeoutBranches:
             for call in mock_logger.error.call_args_list
         )
         assert not any(
-            "stale BlueZ" in str(call)
-            for call in mock_logger.warning.call_args_list
+            "stale BlueZ" in str(call) for call in mock_logger.warning.call_args_list
         )
         assert any(
             "interrupted by shutdown" in str(call)

--- a/tests/test_meshtastic_connection.py
+++ b/tests/test_meshtastic_connection.py
@@ -564,6 +564,56 @@ class TestConnectMeshtasticTimeoutBranches:
         mu.meshtastic_iface = None
         return ble_address
 
+    def test_interface_creation_shutdown_is_not_reported_as_timeout(self, monkeypatch):
+        from mmrelay.meshtastic.connection import _connect_meshtastic_impl
+
+        self._configure_ble()
+
+        class FakeBleInterface:
+            def __init__(
+                self,
+                *,
+                address,
+                noProto=False,
+                debugOut=None,
+                noNodes=False,
+                timeout=None,
+                auto_reconnect=False,
+            ):
+                self.address = address
+                self.auto_reconnect = auto_reconnect
+
+        pending_future = Future()
+        mock_executor = MagicMock()
+        mock_executor.submit.return_value = pending_future
+
+        with (
+            patch.object(mu.meshtastic.ble_interface, "BLEInterface", FakeBleInterface),
+            patch.object(mu, "_get_ble_executor", return_value=mock_executor),
+            patch.object(
+                mu,
+                "_wait_for_future_result_with_shutdown",
+                side_effect=mu.FutureWaitShutdownError("Shutdown in progress"),
+            ),
+            patch.object(mu, "_ensure_ble_worker_available"),
+            patch.object(mu, "logger") as mock_logger,
+        ):
+            result = _connect_meshtastic_impl()
+
+        assert result is None
+        assert not any(
+            "BLE interface creation timed out" in str(call)
+            for call in mock_logger.error.call_args_list
+        )
+        assert not any(
+            "stale BlueZ" in str(call)
+            for call in mock_logger.warning.call_args_list
+        )
+        assert any(
+            "interrupted by shutdown" in str(call)
+            for call in mock_logger.debug.call_args_list
+        )
+
     def test_typed_timeout_return_action(self, monkeypatch):
         from mmrelay.meshtastic.connection import _connect_meshtastic_impl
 

--- a/tests/test_meshtastic_connection.py
+++ b/tests/test_meshtastic_connection.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from concurrent.futures import Future
-from typing import Callable
+from typing import Any, Callable
 from unittest.mock import ANY, MagicMock, patch
 
 import pytest
@@ -638,8 +638,10 @@ class TestConnectMeshtasticTimeoutBranches:
                 return None
 
         class ImmediateExecutor:
-            def submit(self, fn, *args):
-                future = Future()
+            def submit(
+                self, fn: Callable[..., Any], /, *args: Any
+            ) -> Future[Any]:
+                future: Future[Any] = Future()
                 try:
                     future.set_result(fn(*args))
                 except BaseException as exc:
@@ -648,7 +650,12 @@ class TestConnectMeshtasticTimeoutBranches:
 
         wait_count = 0
 
-        def _wait_then_shutdown(future, *, timeout_seconds, poll_seconds=1.0):
+        def _wait_then_shutdown(
+            future: Future[Any],
+            *,
+            timeout_seconds: float,
+            poll_seconds: float = 1.0,
+        ) -> Any:
             nonlocal wait_count
             del timeout_seconds, poll_seconds
             wait_count += 1

--- a/tests/test_meshtastic_connection.py
+++ b/tests/test_meshtastic_connection.py
@@ -564,7 +564,7 @@ class TestConnectMeshtasticTimeoutBranches:
         mu.meshtastic_iface = None
         return ble_address
 
-    def test_interface_creation_shutdown_is_not_reported_as_timeout(self, monkeypatch):
+    def test_interface_creation_shutdown_is_not_reported_as_timeout(self):
         from mmrelay.meshtastic.connection import _connect_meshtastic_impl
 
         self._configure_ble()
@@ -573,13 +573,14 @@ class TestConnectMeshtasticTimeoutBranches:
             def __init__(
                 self,
                 *,
-                address,
-                noProto=False,
-                debugOut=None,
-                noNodes=False,
-                timeout=None,
-                auto_reconnect=False,
-            ):
+                address: str,
+                noProto: bool = False,
+                debugOut: object | None = None,
+                noNodes: bool = False,
+                timeout: int | None = None,
+                auto_reconnect: bool = False,
+            ) -> None:
+                del noProto, debugOut, noNodes, timeout
                 self.address = address
                 self.auto_reconnect = auto_reconnect
 
@@ -610,6 +611,81 @@ class TestConnectMeshtasticTimeoutBranches:
         )
         assert any(
             "interrupted by shutdown" in str(call)
+            for call in mock_logger.debug.call_args_list
+        )
+
+    def test_ble_connect_shutdown_is_not_reported_as_timeout(self):
+        from mmrelay.meshtastic.connection import _connect_meshtastic_impl
+
+        ble_address = self._configure_ble()
+
+        class FakeBleInterface:
+            def __init__(
+                self,
+                *,
+                address: str,
+                noProto: bool = False,
+                debugOut: object | None = None,
+                noNodes: bool = False,
+                timeout: int | None = None,
+                auto_reconnect: bool = False,
+            ) -> None:
+                del noProto, debugOut, noNodes, timeout
+                self.address = address
+                self.auto_reconnect = auto_reconnect
+
+            def connect(self) -> None:
+                return None
+
+        class ImmediateExecutor:
+            def submit(self, fn, *args):
+                future = Future()
+                try:
+                    future.set_result(fn(*args))
+                except BaseException as exc:
+                    future.set_exception(exc)
+                return future
+
+        wait_count = 0
+
+        def _wait_then_shutdown(future, *, timeout_seconds, poll_seconds=1.0):
+            nonlocal wait_count
+            del timeout_seconds, poll_seconds
+            wait_count += 1
+            if wait_count == 1:
+                return future.result()
+            raise mu.FutureWaitShutdownError("Shutdown in progress")
+
+        mock_executor = ImmediateExecutor()
+        with (
+            patch.object(mu.meshtastic.ble_interface, "BLEInterface", FakeBleInterface),
+            patch.object(mu, "_get_ble_executor", return_value=mock_executor),
+            patch.object(
+                mu,
+                "_wait_for_future_result_with_shutdown",
+                side_effect=_wait_then_shutdown,
+            ),
+            patch.object(mu, "_ensure_ble_worker_available"),
+            patch.object(mu, "_get_ble_unresolved_teardown_generations", return_value=[]),
+            patch.object(mu, "logger") as mock_logger,
+        ):
+            result = _connect_meshtastic_impl()
+
+        assert result is None
+        assert wait_count == 2
+        assert mu.meshtastic_iface is None
+        assert mu._ble_future is None
+        assert mu._ble_future_address is None
+        assert not any(
+            "BLE connect() call timed out" in str(call)
+            for call in mock_logger.error.call_args_list
+        )
+        assert not any(
+            "stale BlueZ" in str(call) for call in mock_logger.warning.call_args_list
+        )
+        assert any(
+            call.args[:2]
+            == ("BLE connect() interrupted by shutdown for %s", ble_address)
             for call in mock_logger.debug.call_args_list
         )
 

--- a/tests/test_meshtastic_connection.py
+++ b/tests/test_meshtastic_connection.py
@@ -1679,3 +1679,92 @@ class TestBleTeardownBarrier:
         assert disconnected_iface.connect.call_count == 0
         assert mu.meshtastic_iface is None
         assert mu.meshtastic_client is None
+
+    def test_shutdown_before_connect_submits_disposes_published_iface(self):
+        from mmrelay.meshtastic.connection import _connect_meshtastic_impl
+
+        class BleInterfaceWithConnect:
+            def __init__(  # noqa: PLR0913
+                self,
+                *,
+                address: str,
+                noProto: bool,  # noqa: N803
+                debugOut: object,  # noqa: N803
+                noNodes: bool,  # noqa: N803
+                timeout: int,
+                auto_reconnect: bool = True,
+            ) -> None:
+                _ = (noProto, debugOut, noNodes, timeout)
+                self.address = address
+                self.client = object()
+                self.auto_reconnect = auto_reconnect
+                self.connect = MagicMock()
+
+        ble_address = "44:55:66:77:88:99"
+        mu.config = {
+            "meshtastic": {
+                "connection_type": "ble",
+                "ble_address": ble_address,
+                "retries": 1,
+            }
+        }
+        mu.shutting_down = False
+        mu.reconnecting = False
+        mu.meshtastic_client = None
+        mu.meshtastic_iface = None
+
+        unresolved_calls = 0
+
+        def _unresolved_teardown_then_shutdown(
+            _address: str,
+        ) -> list[tuple[int, int]]:
+            nonlocal unresolved_calls
+            unresolved_calls += 1
+            if unresolved_calls == 1:
+                # Allow interface creation pre-check.
+                return []
+            # Shutdown lands after interface construction but before the
+            # connect() submission check.
+            mu.shutting_down = True
+            return []
+
+        def _sync_submit(
+            fn: Callable[..., object], *args: object, **kwargs: object
+        ) -> Future[object]:
+            future: Future[object] = Future()
+            try:
+                future.set_result(fn(*args, **kwargs))
+            except Exception as exc:  # noqa: BLE001 - test harness helper
+                future.set_exception(exc)
+            return future
+
+        mock_executor = MagicMock()
+        mock_executor.submit.side_effect = _sync_submit
+
+        with (
+            patch.object(
+                mu, "_get_ble_unresolved_teardown_generations"
+            ) as mock_unresolved,
+            patch.object(mu, "_disconnect_ble_by_address"),
+            patch.object(mu, "_get_ble_executor", return_value=mock_executor),
+            patch.object(mu, "_disconnect_ble_interface") as mock_disconnect_iface,
+            patch.object(
+                mu.meshtastic.ble_interface,
+                "BLEInterface",
+                BleInterfaceWithConnect,
+            ),
+        ):
+            mock_unresolved.side_effect = _unresolved_teardown_then_shutdown
+            result = _connect_meshtastic_impl()
+
+        assert result is None
+        assert unresolved_calls >= 2
+        assert mock_disconnect_iface.call_count == 1
+        disconnected_iface = mock_disconnect_iface.call_args.args[0]
+        assert disconnected_iface.address == ble_address
+        assert (
+            mock_disconnect_iface.call_args.kwargs["reason"] == "connect setup failed"
+        )
+        assert disconnected_iface.connect.call_count == 0
+        assert mu.meshtastic_iface is None
+        assert mu.meshtastic_client is None

--- a/tests/test_meshtastic_connection.py
+++ b/tests/test_meshtastic_connection.py
@@ -666,7 +666,9 @@ class TestConnectMeshtasticTimeoutBranches:
                 side_effect=_wait_then_shutdown,
             ),
             patch.object(mu, "_ensure_ble_worker_available"),
-            patch.object(mu, "_get_ble_unresolved_teardown_generations", return_value=[]),
+            patch.object(
+                mu, "_get_ble_unresolved_teardown_generations", return_value=[]
+            ),
             patch.object(mu, "logger") as mock_logger,
         ):
             result = _connect_meshtastic_impl()

--- a/tests/test_meshtastic_connection.py
+++ b/tests/test_meshtastic_connection.py
@@ -638,9 +638,7 @@ class TestConnectMeshtasticTimeoutBranches:
                 return None
 
         class ImmediateExecutor:
-            def submit(
-                self, fn: Callable[..., Any], /, *args: Any
-            ) -> Future[Any]:
+            def submit(self, fn: Callable[..., Any], /, *args: Any) -> Future[Any]:
                 future: Future[Any] = Future()
                 try:
                     future.set_result(fn(*args))

--- a/tests/test_meshtastic_executors.py
+++ b/tests/test_meshtastic_executors.py
@@ -4,6 +4,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 import mmrelay.meshtastic_utils as mu
+from mmrelay.meshtastic.daemon_executor import DaemonThreadExecutor
 
 
 @pytest.mark.usefixtures("reset_meshtastic_globals")
@@ -52,8 +53,38 @@ class TestGetBleExecutor:
         with mu._ble_executor_lock:
             executor = _get_ble_executor()
         assert executor is not None
-        assert isinstance(executor, ThreadPoolExecutor)
+        assert isinstance(executor, DaemonThreadExecutor)
         executor.shutdown(wait=False)
+
+    def test_worker_thread_is_daemon_and_shutdown_does_not_wait(self):
+        import threading
+        import time
+
+        from mmrelay.meshtastic.executors import _get_ble_executor
+
+        started = threading.Event()
+        release = threading.Event()
+
+        def _blocking_ble_call() -> None:
+            started.set()
+            release.wait(5.0)
+
+        mu._ble_executor = None
+        with mu._ble_executor_lock:
+            executor = _get_ble_executor()
+        future = executor.submit(_blocking_ble_call)
+        assert started.wait(1.0)
+        assert isinstance(executor, DaemonThreadExecutor)
+        assert executor._threads
+        assert all(thread.daemon for thread in executor._threads)
+
+        started_at = time.monotonic()
+        executor.shutdown(wait=False, cancel_futures=True)
+        assert time.monotonic() - started_at < 0.5
+        assert not future.cancelled()
+
+        release.set()
+        future.result(timeout=1.0)
 
     def test_recreates_when_shutdown(self):
         from mmrelay.meshtastic.executors import _get_ble_executor
@@ -65,7 +96,7 @@ class TestGetBleExecutor:
         with mu._ble_executor_lock:
             executor = _get_ble_executor()
         assert executor is not old
-        assert isinstance(executor, ThreadPoolExecutor)
+        assert isinstance(executor, DaemonThreadExecutor)
         executor.shutdown(wait=False)
 
 

--- a/tests/test_meshtastic_executors.py
+++ b/tests/test_meshtastic_executors.py
@@ -73,18 +73,63 @@ class TestGetBleExecutor:
         with mu._ble_executor_lock:
             executor = _get_ble_executor()
         future = executor.submit(_blocking_ble_call)
+        queued_ran = threading.Event()
+        queued_future = executor.submit(queued_ran.set)
         assert started.wait(1.0)
         assert isinstance(executor, DaemonThreadExecutor)
-        assert executor._threads
-        assert all(thread.daemon for thread in executor._threads)
+        worker_threads = list(executor._threads)
+        assert worker_threads
+        assert all(thread.daemon for thread in worker_threads)
 
         started_at = time.monotonic()
         executor.shutdown(wait=False, cancel_futures=True)
         assert time.monotonic() - started_at < 0.5
         assert not future.cancelled()
+        assert queued_future.cancelled()
+        assert not queued_ran.is_set()
 
         release.set()
         future.result(timeout=1.0)
+        for thread in worker_threads:
+            thread.join(timeout=1.0)
+            assert not thread.is_alive()
+
+    def test_repeated_shutdown_restores_worker_sentinel(self):
+        import threading
+
+        started = threading.Event()
+        release = threading.Event()
+        executor = DaemonThreadExecutor(
+            max_workers=1, thread_name_prefix="repeat-shutdown"
+        )
+
+        def _blocking_call() -> None:
+            started.set()
+            release.wait(5.0)
+
+        future = executor.submit(_blocking_call)
+        assert started.wait(1.0)
+        worker_threads = list(executor._threads)
+
+        executor.shutdown(wait=False)
+
+        shutdown_done = threading.Event()
+
+        def _repeat_shutdown() -> None:
+            executor.shutdown(wait=True, cancel_futures=True)
+            shutdown_done.set()
+
+        shutdown_thread = threading.Thread(target=_repeat_shutdown, daemon=True)
+        shutdown_thread.start()
+        release.set()
+        future.result(timeout=1.0)
+
+        assert shutdown_done.wait(1.0), "repeated shutdown must not strand a worker"
+        shutdown_thread.join(timeout=1.0)
+        assert not shutdown_thread.is_alive()
+        for thread in worker_threads:
+            thread.join(timeout=1.0)
+            assert not thread.is_alive()
 
     def test_recreates_when_shutdown(self):
         from mmrelay.meshtastic.executors import _get_ble_executor

--- a/tests/test_meshtastic_utils_async.py
+++ b/tests/test_meshtastic_utils_async.py
@@ -809,13 +809,15 @@ def test_wait_for_future_result_with_shutdown_returns_result():
 def test_wait_for_future_result_with_shutdown_aborts_when_shutting_down():
     future = MagicMock()
 
-    with patch.object(mu, "shutting_down", True):
-        with pytest.raises(FutureWaitShutdownError, match="Shutdown in progress"):
-            _wait_for_future_result_with_shutdown(
-                future,
-                timeout_seconds=0.5,
-                poll_seconds=0.01,
-            )
+    with (
+        patch.object(mu, "shutting_down", True),
+        pytest.raises(FutureWaitShutdownError, match="Shutdown in progress"),
+    ):
+        _wait_for_future_result_with_shutdown(
+            future,
+            timeout_seconds=0.5,
+            poll_seconds=0.01,
+        )
 
     future.result.assert_not_called()
 

--- a/tests/test_meshtastic_utils_async.py
+++ b/tests/test_meshtastic_utils_async.py
@@ -26,6 +26,7 @@ import pytest
 import mmrelay.meshtastic_utils as _mu_real
 import mmrelay.meshtastic_utils as mu
 from mmrelay.meshtastic_utils import (
+    FutureWaitShutdownError,
     _get_name_safely,
     _make_awaitable,
     _wait_for_future_result_with_shutdown,
@@ -809,7 +810,7 @@ def test_wait_for_future_result_with_shutdown_aborts_when_shutting_down():
     future = MagicMock()
 
     with patch.object(mu, "shutting_down", True):
-        with pytest.raises(TimeoutError, match="Shutdown in progress"):
+        with pytest.raises(FutureWaitShutdownError, match="Shutdown in progress"):
             _wait_for_future_result_with_shutdown(
                 future,
                 timeout_seconds=0.5,

--- a/tests/test_meshtastic_utils_disconnect.py
+++ b/tests/test_meshtastic_utils_disconnect.py
@@ -783,6 +783,22 @@ class TestReconnectCancellation:
 class TestConnectionLostHandlerClearingStaleBleFuture:
     """Test connection lost handler clearing stale BLE future."""
 
+    def test_stale_ble_executor_is_not_replaced_with_non_daemon_pool(self):
+        from mmrelay.meshtastic.events import _clear_stale_ble_future_for_reconnect
+
+        old_executor = MagicMock()
+        mu._ble_executor = old_executor
+        mu._ble_future = MagicMock()
+        mu._ble_future.done.return_value = False
+        mu._ble_future_address = "AA:BB:CC:DD:EE:FF"
+
+        _future, stale_executor, _address = _clear_stale_ble_future_for_reconnect(
+            "test"
+        )
+
+        assert stale_executor is old_executor
+        assert mu._ble_executor is None
+
     def test_on_lost_meshtastic_connection_clears_ble_future_globals(self):
         """Test that _ble_future, _ble_future_address, _ble_future_started_at, _ble_future_timeout_secs are cleared."""
         mock_future = Mock(spec=Future)

--- a/tests/test_meshtastic_utils_disconnect.py
+++ b/tests/test_meshtastic_utils_disconnect.py
@@ -783,14 +783,19 @@ class TestReconnectCancellation:
 class TestConnectionLostHandlerClearingStaleBleFuture:
     """Test connection lost handler clearing stale BLE future."""
 
-    def test_stale_ble_executor_is_not_replaced_with_non_daemon_pool(self):
+    def test_stale_ble_executor_is_not_replaced_with_non_daemon_pool(self, monkeypatch):
         from mmrelay.meshtastic.events import _clear_stale_ble_future_for_reconnect
 
         old_executor = MagicMock()
-        mu._ble_executor = old_executor
-        mu._ble_future = MagicMock()
-        mu._ble_future.done.return_value = False
-        mu._ble_future_address = "AA:BB:CC:DD:EE:FF"
+        pending_future = MagicMock()
+        pending_future.done.return_value = False
+        ble_address = "AA:BB:CC:DD:EE:FF"
+        monkeypatch.setattr(mu, "_ble_executor", old_executor)
+        monkeypatch.setattr(mu, "_ble_future", pending_future)
+        monkeypatch.setattr(mu, "_ble_future_address", ble_address)
+        monkeypatch.setattr(mu, "_ble_future_started_at", 123.0)
+        monkeypatch.setattr(mu, "_ble_future_timeout_secs", 30.0)
+        monkeypatch.setattr(mu, "_ble_timeout_counts", {ble_address: 2})
 
         _future, stale_executor, _address = _clear_stale_ble_future_for_reconnect(
             "test"
@@ -798,6 +803,11 @@ class TestConnectionLostHandlerClearingStaleBleFuture:
 
         assert stale_executor is old_executor
         assert mu._ble_executor is None
+        assert mu._ble_future is None
+        assert mu._ble_future_address is None
+        assert mu._ble_future_started_at is None
+        assert mu._ble_future_timeout_secs is None
+        assert ble_address not in mu._ble_timeout_counts
 
     def test_on_lost_meshtastic_connection_clears_ble_future_globals(self):
         """Test that _ble_future, _ble_future_address, _ble_future_started_at, _ble_future_timeout_secs are cleared."""

--- a/tests/test_meshtastic_utils_metadata.py
+++ b/tests/test_meshtastic_utils_metadata.py
@@ -666,9 +666,9 @@ class TestUncoveredMeshtasticUtils(unittest.TestCase):
             7.0,
         )
 
-    @patch("mmrelay.meshtastic_utils.ThreadPoolExecutor")
+    @patch("mmrelay.meshtastic.executors.DaemonThreadExecutor")
     def test_maybe_reset_ble_executor_handles_cancel_timeout_and_stale_executor_shutdown(
-        self, mock_thread_pool
+        self, mock_daemon_executor
     ):
         """BLE executor reset should cancel stale futures and shutdown old executors."""
         import mmrelay.meshtastic_utils as mu
@@ -690,7 +690,7 @@ class TestUncoveredMeshtasticUtils(unittest.TestCase):
         stale_future.result.side_effect = ConcurrentTimeoutError()
 
         replacement_executor = Mock()
-        mock_thread_pool.return_value = replacement_executor
+        mock_daemon_executor.return_value = replacement_executor
         created_executor = None
 
         try:
@@ -719,7 +719,7 @@ class TestUncoveredMeshtasticUtils(unittest.TestCase):
 
         stale_future.cancel.assert_called_once()
         stale_executor.shutdown.assert_called_once_with(wait=False, cancel_futures=True)
-        mock_thread_pool.assert_called_once()
+        mock_daemon_executor.assert_called_once()
         self.assertIs(created_executor, replacement_executor)
 
     @patch("mmrelay.meshtastic_utils.logger")


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview

This change improves BLE shutdown handling. It prevents daemon workers from blocking shutdown and distinguishes shutdown interruptions from connection timeouts. It also simplifies BLE executor cleanup and adds regression tests.

## Key changes

### Features
- Added `DaemonThreadExecutor` with daemon worker threads.
- Added `FutureWaitShutdownError` for shutdown-aborted future waits.
- Added cancellation support for queued futures during executor shutdown.
- Added tests for daemon workers, non-blocking shutdown, and future cancellation.

### Fixes
- BLE connection attempts now stop cleanly when shutdown begins.
- Pending BLE futures are cancelled or scheduled for late cleanup.
- BLE references are cleared after shutdown interruptions.
- Shutdown interruptions no longer produce timeout or stale-BlueZ diagnostics.
- Deferred executor replacement prevents stale cleanup from creating an unused executor.
- Added regression tests for shutdown during BLE interface creation and connection.

### Refactors
- Updated BLE executor handling to use the generic `Executor` interface.
- Deferred BLE executor creation until it is required.
- Updated imports, tests, and exception handling for `DaemonThreadExecutor` and `FutureWaitShutdownError`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->