### PR TITLE
fix(ble): defer reconnect metadata probe until settled

### DIFF
--- a/docs/ADVANCED_CONFIGURATION.md
+++ b/docs/ADVANCED_CONFIGURATION.md
@@ -147,6 +147,7 @@ Behavior notes:
 - `connect_probe_enabled` defaults to `health_check.enabled` when unset.
 - First process connect uses a startup drain window to avoid relaying backlogged packets.
 - Reconnects use a bounded pre-start bootstrap path; they do not re-run the startup drain window.
+- A connect-time metadata probe waits until the active startup drain or reconnect bootstrap window has ended, then adds the normal post-stabilization delay before sending probe traffic.
 - BLE connections use disconnect detection and skip periodic metadata probes.
 - Legacy `meshtastic.heartbeat_interval` is still supported for compatibility, but `health_check` is preferred.
 

--- a/src/mmrelay/meshtastic/connection.py
+++ b/src/mmrelay/meshtastic/connection.py
@@ -46,7 +46,7 @@ __all__ = [
     "serial_port_exists",
 ]
 
-CONNECT_PROBE_POST_DRAIN_DELAY_SECS: float = 2.0
+CONNECT_PROBE_POST_STABILIZATION_DELAY_SECS: float = 2.0
 
 
 class BLEDiscoveryTransientError(Exception):
@@ -354,6 +354,32 @@ def _get_connect_time_probe_settings(
     return enabled, timeout_secs
 
 
+def _get_connect_probe_stabilization_deadline() -> tuple[float | None, str | None]:
+    """Return the latest startup/reconnect deadline that should defer probe traffic.
+
+    Connect-time metadata probes are backup calibration traffic. They should not
+    compete with either the first-connect startup drain or the reconnect bootstrap
+    window while the transport and firmware are settling.
+    """
+    with facade._relay_rx_time_clock_skew_lock:
+        candidates = (
+            ("startup drain", facade._relay_startup_drain_deadline_monotonic_secs),
+            (
+                "reconnect bootstrap",
+                facade._relay_reconnect_prestart_bootstrap_deadline_monotonic_secs,
+            ),
+        )
+    deadlines = [
+        (name, float(deadline))
+        for name, deadline in candidates
+        if isinstance(deadline, (float, int))
+    ]
+    if not deadlines:
+        return None, None
+    name, deadline = max(deadlines, key=lambda item: item[1])
+    return deadline, name
+
+
 def _schedule_connect_time_calibration_probe(
     client: Any,
     *,
@@ -409,16 +435,18 @@ def _schedule_connect_time_calibration_probe(
             timeout_secs,
         )
 
-    with facade._relay_rx_time_clock_skew_lock:
-        drain_deadline = facade._relay_startup_drain_deadline_monotonic_secs
+    stabilization_deadline, stabilization_window = (
+        _get_connect_probe_stabilization_deadline()
+    )
 
-    if drain_deadline is not None:
-        remaining = drain_deadline - facade.time.monotonic()
+    if stabilization_deadline is not None:
+        remaining = stabilization_deadline - facade.time.monotonic()
         if remaining > 0:
-            delay = remaining + CONNECT_PROBE_POST_DRAIN_DELAY_SECS
+            delay = remaining + CONNECT_PROBE_POST_STABILIZATION_DELAY_SECS
             facade.logger.debug(
-                "Delaying connect-time metadata probe by %.1fs until after startup drain window",
+                "Delaying connect-time metadata probe by %.1fs until after %s window",
                 delay,
+                stabilization_window,
             )
 
             def _delayed_submit_with_stale_guard() -> None:

--- a/src/mmrelay/meshtastic/connection.py
+++ b/src/mmrelay/meshtastic/connection.py
@@ -439,52 +439,74 @@ def _schedule_connect_time_calibration_probe(
         _get_connect_probe_stabilization_deadline()
     )
 
-    if stabilization_deadline is not None:
-        remaining = stabilization_deadline - facade.time.monotonic()
-        if remaining > 0:
-            delay = remaining + CONNECT_PROBE_POST_STABILIZATION_DELAY_SECS
-            facade.logger.debug(
-                "Delaying connect-time metadata probe by %.1fs until after %s window",
-                delay,
-                stabilization_window,
-            )
+    def _clear_pending_timer(timer: threading.Timer) -> bool:
+        with facade._relay_rx_time_clock_skew_lock:
+            if facade._pending_connect_time_probe_timer is not timer:
+                return False
+            facade._pending_connect_time_probe_timer = None
+            return True
 
-            def _delayed_submit_with_stale_guard() -> None:
-                if facade.shutting_down:
-                    facade.logger.debug(
-                        "Skipping delayed connect-time metadata probe; shutdown in progress"
-                    )
-                    with facade._relay_rx_time_clock_skew_lock:
-                        if facade._pending_connect_time_probe_timer is timer:
-                            facade._pending_connect_time_probe_timer = None
+    def _arm_delayed_probe(delay: float, window: str | None) -> None:
+        facade.logger.debug(
+            "Delaying connect-time metadata probe by %.1fs until after %s window",
+            delay,
+            window,
+        )
+
+        def _delayed_submit_with_stale_guard() -> None:
+            with facade._relay_rx_time_clock_skew_lock:
+                if facade._pending_connect_time_probe_timer is not timer:
                     return
-                active_client = facade.meshtastic_client
-                active_client_id = facade._relay_active_client_id
-                if active_client is not client and (
-                    active_client_id is None or active_client_id != id(client)
-                ):
-                    facade.logger.debug(
-                        "Skipping delayed connect-time metadata probe; active client changed since scheduling"
-                    )
-                    with facade._relay_rx_time_clock_skew_lock:
-                        if facade._pending_connect_time_probe_timer is timer:
-                            facade._pending_connect_time_probe_timer = None
+            if facade.shutting_down:
+                facade.logger.debug(
+                    "Skipping delayed connect-time metadata probe; shutdown in progress"
+                )
+                _clear_pending_timer(timer)
+                return
+            active_client = facade.meshtastic_client
+            active_client_id = facade._relay_active_client_id
+            if active_client is not client and (
+                active_client_id is None or active_client_id != id(client)
+            ):
+                facade.logger.debug(
+                    "Skipping delayed connect-time metadata probe; active client changed since scheduling"
+                )
+                _clear_pending_timer(timer)
+                return
+
+            latest_deadline, latest_window = _get_connect_probe_stabilization_deadline()
+            if latest_deadline is not None:
+                latest_delay = (
+                    latest_deadline
+                    + CONNECT_PROBE_POST_STABILIZATION_DELAY_SECS
+                    - facade.time.monotonic()
+                )
+                if latest_delay > 0:
+                    _arm_delayed_probe(latest_delay, latest_window)
                     return
-                with facade._relay_rx_time_clock_skew_lock:
-                    if facade._pending_connect_time_probe_timer is timer:
-                        facade._pending_connect_time_probe_timer = None
+
+            if _clear_pending_timer(timer):
                 _submit_probe()
 
-            timer = threading.Timer(delay, _delayed_submit_with_stale_guard)
-            timer.daemon = True
-            old_timer = None
-            with facade._relay_rx_time_clock_skew_lock:
-                old_timer = facade._pending_connect_time_probe_timer
-                facade._pending_connect_time_probe_timer = timer
-            if old_timer is not None:
-                with contextlib.suppress(Exception):
-                    old_timer.cancel()
-            timer.start()
+        timer = threading.Timer(delay, _delayed_submit_with_stale_guard)
+        timer.daemon = True
+        old_timer = None
+        with facade._relay_rx_time_clock_skew_lock:
+            old_timer = facade._pending_connect_time_probe_timer
+            facade._pending_connect_time_probe_timer = timer
+        if old_timer is not None:
+            with contextlib.suppress(Exception):
+                old_timer.cancel()
+        timer.start()
+
+    if stabilization_deadline is not None:
+        delay = (
+            stabilization_deadline
+            + CONNECT_PROBE_POST_STABILIZATION_DELAY_SECS
+            - facade.time.monotonic()
+        )
+        if delay > 0:
+            _arm_delayed_probe(delay, stabilization_window)
             return
 
     _submit_probe()

--- a/tests/test_meshtastic_utils_metadata.py
+++ b/tests/test_meshtastic_utils_metadata.py
@@ -1505,6 +1505,106 @@ def test_connect_probe_delays_until_after_stabilization_window(
     submit_probe.assert_not_called()
 
 
+def test_connect_probe_applies_remaining_delay_after_window_just_ended(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The post-window delay starts at the deadline, not at scheduling time."""
+    from mmrelay.meshtastic import connection as connection_module
+
+    timer_instances: list[SimpleNamespace] = []
+
+    def _timer_factory(delay: float, callback: Any) -> SimpleNamespace:
+        timer = SimpleNamespace(
+            interval=delay,
+            function=callback,
+            daemon=False,
+            start=Mock(),
+            cancel=Mock(),
+        )
+        timer_instances.append(timer)
+        return timer
+
+    monkeypatch.setattr(mu, "_relay_startup_drain_deadline_monotonic_secs", 99.0)
+    monkeypatch.setattr(
+        mu, "_relay_reconnect_prestart_bootstrap_deadline_monotonic_secs", None
+    )
+    monkeypatch.setattr(mu.time, "monotonic", lambda: 100.0)
+    monkeypatch.setattr(connection_module.threading, "Timer", _timer_factory)
+    monkeypatch.setattr(
+        mu, "_get_connect_time_probe_settings", lambda *_args: (True, 30.0)
+    )
+    submit_probe = Mock()
+    monkeypatch.setattr(mu, "_submit_metadata_probe", submit_probe)
+    client = SimpleNamespace(localNode=object(), sendData=Mock())
+
+    mu._schedule_connect_time_calibration_probe(
+        client,
+        connection_type=CONNECTION_TYPE_BLE,
+        active_config={"meshtastic": {}},
+    )
+
+    assert len(timer_instances) == 1
+    assert timer_instances[0].interval == pytest.approx(1.0)
+    timer_instances[0].start.assert_called_once_with()
+    submit_probe.assert_not_called()
+
+
+def test_delayed_connect_probe_rechecks_extended_stabilization_window(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A replacement window must keep an already-timed probe from firing early."""
+    from mmrelay.meshtastic import connection as connection_module
+
+    timer_instances: list[SimpleNamespace] = []
+    now = [100.0]
+
+    def _timer_factory(delay: float, callback: Any) -> SimpleNamespace:
+        timer = SimpleNamespace(
+            interval=delay,
+            function=callback,
+            daemon=False,
+            start=Mock(),
+            cancel=Mock(),
+        )
+        timer_instances.append(timer)
+        return timer
+
+    monkeypatch.setattr(mu, "_relay_startup_drain_deadline_monotonic_secs", 105.0)
+    monkeypatch.setattr(
+        mu, "_relay_reconnect_prestart_bootstrap_deadline_monotonic_secs", None
+    )
+    monkeypatch.setattr(mu.time, "monotonic", lambda: now[0])
+    monkeypatch.setattr(connection_module.threading, "Timer", _timer_factory)
+    monkeypatch.setattr(
+        mu, "_get_connect_time_probe_settings", lambda *_args: (True, 30.0)
+    )
+    submit_probe = Mock(return_value=Mock())
+    monkeypatch.setattr(mu, "_submit_metadata_probe", submit_probe)
+    client = SimpleNamespace(localNode=object(), sendData=Mock())
+    monkeypatch.setattr(mu, "meshtastic_client", client)
+
+    mu._schedule_connect_time_calibration_probe(
+        client,
+        connection_type=CONNECTION_TYPE_BLE,
+        active_config={"meshtastic": {}},
+    )
+    assert timer_instances[0].interval == pytest.approx(7.0)
+
+    monkeypatch.setattr(mu, "_relay_startup_drain_deadline_monotonic_secs", 110.0)
+    now[0] = 107.0
+    timer_instances[0].function()
+
+    assert len(timer_instances) == 2
+    assert timer_instances[1].interval == pytest.approx(5.0)
+    timer_instances[1].start.assert_called_once_with()
+    submit_probe.assert_not_called()
+
+    now[0] = 112.0
+    timer_instances[1].function()
+
+    submit_probe.assert_called_once()
+
+
 class TestScheduleConnectTimeCalibrationProbe(unittest.TestCase):
     @patch("mmrelay.meshtastic_utils._get_connect_time_probe_settings")
     def test_client_no_local_node_returns_early(self, mock_settings):

--- a/tests/test_meshtastic_utils_metadata.py
+++ b/tests/test_meshtastic_utils_metadata.py
@@ -1433,12 +1433,16 @@ class TestGetConnectTimeProbeSettings(unittest.TestCase):
         self.assertEqual(timeout, float(DEFAULT_MESHTASTIC_OPERATION_TIMEOUT))
 
 
-def test_get_connect_probe_stabilization_deadline_prefers_latest_window() -> None:
+def test_get_connect_probe_stabilization_deadline_prefers_latest_window(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """The connect probe should wait for the latest stabilization window."""
     from mmrelay.meshtastic.connection import _get_connect_probe_stabilization_deadline
 
-    mu._relay_startup_drain_deadline_monotonic_secs = 115.0
-    mu._relay_reconnect_prestart_bootstrap_deadline_monotonic_secs = 105.0
+    monkeypatch.setattr(mu, "_relay_startup_drain_deadline_monotonic_secs", 115.0)
+    monkeypatch.setattr(
+        mu, "_relay_reconnect_prestart_bootstrap_deadline_monotonic_secs", 105.0
+    )
 
     deadline, window = _get_connect_probe_stabilization_deadline()
 
@@ -1472,8 +1476,14 @@ def test_connect_probe_delays_until_after_stabilization_window(
         timer_instances.append(timer)
         return timer
 
-    mu._relay_startup_drain_deadline_monotonic_secs = startup_deadline
-    mu._relay_reconnect_prestart_bootstrap_deadline_monotonic_secs = reconnect_deadline
+    monkeypatch.setattr(
+        mu, "_relay_startup_drain_deadline_monotonic_secs", startup_deadline
+    )
+    monkeypatch.setattr(
+        mu,
+        "_relay_reconnect_prestart_bootstrap_deadline_monotonic_secs",
+        reconnect_deadline,
+    )
     monkeypatch.setattr(mu.time, "monotonic", lambda: 100.0)
     monkeypatch.setattr(connection_module.threading, "Timer", _timer_factory)
     monkeypatch.setattr(

--- a/tests/test_meshtastic_utils_metadata.py
+++ b/tests/test_meshtastic_utils_metadata.py
@@ -1433,6 +1433,68 @@ class TestGetConnectTimeProbeSettings(unittest.TestCase):
         self.assertEqual(timeout, float(DEFAULT_MESHTASTIC_OPERATION_TIMEOUT))
 
 
+def test_get_connect_probe_stabilization_deadline_prefers_latest_window() -> None:
+    """The connect probe should wait for the latest stabilization window."""
+    from mmrelay.meshtastic.connection import _get_connect_probe_stabilization_deadline
+
+    mu._relay_startup_drain_deadline_monotonic_secs = 115.0
+    mu._relay_reconnect_prestart_bootstrap_deadline_monotonic_secs = 105.0
+
+    deadline, window = _get_connect_probe_stabilization_deadline()
+
+    assert deadline == 115.0
+    assert window == "startup drain"
+
+
+@pytest.mark.parametrize(
+    ("startup_deadline", "reconnect_deadline"),
+    [(105.0, None), (None, 105.0)],
+    ids=("startup-drain", "reconnect-bootstrap"),
+)
+def test_connect_probe_delays_until_after_stabilization_window(
+    monkeypatch: pytest.MonkeyPatch,
+    startup_deadline: float | None,
+    reconnect_deadline: float | None,
+) -> None:
+    """Connect calibration traffic should not run while either window is active."""
+    from mmrelay.meshtastic import connection as connection_module
+
+    timer_instances: list[SimpleNamespace] = []
+
+    def _timer_factory(delay: float, callback: Any) -> SimpleNamespace:
+        timer = SimpleNamespace(
+            interval=delay,
+            function=callback,
+            daemon=False,
+            start=Mock(),
+            cancel=Mock(),
+        )
+        timer_instances.append(timer)
+        return timer
+
+    mu._relay_startup_drain_deadline_monotonic_secs = startup_deadline
+    mu._relay_reconnect_prestart_bootstrap_deadline_monotonic_secs = reconnect_deadline
+    monkeypatch.setattr(mu.time, "monotonic", lambda: 100.0)
+    monkeypatch.setattr(connection_module.threading, "Timer", _timer_factory)
+    monkeypatch.setattr(
+        mu, "_get_connect_time_probe_settings", lambda *_args: (True, 30.0)
+    )
+    submit_probe = Mock()
+    monkeypatch.setattr(mu, "_submit_metadata_probe", submit_probe)
+    client = SimpleNamespace(localNode=object(), sendData=Mock())
+
+    mu._schedule_connect_time_calibration_probe(
+        client,
+        connection_type=CONNECTION_TYPE_BLE,
+        active_config={"meshtastic": {}},
+    )
+
+    assert len(timer_instances) == 1
+    assert timer_instances[0].interval == pytest.approx(7.0)
+    timer_instances[0].start.assert_called_once_with()
+    submit_probe.assert_not_called()
+
+
 class TestScheduleConnectTimeCalibrationProbe(unittest.TestCase):
     @patch("mmrelay.meshtastic_utils._get_connect_time_probe_settings")
     def test_client_no_local_node_returns_early(self, mock_settings):


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview

This change defers the BLE reconnect metadata probe until startup drain or reconnect bootstrap completes. The probe then waits for the configured post-stabilization delay before sending traffic.

## Key changes

### Fixes
- Select the latest active stabilization deadline.
- Defer probe scheduling during startup-drain and reconnect-bootstrap windows.
- Apply the post-stabilization delay after the selected window ends.

### Refactors
- Rename `CONNECT_PROBE_POST_DRAIN_DELAY_SECS` to `CONNECT_PROBE_POST_STABILIZATION_DELAY_SECS`.
- Add a helper to identify the active stabilization window.

### Tests and documentation
- Add tests for deadline selection, window identification, and deferred probe submission.
- Document the probe timing in `docs/ADVANCED_CONFIGURATION.md`.

## Breaking changes and migration

- Update any references to `CONNECT_PROBE_POST_DRAIN_DELAY_SECS` to use `CONNECT_PROBE_POST_STABILIZATION_DELAY_SECS`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->