### PR TITLE
Ensure reliable file output path and rotation for logging

### DIFF
--- a/docs/ADVANCED_CONFIGURATION.md
+++ b/docs/ADVANCED_CONFIGURATION.md
@@ -329,6 +329,14 @@ Use environment variables **only** when:
 | `MMRELAY_HOME`                               | _(path override)_                    | string  | Override application home directory (default: `~/.mmrelay`)                                                          |
 | `MMRELAY_LOG_PATH`                           | _(path override)_                    | string  | Override log file path (default: `<home>/logs/mmrelay.log`)                                                          |
 
+For the application log file, path precedence is `--logfile`, `MMRELAY_LOG_PATH`,
+`logging.filename` (including `MMRELAY_LOG_FILE`), then the default
+`<home>/logs/mmrelay.log`. User-home (`~`) and environment-variable markers are
+expanded before the file is opened. Normal direct runs and the systemd service
+use the same file-logging rules; systemd additionally captures console output in
+the journal. CLI-only maintenance commands may suppress file logging unless it
+is explicitly enabled.
+
 ## Tips for Advanced Configuration
 
 ### Performance Considerations

--- a/docs/ADVANCED_CONFIGURATION.md
+++ b/docs/ADVANCED_CONFIGURATION.md
@@ -329,9 +329,10 @@ Use environment variables **only** when:
 | `MMRELAY_HOME`                               | _(path override)_                    | string  | Override application home directory (default: `~/.mmrelay`)                                                          |
 | `MMRELAY_LOG_PATH`                           | _(path override)_                    | string  | Override log file path (default: `<home>/logs/mmrelay.log`)                                                          |
 
-For the application log file, path precedence is `--logfile`, `MMRELAY_LOG_PATH`,
-`logging.filename` (including `MMRELAY_LOG_FILE`), then the default
-`<home>/logs/mmrelay.log`. User-home (`~`) and environment-variable markers are
+For the application log file, path precedence is the explicit logfile CLI option,
+`MMRELAY_LOG_PATH`, `logging.filename` (including `MMRELAY_LOG_FILE`), then the
+default `<home>/logs/mmrelay.log`. User home directory (`~`) and
+environment-variable markers are
 expanded before the file is opened. Normal direct runs and the systemd service
 use the same file-logging rules; systemd additionally captures console output in
 the journal. CLI-only maintenance commands may suppress file logging unless it

--- a/src/mmrelay/log_utils.py
+++ b/src/mmrelay/log_utils.py
@@ -415,7 +415,8 @@ def _configure_logger(
                 os.makedirs(log_dir, exist_ok=True)
             except OSError as e:
                 if logger.name == APP_DISPLAY_NAME:
-                    log_file_path = None
+                    with _shared_file_handler_lock:
+                        log_file_path = None
                 # Use the logger itself to report the error if available, otherwise print
                 error_msg = f"Error creating log directory {log_dir}: {e}"
                 if logger and logger.handlers:
@@ -438,7 +439,8 @@ def _configure_logger(
             )
         except OSError as e:
             if logger.name == APP_DISPLAY_NAME:
-                log_file_path = None
+                with _shared_file_handler_lock:
+                    log_file_path = None
             error_msg = f"Error creating log file at {log_file}: {e}"
             if logger and logger.handlers:
                 logger.exception(error_msg)
@@ -447,7 +449,8 @@ def _configure_logger(
             return logger
         except Exception as e:
             if logger.name == APP_DISPLAY_NAME:
-                log_file_path = None
+                with _shared_file_handler_lock:
+                    log_file_path = None
             error_msg = f"Unexpected error creating log file at {log_file}: {e}"
             if logger and logger.handlers:
                 logger.exception(error_msg)
@@ -457,9 +460,11 @@ def _configure_logger(
 
         logger.addHandler(file_handler)
         if logger.name == APP_DISPLAY_NAME:
-            log_file_path = file_handler.baseFilename
+            with _shared_file_handler_lock:
+                log_file_path = file_handler.baseFilename
     elif logger.name == APP_DISPLAY_NAME:
-        log_file_path = None
+        with _shared_file_handler_lock:
+            log_file_path = None
 
     _logger_config_generations[logger.name] = _config_generation
     return logger

--- a/src/mmrelay/log_utils.py
+++ b/src/mmrelay/log_utils.py
@@ -98,6 +98,12 @@ _COMPONENT_LOGGERS = {
     ],
 }
 
+# Component loggers are owned by third-party libraries, so only detach handlers
+# that this module previously attached. This preserves handlers installed by an
+# embedding application while allowing refreshes to replace MMRelay's console
+# and shared-file handlers exactly once.
+_component_attached_handlers: Dict[str, Set[logging.Handler]] = {}
+
 # Avoid file logging for loggers that are used during path resolution to
 # prevent recursive logging configuration (paths -> log_utils -> paths).
 # Include both the short name and fully-qualified name for robustness.
@@ -136,6 +142,13 @@ def configure_component_debug_logging() -> None:
     for component, loggers in _COMPONENT_LOGGERS.items():
         component_config = debug_config.get(component)
 
+        for logger_name in loggers:
+            component_logger = logging.getLogger(logger_name)
+            previous_handlers = _component_attached_handlers.pop(logger_name, set())
+            for handler in previous_handlers:
+                if handler in component_logger.handlers:
+                    component_logger.removeHandler(handler)
+
         if component_config:
             # Component debug is enabled - check if it's a boolean or a log level
             if isinstance(component_config, bool):
@@ -159,8 +172,8 @@ def configure_component_debug_logging() -> None:
                 component_logger.propagate = False  # Prevent duplicate logging
                 # Attach main handlers to the component logger
                 for handler in main_handlers:
-                    if handler not in component_logger.handlers:
-                        component_logger.addHandler(handler)
+                    component_logger.addHandler(handler)
+                _component_attached_handlers[logger_name] = set(main_handlers)
         else:
             # Component debug is disabled - completely suppress external library logging
             # Use a level higher than CRITICAL to effectively disable all messages

--- a/src/mmrelay/log_utils.py
+++ b/src/mmrelay/log_utils.py
@@ -523,3 +523,8 @@ def refresh_all_loggers(args: argparse.Namespace | None = None) -> None:
 
     for logger_name in list(_registered_logger_names):
         _configure_logger(logging.getLogger(logger_name), args=args)
+
+    # Component loggers are configured directly through logging.getLogger() and
+    # are therefore not part of _registered_logger_names. Reapply their settings
+    # so they receive the newly-created shared handler after the old one closes.
+    configure_component_debug_logging()

--- a/src/mmrelay/log_utils.py
+++ b/src/mmrelay/log_utils.py
@@ -2,6 +2,7 @@ import argparse
 import contextlib
 import logging
 import os
+import threading
 from logging.handlers import RotatingFileHandler
 from typing import TYPE_CHECKING, Any, Dict, Iterator, Optional, Set
 
@@ -56,8 +57,16 @@ LOG_LEVEL_STYLES = {
 # Global config variable that will be set from main.py
 config = None
 
-# Global variable to store the log file path
-log_file_path = None
+# Global variable to store the active log file path. This is populated only
+# after a file handler has been opened successfully.
+log_file_path: str | None = None
+
+# All MMRelay loggers share one rotating file handler. Separate
+# RotatingFileHandler instances pointed at the same path can rotate underneath
+# one another, leaving different loggers writing to different generations.
+_shared_file_handler: RotatingFileHandler | None = None
+_shared_file_handler_key: tuple[str, int, int] | None = None
+_shared_file_handler_lock = threading.RLock()
 
 # Track loggers configured through this module so we can reconfigure them when
 # configuration changes later in the startup sequence.
@@ -191,25 +200,32 @@ def _should_log_to_file(args: argparse.Namespace | None) -> bool:
     return bool(enabled)
 
 
+def _expand_log_path(path: str) -> str:
+    """Expand environment/user markers and return an absolute log path."""
+    return os.path.abspath(os.path.expandvars(os.path.expanduser(path)))
+
+
 def _resolve_log_file(args: argparse.Namespace | None) -> str:
-    """
-    Resolve the log file path using the following precedence: CLI `args.logfile`, configuration `logging.filename`, or the default "<log_dir>/mmrelay.log".
+    """Resolve the active log path.
 
-    Parameters:
-        args (argparse.Namespace | None): Optional namespace that may contain a `logfile` attribute; when present and a non-empty string, that value is selected.
-
-    Returns:
-        str: Filesystem path chosen for log output.
+    Precedence is explicit ``--logfile``, ``MMRELAY_LOG_PATH``, configured
+    ``logging.filename`` (including the ``MMRELAY_LOG_FILE`` config override),
+    then the default logs directory. All selected paths expand ``~`` and
+    environment-variable markers before use.
     """
     logfile = getattr(args, "logfile", None) if args is not None else None
     if isinstance(logfile, str) and logfile:
-        return logfile
+        return _expand_log_path(logfile)
+
+    env_log_file = os.getenv("MMRELAY_LOG_PATH")
+    if env_log_file:
+        return _expand_log_path(env_log_file)
 
     config_log_file = config.get("logging", {}).get("filename") if config else None
     if isinstance(config_log_file, str) and config_log_file:
-        return config_log_file
+        return _expand_log_path(config_log_file)
 
-    return os.path.join(get_log_dir(), LOG_FILENAME)
+    return _expand_log_path(os.path.join(get_log_dir(), LOG_FILENAME))
 
 
 class LogsDirTypeError(TypeError):
@@ -234,6 +250,70 @@ def get_log_dir() -> str:
     if not isinstance(result, str):
         raise LogsDirTypeError()
     return result
+
+
+def _detach_handler_from_all_loggers(handler: logging.Handler) -> None:
+    """Remove a shared handler from every live logger before closing it."""
+    loggers: list[logging.Logger] = [logging.getLogger()]
+    for value in logging.Logger.manager.loggerDict.values():
+        if isinstance(value, logging.Logger):
+            loggers.append(value)
+    for logger in loggers:
+        if handler in logger.handlers:
+            logger.removeHandler(handler)
+
+
+def _close_shared_file_handler() -> None:
+    """Detach and close the process-wide rotating file handler, if present."""
+    global _shared_file_handler, _shared_file_handler_key, log_file_path
+
+    with _shared_file_handler_lock:
+        handler = _shared_file_handler
+        _shared_file_handler = None
+        _shared_file_handler_key = None
+        log_file_path = None
+        if handler is None:
+            return
+        _detach_handler_from_all_loggers(handler)
+        with contextlib.suppress(OSError, ValueError):
+            handler.close()
+
+
+def _get_shared_file_handler(
+    log_file: str, *, max_bytes: int, backup_count: int
+) -> RotatingFileHandler:
+    """Return the single rotating handler used by all MMRelay loggers."""
+    global _shared_file_handler, _shared_file_handler_key
+
+    normalized_path = _expand_log_path(log_file)
+    key = (normalized_path, int(max_bytes), int(backup_count))
+    with _shared_file_handler_lock:
+        if _shared_file_handler is not None and _shared_file_handler_key == key:
+            return _shared_file_handler
+
+        if _shared_file_handler is not None:
+            old_handler = _shared_file_handler
+            _shared_file_handler = None
+            _shared_file_handler_key = None
+            _detach_handler_from_all_loggers(old_handler)
+            with contextlib.suppress(OSError, ValueError):
+                old_handler.close()
+
+        handler = RotatingFileHandler(
+            normalized_path,
+            maxBytes=max_bytes,
+            backupCount=backup_count,
+            encoding="utf-8",
+        )
+        handler.setFormatter(
+            logging.Formatter(
+                fmt="%(asctime)s %(levelname)s:%(name)s:%(message)s",
+                datefmt=DATETIME_FORMAT_WITH_TZ,
+            )
+        )
+        _shared_file_handler = handler
+        _shared_file_handler_key = key
+        return handler
 
 
 def _configure_logger(
@@ -283,11 +363,14 @@ def _configure_logger(
     if not needs_refresh:
         return logger
 
-    # Reset handlers so we can rebuild with the latest configuration
+    # Reset handlers so we can rebuild with the latest configuration. The shared
+    # file handler may still be attached to other loggers, so only detach it here.
     for handler in list(logger.handlers):
+        logger.removeHandler(handler)
+        if handler is _shared_file_handler:
+            continue
         with contextlib.suppress(OSError, ValueError):
             handler.close()
-    logger.handlers.clear()
 
     # Add handler for console logging (with or without colors), unless in CLI mode.
     if not _cli_mode:
@@ -331,6 +414,8 @@ def _configure_logger(
             try:
                 os.makedirs(log_dir, exist_ok=True)
             except OSError as e:
+                if logger.name == APP_DISPLAY_NAME:
+                    log_file_path = None
                 # Use the logger itself to report the error if available, otherwise print
                 error_msg = f"Error creating log directory {log_dir}: {e}"
                 if logger and logger.handlers:
@@ -339,46 +424,40 @@ def _configure_logger(
                     print(error_msg)
                 return logger  # Return logger without file handler
 
-        # Store the log file path for later use
-        if logger.name == APP_DISPLAY_NAME:
-            log_file_path = log_file
-
-        # Create a file handler for logging
+        # Create or reuse the process-wide file handler. Only advertise the log
+        # path after the handler is open successfully.
         try:
-            # Set up size-based log rotation
             max_bytes = DEFAULT_LOG_SIZE_MB * LOG_SIZE_BYTES_MULTIPLIER
             backup_count = DEFAULT_LOG_BACKUP_COUNT
 
             if config is not None and "logging" in config:
                 max_bytes = config["logging"].get("max_log_size", max_bytes)
                 backup_count = config["logging"].get("backup_count", backup_count)
-            file_handler = RotatingFileHandler(
-                log_file, maxBytes=max_bytes, backupCount=backup_count, encoding="utf-8"
+            file_handler = _get_shared_file_handler(
+                log_file, max_bytes=max_bytes, backup_count=backup_count
             )
         except OSError as e:
-            # Use the logger itself to report the error if available, otherwise print
+            if logger.name == APP_DISPLAY_NAME:
+                log_file_path = None
             error_msg = f"Error creating log file at {log_file}: {e}"
             if logger and logger.handlers:
                 logger.exception(error_msg)
             else:
                 print(error_msg)
-            return logger  # Return logger without file handler
+            return logger
         except Exception as e:
-            # Catch any other unexpected exceptions
+            if logger.name == APP_DISPLAY_NAME:
+                log_file_path = None
             error_msg = f"Unexpected error creating log file at {log_file}: {e}"
             if logger and logger.handlers:
                 logger.exception(error_msg)
             else:
                 print(error_msg)
-            return logger  # Return logger without file handler
+            return logger
 
-        file_handler.setFormatter(
-            logging.Formatter(
-                fmt="%(asctime)s %(levelname)s:%(name)s:%(message)s",
-                datefmt=DATETIME_FORMAT_WITH_TZ,
-            )
-        )
         logger.addHandler(file_handler)
+        if logger.name == APP_DISPLAY_NAME:
+            log_file_path = file_handler.baseFilename
     elif logger.name == APP_DISPLAY_NAME:
         log_file_path = None
 
@@ -437,6 +516,9 @@ def refresh_all_loggers(args: argparse.Namespace | None = None) -> None:
     """
     global _config_generation
 
+    # Component loggers can share the main handler too. Detach it globally before
+    # rebuilding so no logger retains a closed rotation file descriptor.
+    _close_shared_file_handler()
     _config_generation += 1
 
     for logger_name in list(_registered_logger_names):

--- a/src/mmrelay/main.py
+++ b/src/mmrelay/main.py
@@ -1289,9 +1289,6 @@ def run_main(args: Any) -> int:
     set_config(db_utils, config)
     set_config(base_plugin, config)
 
-    # Configure component debug logging now that config is available
-    log_utils.configure_component_debug_logging()
-
     # Get config path and log file path for logging
     from mmrelay.config import config_path
     from mmrelay.log_utils import log_file_path

--- a/src/mmrelay/paths.py
+++ b/src/mmrelay/paths.py
@@ -539,7 +539,8 @@ def get_log_file() -> Path:
     """
     env_log = os.getenv("MMRELAY_LOG_PATH")
     if env_log:
-        return Path(env_log).expanduser().absolute()
+        expanded_log = os.path.expandvars(os.path.expanduser(env_log))
+        return Path(expanded_log).absolute()
     return get_logs_dir() / LOG_FILENAME
 
 

--- a/tests/test_log_file_reliability.py
+++ b/tests/test_log_file_reliability.py
@@ -1,0 +1,136 @@
+from __future__ import annotations
+
+import logging
+import os
+from logging.handlers import RotatingFileHandler
+
+import pytest
+
+import mmrelay.log_utils as lu
+from mmrelay.constants.app import APP_DISPLAY_NAME
+
+
+@pytest.fixture(autouse=True)
+def _reset_logging_state():
+    original_config = lu.config
+    original_cli_mode = lu._cli_mode
+    lu._close_shared_file_handler()
+    lu._registered_logger_names.clear()
+    lu._logger_config_generations.clear()
+    lu._config_generation = 0
+    lu.log_file_path = None
+    try:
+        yield
+    finally:
+        lu._close_shared_file_handler()
+        for name in list(lu._registered_logger_names):
+            logger = logging.getLogger(name)
+            for handler in list(logger.handlers):
+                logger.removeHandler(handler)
+                handler.close()
+        lu._registered_logger_names.clear()
+        lu._logger_config_generations.clear()
+        lu._config_generation = 0
+        lu.log_file_path = None
+        lu.config = original_config
+        lu._cli_mode = original_cli_mode
+
+
+def _file_handler(logger: logging.Logger) -> RotatingFileHandler:
+    handlers = [
+        handler
+        for handler in logger.handlers
+        if isinstance(handler, RotatingFileHandler)
+    ]
+    assert len(handlers) == 1
+    return handlers[0]
+
+
+def test_resolve_log_file_honors_path_override_environment(tmp_path, monkeypatch):
+    config_logfile = tmp_path / "config.log"
+    env_logfile = tmp_path / "env.log"
+    lu.config = {"logging": {"filename": str(config_logfile)}}
+    monkeypatch.setenv("MMRELAY_LOG_PATH", str(env_logfile))
+
+    result = lu._resolve_log_file(None)
+
+    assert result == str(env_logfile.resolve())
+
+
+def test_resolve_log_file_expands_user_path(tmp_path, monkeypatch):
+    lu.config = {"logging": {"filename": "~/logs/mmrelay.log"}}
+    monkeypatch.setenv("HOME", str(tmp_path))
+
+    result = lu._resolve_log_file(None)
+
+    assert result == str((tmp_path / "logs" / "mmrelay.log").resolve())
+
+
+def test_loggers_share_single_rotating_file_handler(tmp_path):
+    log_path = tmp_path / "mmrelay.log"
+    lu.config = {
+        "logging": {
+            "log_to_file": True,
+            "filename": str(log_path),
+            "max_log_size": 4096,
+            "backup_count": 2,
+            "color_enabled": False,
+        }
+    }
+
+    first = lu.get_logger("test_shared_file_first")
+    second = lu.get_logger("test_shared_file_second")
+
+    first_handler = _file_handler(first)
+    second_handler = _file_handler(second)
+    assert first_handler is second_handler
+
+    first.info("message from first logger")
+    second.info("message from second logger")
+    first_handler.flush()
+    contents = log_path.read_text(encoding="utf-8")
+    assert "message from first logger" in contents
+    assert "message from second logger" in contents
+
+
+def test_shared_handler_keeps_all_loggers_on_active_file_after_rotation(tmp_path):
+    log_path = tmp_path / "mmrelay.log"
+    lu.config = {
+        "logging": {
+            "log_to_file": True,
+            "filename": str(log_path),
+            "max_log_size": 180,
+            "backup_count": 3,
+            "color_enabled": False,
+        }
+    }
+    loggers = [lu.get_logger(f"rotation-{index}") for index in range(3)]
+    shared = _file_handler(loggers[0])
+    assert all(_file_handler(logger) is shared for logger in loggers)
+
+    for index in range(20):
+        loggers[index % len(loggers)].info("entry-%02d %s", index, "x" * 40)
+    shared.flush()
+
+    assert (tmp_path / "mmrelay.log.1").exists()
+    assert "entry-19" in log_path.read_text(encoding="utf-8")
+    assert all(_file_handler(logger) is shared for logger in loggers)
+
+
+def test_main_log_path_is_not_advertised_when_file_handler_fails(
+    tmp_path, monkeypatch
+):
+    log_path = tmp_path / "mmrelay.log"
+    lu.config = {"logging": {"log_to_file": True, "filename": str(log_path)}}
+
+    def _raise_permission_error(*args, **kwargs):
+        raise PermissionError("denied")
+
+    monkeypatch.setattr(lu, "RotatingFileHandler", _raise_permission_error)
+    logger = lu.get_logger(APP_DISPLAY_NAME)
+
+    assert isinstance(logger, logging.Logger)
+    assert lu.log_file_path is None
+    assert not any(
+        isinstance(handler, RotatingFileHandler) for handler in logger.handlers
+    )

--- a/tests/test_log_file_reliability.py
+++ b/tests/test_log_file_reliability.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import logging
-import os
 from logging.handlers import RotatingFileHandler
 
 import pytest
@@ -117,9 +116,7 @@ def test_shared_handler_keeps_all_loggers_on_active_file_after_rotation(tmp_path
     assert all(_file_handler(logger) is shared for logger in loggers)
 
 
-def test_main_log_path_is_not_advertised_when_file_handler_fails(
-    tmp_path, monkeypatch
-):
+def test_main_log_path_is_not_advertised_when_file_handler_fails(tmp_path, monkeypatch):
     log_path = tmp_path / "mmrelay.log"
     lu.config = {"logging": {"log_to_file": True, "filename": str(log_path)}}
 

--- a/tests/test_log_file_reliability.py
+++ b/tests/test_log_file_reliability.py
@@ -131,3 +131,58 @@ def test_main_log_path_is_not_advertised_when_file_handler_fails(tmp_path, monke
     assert not any(
         isinstance(handler, RotatingFileHandler) for handler in logger.handlers
     )
+
+
+def test_refresh_reattaches_shared_handler_to_component_loggers(tmp_path):
+    log_path = tmp_path / "mmrelay.log"
+    lu.config = {
+        "logging": {
+            "log_to_file": True,
+            "filename": str(log_path),
+            "color_enabled": False,
+            "debug": {"meshtastic": True},
+        }
+    }
+
+    main_logger = lu.get_logger(APP_DISPLAY_NAME)
+    lu.configure_component_debug_logging()
+    component_logger = logging.getLogger("meshtastic.ble_interface")
+    old_handler = _file_handler(component_logger)
+    assert old_handler is _file_handler(main_logger)
+
+    lu.refresh_all_loggers()
+
+    new_handler = _file_handler(main_logger)
+    assert new_handler is _file_handler(component_logger)
+    assert new_handler is not old_handler
+    component_logger.debug("component survives refresh")
+    new_handler.flush()
+    assert "component survives refresh" in log_path.read_text(encoding="utf-8")
+
+
+def test_close_shared_file_handler_detaches_every_logger_and_resets_state(tmp_path):
+    log_path = tmp_path / "mmrelay.log"
+    lu.config = {
+        "logging": {
+            "log_to_file": True,
+            "filename": str(log_path),
+            "color_enabled": False,
+            "debug": {"meshtastic": True},
+        }
+    }
+
+    main_logger = lu.get_logger(APP_DISPLAY_NAME)
+    lu.configure_component_debug_logging()
+    component_logger = logging.getLogger("meshtastic.ble_interface")
+    shared_handler = _file_handler(main_logger)
+    assert shared_handler in component_logger.handlers
+    assert lu._shared_file_handler_key is not None
+    assert lu.log_file_path == str(log_path)
+
+    lu._close_shared_file_handler()
+
+    assert lu._shared_file_handler is None
+    assert lu._shared_file_handler_key is None
+    assert lu.log_file_path is None
+    assert shared_handler not in main_logger.handlers
+    assert shared_handler not in component_logger.handlers

--- a/tests/test_log_file_reliability.py
+++ b/tests/test_log_file_reliability.py
@@ -15,6 +15,7 @@ def _reset_logging_state():
     original_cli_mode = lu._cli_mode
     lu._close_shared_file_handler()
     lu._registered_logger_names.clear()
+    lu._component_attached_handlers.clear()
     lu._logger_config_generations.clear()
     lu._config_generation = 0
     lu.log_file_path = None
@@ -28,6 +29,12 @@ def _reset_logging_state():
                 logger.removeHandler(handler)
                 handler.close()
         lu._registered_logger_names.clear()
+        for name, handlers in lu._component_attached_handlers.items():
+            logger = logging.getLogger(name)
+            for handler in handlers:
+                if handler in logger.handlers:
+                    logger.removeHandler(handler)
+        lu._component_attached_handlers.clear()
         lu._logger_config_generations.clear()
         lu._config_generation = 0
         lu.log_file_path = None
@@ -158,6 +165,29 @@ def test_refresh_reattaches_shared_handler_to_component_loggers(tmp_path):
     component_logger.debug("component survives refresh")
     new_handler.flush()
     assert "component survives refresh" in log_path.read_text(encoding="utf-8")
+
+
+def test_refresh_replaces_component_console_handler_without_duplicates(tmp_path):
+    log_path = tmp_path / "mmrelay.log"
+    lu.config = {
+        "logging": {
+            "log_to_file": True,
+            "filename": str(log_path),
+            "color_enabled": False,
+            "debug": {"matrix_nio": True},
+        }
+    }
+
+    main_logger = lu.get_logger(APP_DISPLAY_NAME)
+    lu.configure_component_debug_logging()
+    component_logger = logging.getLogger("nio")
+    original_handlers = set(component_logger.handlers)
+    assert original_handlers == set(main_logger.handlers)
+
+    lu.refresh_all_loggers()
+
+    assert set(component_logger.handlers) == set(main_logger.handlers)
+    assert original_handlers.isdisjoint(component_logger.handlers)
 
 
 def test_close_shared_file_handler_detaches_every_logger_and_resets_state(tmp_path):

--- a/tests/test_log_utils.py
+++ b/tests/test_log_utils.py
@@ -90,9 +90,7 @@ class TestLogUtils(unittest.TestCase):
         # Create temporary directory for test logs
         self.test_dir = tempfile.mkdtemp()
         self.test_log_file = os.path.join(self.test_dir, "test.log")
-        self._log_path_env_patcher = patch.dict(
-            os.environ, {"MMRELAY_LOG_PATH": ""}
-        )
+        self._log_path_env_patcher = patch.dict(os.environ, {"MMRELAY_LOG_PATH": ""})
         self._log_path_env_patcher.start()
         self.addCleanup(self._log_path_env_patcher.stop)
 

--- a/tests/test_log_utils.py
+++ b/tests/test_log_utils.py
@@ -90,10 +90,16 @@ class TestLogUtils(unittest.TestCase):
         # Create temporary directory for test logs
         self.test_dir = tempfile.mkdtemp()
         self.test_log_file = os.path.join(self.test_dir, "test.log")
+        self._log_path_env_patcher = patch.dict(
+            os.environ, {"MMRELAY_LOG_PATH": ""}
+        )
+        self._log_path_env_patcher.start()
+        self.addCleanup(self._log_path_env_patcher.stop)
 
         # Reset global state
         import mmrelay.log_utils
 
+        mmrelay.log_utils._close_shared_file_handler()
         mmrelay.log_utils.config = None
         mmrelay.log_utils.log_file_path = None
         mmrelay.log_utils._registered_logger_names.clear()
@@ -113,6 +119,9 @@ class TestLogUtils(unittest.TestCase):
         shutil.rmtree(self.test_dir, ignore_errors=True)
 
         # Reset logging state using the comprehensive handler cleanup helper
+        import mmrelay.log_utils as lu
+
+        lu._close_shared_file_handler()
         self._close_all_handlers()
         logging.getLogger().setLevel(logging.WARNING)
 

--- a/tests/test_log_utils.py
+++ b/tests/test_log_utils.py
@@ -141,6 +141,40 @@ class TestLogUtils(unittest.TestCase):
                 h.close()
         logging.getLogger().handlers.clear()
 
+    def test_close_shared_file_handler_detaches_shared_handler_and_resets_state(self):
+        """Shared handler cleanup detaches every logger and clears advertised state."""
+        import mmrelay.log_utils as lu
+        from mmrelay.constants.app import APP_DISPLAY_NAME
+
+        lu.config = {
+            "logging": {
+                "log_to_file": True,
+                "filename": self.test_log_file,
+                "color_enabled": False,
+            }
+        }
+        main_logger = lu.get_logger(APP_DISPLAY_NAME)
+        logger1 = lu.get_logger("mmrelay.test.close_shared_handler.1")
+        logger2 = lu.get_logger("mmrelay.test.close_shared_handler.2")
+        shared_handler = lu._shared_file_handler
+
+        self.assertIsNotNone(shared_handler)
+        self.assertIsNotNone(lu._shared_file_handler_key)
+        self.assertEqual(lu.log_file_path, os.path.abspath(self.test_log_file))
+        self.assertIn(shared_handler, main_logger.handlers)
+        self.assertIn(shared_handler, logger1.handlers)
+        self.assertIn(shared_handler, logger2.handlers)
+
+        lu._close_shared_file_handler()
+
+        self.assertIsNone(lu._shared_file_handler)
+        self.assertIsNone(lu._shared_file_handler_key)
+        self.assertIsNone(lu.log_file_path)
+        self.assertNotIn(shared_handler, main_logger.handlers)
+        self.assertNotIn(shared_handler, logger1.handlers)
+        self.assertNotIn(shared_handler, logger2.handlers)
+        self.assertNotIn(shared_handler, logging.getLogger().handlers)
+
     def test_get_logger_basic(self):
         """
         Verifies that a logger is created with default settings when no configuration is provided.

--- a/tests/test_paths_coverage.py
+++ b/tests/test_paths_coverage.py
@@ -25,6 +25,7 @@ from mmrelay.paths import (
     get_home_dir,
     get_legacy_dirs,
     get_legacy_env_vars,
+    get_log_file,
     get_plugin_code_dir,
     get_plugin_data_dir,
     is_deprecation_window_active,
@@ -931,6 +932,14 @@ def test_resolve_all_paths_home_source_data_dir(
         assert resolved["home_source"] == "MMRELAY_DATA_DIR env var"
     finally:
         paths_module._reset_deprecation_warning_flag()
+
+
+def test_get_log_file_expands_environment_markers(monkeypatch, tmp_path: Path) -> None:
+    """Reported log path should match the expanded path used by file logging."""
+    monkeypatch.setenv("MMRELAY_LOG_ROOT", str(tmp_path))
+    monkeypatch.setenv("MMRELAY_LOG_PATH", "$MMRELAY_LOG_ROOT/mmrelay.log")
+
+    assert get_log_file() == (tmp_path / "mmrelay.log").absolute()
 
 
 def test_resolve_all_paths_home_source_platform_defaults(


### PR DESCRIPTION
## Summary by Sourcery

Unify MMRelay logging onto a single rotating file handler with reliable path resolution and state management across configuration refreshes.

Enhancements:
- Ensure log file path resolution consistently expands user and environment markers and honors MMRELAY_LOG_PATH precedence over configuration.
- Share a process-wide RotatingFileHandler across MMRelay loggers to prevent divergent rotation behavior and keep all loggers on the active file.
- Advertise the active log file path only after the shared handler is successfully created, clearing it whenever handler setup fails or is torn down.
- Improve logger reconfiguration so component debug loggers are reattached to the refreshed shared handler after configuration changes.
- Add helper utilities to detach and close the shared file handler from all loggers and to safely manage handler lifecycle under concurrent access.

Documentation:
- Document the precise precedence and expansion rules for application log file paths and clarify behavior for normal runs, systemd service usage, and CLI-only commands.

Tests:
- Add targeted tests covering log path expansion, environment variable precedence, shared rotating handler behavior and rotation, failure cases where the file handler cannot be created, refresh behavior for component loggers, and global cleanup of the shared handler.
- Extend path coverage tests to verify that the reported log file path matches the expanded environment-based path used for file logging.
- Strengthen existing logging tests to reset shared handler state between runs and validate handler detachment and state reset on cleanup.