### PR TITLE
chore(migration): keep 1.4 as final compatibility window

### DIFF
--- a/src/mmrelay/cli.py
+++ b/src/mmrelay/cli.py
@@ -57,6 +57,8 @@ from mmrelay.constants.config import (
     CONFIG_SECTION_DATABASE_LEGACY,
     CONFIG_SECTION_MATRIX,
     CONFIG_SECTION_MESHTASTIC,
+    LEGACY_LAYOUT_FINAL_MIGRATION_SERIES,
+    LEGACY_LAYOUT_REMOVAL_VERSION,
     REQUIRED_CREDENTIALS_KEYS,
 )
 from mmrelay.constants.formats import (
@@ -2533,6 +2535,14 @@ def handle_migrate_command(args: argparse.Namespace) -> int:
 
         print("MMRelay Migration")
         print("=================")
+        print(
+            f"NOTICE: MMRelay {LEGACY_LAYOUT_FINAL_MIGRATION_SERIES} is the final "
+            "release series that includes legacy-layout migration tooling."
+        )
+        print(
+            f"Complete migration before upgrading to v{LEGACY_LAYOUT_REMOVAL_VERSION} "
+            "or newer."
+        )
         print(f"Mode: {'DRY RUN' if dry_run else 'APPLY'}")
         print(f"Force overwrite: {'yes' if force else 'no'}")
         print(f"MMRELAY_HOME: {paths_info.get('home')}")

--- a/src/mmrelay/config.py
+++ b/src/mmrelay/config.py
@@ -35,7 +35,7 @@ from mmrelay.constants.config import (
     CONFIG_SECTION_CUSTOM_PLUGINS,
     CONFIG_SECTION_MATRIX,
     CONFIG_SECTION_MESHTASTIC,
-    DEPRECATION_VERSIONS,
+    LEGACY_LAYOUT_REMOVAL_VERSION,
     ENV_BOOL_FALSE_VALUES,
     ENV_BOOL_TRUE_VALUES,
     JSON_INDENT_STANDARD,
@@ -149,7 +149,7 @@ def _warn_on_legacy_path_overrides(
                 "Use MMRELAY_HOME to control all data paths. "
                 "Support for these overrides will be removed in v%s.",
                 "; ".join(warnings_to_emit),
-                DEPRECATION_VERSIONS[1],
+                LEGACY_LAYOUT_REMOVAL_VERSION,
             )
 
 
@@ -173,7 +173,7 @@ def _emit_legacy_credentials_warning(credentials_path: str) -> None:
         "Please run 'mmrelay migrate' to move to new unified structure. "
         "Support for legacy credentials will be removed in v%s.",
         credentials_path,
-        DEPRECATION_VERSIONS[1],
+        LEGACY_LAYOUT_REMOVAL_VERSION,
     )
 
 
@@ -186,7 +186,7 @@ def _warn_deprecated(_name: str) -> None:
         _name (str): Ignored; included so callers can cache or key warnings (e.g., with lru_cache).
     """
     warnings.warn(
-        f"Use paths.get_home_dir() instead. Support will be removed in v{DEPRECATION_VERSIONS[1]}.",  # [1] is the removal version
+        f"Use paths.get_home_dir() instead. Support will be removed in v{LEGACY_LAYOUT_REMOVAL_VERSION}.",
         DeprecationWarning,
         stacklevel=3,
     )

--- a/src/mmrelay/constants/config.py
+++ b/src/mmrelay/constants/config.py
@@ -167,8 +167,13 @@ PLUGIN_SECTION_TYPES: Final[Mapping[str, str]] = MappingProxyType(
     }
 )
 
-# Versions where deprecation warnings were introduced
-# Each version marks when a feature became deprecated; removal follows in a later release
-# v1.3: Deprecated legacy config paths and --generate-config, --check-config flags
-# v1.4: Deprecated legacy credential storage location and --install-service flag
+# Versions where deprecation warnings were introduced.
+# These are historical introduction versions, not removal deadlines.
 DEPRECATION_VERSIONS: Final[tuple[str, ...]] = ("1.3", "1.4")
+
+# MMRelay 1.4 intentionally remains a final bridge release for installations that
+# still need the v1.3 data-layout migration tooling. Remove legacy layout fallback
+# and migration commands together in 1.5 so direct upgrades from <=1.2 are not
+# stranded during the 1.4 release transition.
+LEGACY_LAYOUT_FINAL_MIGRATION_SERIES: Final[str] = "1.4"
+LEGACY_LAYOUT_REMOVAL_VERSION: Final[str] = "1.5"

--- a/src/mmrelay/db_utils.py
+++ b/src/mmrelay/db_utils.py
@@ -13,6 +13,7 @@ from mmrelay.constants.config import (
     CONFIG_SECTION_DATABASE_LEGACY,
     ENV_BOOL_FALSE_VALUES,
     ENV_BOOL_TRUE_VALUES,
+    LEGACY_LAYOUT_REMOVAL_VERSION,
 )
 from mmrelay.constants.database import (
     DEBUG_ID_SAMPLE_LIMIT,
@@ -571,8 +572,9 @@ def get_db_path() -> str:
                         logger.warning(
                             "Database found in legacy location: %s. "
                             "Please run 'mmrelay migrate' to move to new unified structure. "
-                            "Support for legacy database locations will be removed in v1.4.",
+                            "Support for legacy database locations will be removed in v%s.",
                             candidate,
+                            LEGACY_LAYOUT_REMOVAL_VERSION,
                         )
                         _db_path_logged = True
                     _cached_db_path = candidate

--- a/src/mmrelay/main.py
+++ b/src/mmrelay/main.py
@@ -45,6 +45,8 @@ from mmrelay.constants.config import (
     CONFIG_SECTION_MESHTASTIC,
     REQUIRED_CONFIG_SECTIONS_WITH_CREDENTIALS,
     REQUIRED_CONFIG_SECTIONS_WITHOUT_CREDENTIALS,
+    LEGACY_LAYOUT_FINAL_MIGRATION_SERIES,
+    LEGACY_LAYOUT_REMOVAL_VERSION,
 )
 from mmrelay.constants.network import (
     MATRIX_CLIENT_CLOSE_TIMEOUT_SECS,
@@ -1306,13 +1308,18 @@ def run_main(args: Any) -> int:
     legacy_dirs = get_legacy_dirs()
     if legacy_envs or legacy_dirs:
         config_rich_logger.warning(
-            "Legacy data layout detected (MMRELAY_HOME=%s, legacy_env_vars=%s, legacy_dirs=%s). This layout is deprecated and will be removed in a future release.",
+            "Legacy data layout detected (MMRELAY_HOME=%s, legacy_env_vars=%s, legacy_dirs=%s). "
+            "MMRelay %s is the final release series with legacy-layout migration support; "
+            "compatibility will be removed in v%s.",
             str(get_home_dir()),
             ", ".join(legacy_envs) if legacy_envs else "none",
             ", ".join(str(p) for p in legacy_dirs) if legacy_dirs else "none",
+            LEGACY_LAYOUT_FINAL_MIGRATION_SERIES,
+            LEGACY_LAYOUT_REMOVAL_VERSION,
         )
         config_rich_logger.warning(
-            "To migrate to the new layout, see docs/DOCKER.md: Migrating to the New Layout."
+            "Run 'mmrelay migrate --dry-run' and 'mmrelay migrate' before upgrading "
+            "past the 1.4 release series. See docs/DOCKER.md: Migrating to the New Layout."
         )
 
     # Check if config exists and has the required keys

--- a/src/mmrelay/main.py
+++ b/src/mmrelay/main.py
@@ -1319,7 +1319,8 @@ def run_main(args: Any) -> int:
         )
         config_rich_logger.warning(
             "Run 'mmrelay migrate --dry-run' and 'mmrelay migrate' before upgrading "
-            "past the 1.4 release series. See docs/DOCKER.md: Migrating to the New Layout."
+            "past the %s release series. See docs/DOCKER.md: Migrating to the New Layout.",
+            LEGACY_LAYOUT_FINAL_MIGRATION_SERIES,
         )
 
     # Check if config exists and has the required keys

--- a/src/mmrelay/paths.py
+++ b/src/mmrelay/paths.py
@@ -41,6 +41,7 @@ from mmrelay.constants.app import (
     WINDOWS_INSTALLER_DIR_NAME,
     WINDOWS_PLATFORM,
 )
+from mmrelay.constants.config import LEGACY_LAYOUT_REMOVAL_VERSION
 from mmrelay.constants.database import PLUGIN_DB_FILENAME_TEMPLATE
 from mmrelay.constants.plugins import (
     PLUGIN_TYPE_COMMUNITY,
@@ -298,8 +299,9 @@ def get_home_dir() -> Path:
         if legacy_vars and not _deprecation_warning_shown:
             logger.warning(
                 "MMRELAY_HOME is set; ignoring legacy environment variable(s): %s. "
-                "Support will be removed in v1.4.",
+                "Support will be removed in v%s.",
                 ", ".join(legacy_vars),
+                LEGACY_LAYOUT_REMOVAL_VERSION,
             )
             _deprecation_warning_shown = True
         return Path(env_home).expanduser().absolute()
@@ -313,7 +315,8 @@ def get_home_dir() -> Path:
             logger.warning(
                 "Both MMRELAY_BASE_DIR and MMRELAY_DATA_DIR are set. "
                 "Preferring MMRELAY_BASE_DIR and ignoring MMRELAY_DATA_DIR. "
-                "Support will be removed in v1.4."
+                "Support will be removed in v%s.",
+                LEGACY_LAYOUT_REMOVAL_VERSION,
             )
             _deprecation_warning_shown = True
         return Path(env_base_dir).expanduser().absolute()
@@ -323,7 +326,8 @@ def get_home_dir() -> Path:
             logger.warning(
                 "Deprecated environment variable MMRELAY_BASE_DIR is set. "
                 "Use MMRELAY_HOME instead. "
-                "Support will be removed in v1.4."
+                "Support will be removed in v%s.",
+                LEGACY_LAYOUT_REMOVAL_VERSION,
             )
             _deprecation_warning_shown = True
         return Path(env_base_dir).expanduser().absolute()
@@ -333,7 +337,8 @@ def get_home_dir() -> Path:
             logger.warning(
                 "Deprecated environment variable MMRELAY_DATA_DIR is set. "
                 "Use MMRELAY_HOME instead. "
-                "Support will be removed in v1.4."
+                "Support will be removed in v%s.",
+                LEGACY_LAYOUT_REMOVAL_VERSION,
             )
             _deprecation_warning_shown = True
         return Path(env_data_dir).expanduser().absolute()
@@ -808,8 +813,9 @@ def is_deprecation_window_active() -> bool:
                 logger.warning(
                     "Deprecated environment variable(s) detected: %s. "
                     "Use MMRELAY_HOME instead. "
-                    "Support will be removed in v1.4.",
+                    "Support will be removed in v%s.",
                     ", ".join(legacy_vars),
+                    LEGACY_LAYOUT_REMOVAL_VERSION,
                 )
                 _deprecation_warning_shown = True
             return True

--- a/tests/test_cli_targeted.py
+++ b/tests/test_cli_targeted.py
@@ -32,6 +32,10 @@ from mmrelay.cli import (
 )
 from mmrelay.constants.app import APP_DISPLAY_NAME, CREDENTIALS_FILENAME, LOG_FILENAME
 from mmrelay.constants.cli import EXIT_CODE_ERROR, EXIT_CODE_SUCCESS
+from mmrelay.constants.config import (
+    LEGACY_LAYOUT_FINAL_MIGRATION_SERIES,
+    LEGACY_LAYOUT_REMOVAL_VERSION,
+)
 
 
 def _make_paths_info(**overrides):
@@ -357,15 +361,18 @@ class TestHandleMigrateCommand(unittest.TestCase):
     def test_migration_warns_about_final_compatibility_window(
         self, mock_print, mock_perform
     ):
-        """Migration tells operators that 1.4 is the final bridge release."""
+        """Migration reports the configured final compatibility window."""
         mock_perform.return_value = {"success": True, "migrations": []}
 
         result = handle_migrate_command(self.args)
 
         self.assertEqual(result, EXIT_CODE_SUCCESS)
         output = "\n".join(" ".join(map(str, call.args)) for call in mock_print.call_args_list)
-        self.assertIn("final release series", output)
-        self.assertIn("v1.5", output)
+        self.assertIn(
+            f"MMRelay {LEGACY_LAYOUT_FINAL_MIGRATION_SERIES} is the final release series",
+            output,
+        )
+        self.assertIn(f"v{LEGACY_LAYOUT_REMOVAL_VERSION}", output)
 
     @patch("mmrelay.migrate.perform_migration")
     @patch("builtins.print")

--- a/tests/test_cli_targeted.py
+++ b/tests/test_cli_targeted.py
@@ -354,6 +354,21 @@ class TestHandleMigrateCommand(unittest.TestCase):
 
     @patch("mmrelay.migrate.perform_migration")
     @patch("builtins.print")
+    def test_migration_warns_about_final_compatibility_window(
+        self, mock_print, mock_perform
+    ):
+        """Migration tells operators that 1.4 is the final bridge release."""
+        mock_perform.return_value = {"success": True, "migrations": []}
+
+        result = handle_migrate_command(self.args)
+
+        self.assertEqual(result, EXIT_CODE_SUCCESS)
+        output = "\n".join(" ".join(map(str, call.args)) for call in mock_print.call_args_list)
+        self.assertIn("final release series", output)
+        self.assertIn("v1.5", output)
+
+    @patch("mmrelay.migrate.perform_migration")
+    @patch("builtins.print")
     def test_failed_migration(self, mock_print, mock_perform):
         """Test failed migration prints error message."""
         mock_perform.return_value = {

--- a/tests/test_config_edge_cases.py
+++ b/tests/test_config_edge_cases.py
@@ -1168,15 +1168,18 @@ class TestLegacyPathOverrideWarnings(unittest.TestCase):
 
     def test_warning_includes_removal_version(self):
         from mmrelay.config import _warn_on_legacy_path_overrides
-        from mmrelay.constants.config import DEPRECATION_VERSIONS
+        from mmrelay.constants.config import LEGACY_LAYOUT_REMOVAL_VERSION
 
         config = {"credentials_path": "/some/path"}
         with patch("mmrelay.config.logger") as mock_logger:
             _warn_on_legacy_path_overrides(config)
             warning_calls = [str(call) for call in mock_logger.warning.call_args_list]
             assert any(
-                DEPRECATION_VERSIONS[1] in msg for msg in warning_calls
-            ), f"No warning mentioning {DEPRECATION_VERSIONS[1]} in {warning_calls}"
+                LEGACY_LAYOUT_REMOVAL_VERSION in msg for msg in warning_calls
+            ), (
+                "No warning mentioning "
+                f"{LEGACY_LAYOUT_REMOVAL_VERSION} in {warning_calls}"
+            )
 
     def test_get_explicit_credentials_path_warns_on_env_var(self):
         from mmrelay.config import get_explicit_credentials_path


### PR DESCRIPTION
## Summary

Keep MMRelay 1.4 as the final release series that can migrate and run with
the legacy data layout, with legacy compatibility and migration tooling planned
for removal in 1.5.

- Centralize the final migration series and removal version as explicit policy
  constants.
- Use those constants consistently across CLI, startup, path, config, and
  database warnings.
- Tell operators to complete `mmrelay migrate --dry-run` and `mmrelay migrate`
  before upgrading beyond the 1.4 release series.
- Preserve the migration path for users upgrading directly from older MMRelay
  releases instead of requiring an intermediate 1.3 installation.
- Cover the operator-facing compatibility-window messaging with regression tests.

This intentionally extends migration compatibility through 1.4 while keeping
the 1.5 removal boundary explicit and auditable.