### PR TITLE
chore(release): prepare 1.4.0 metadata and release guardrails

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -21,6 +21,18 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          ref: ${{ github.event_name == 'release' && github.event.release.tag_name || github.ref }}
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
+        with:
+          python-version: "3.14"
+
+      - name: Validate release tag against package version
+        if: ${{ github.event_name == 'release' }}
+        run: python scripts/ci/validate_release_version.py --tag "${{ github.event.release.tag_name }}"
 
       - name: Extract version and build info
         id: get_version

--- a/.github/workflows/package-windows.yml
+++ b/.github/workflows/package-windows.yml
@@ -26,11 +26,18 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          ref: ${{ github.event_name == 'release' && github.event.release.tag_name || github.ref }}
+          persist-credentials: false
 
       - name: Set up Python
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
         with:
           python-version: 3.14
+
+      - name: Validate release tag against package version
+        if: ${{ github.event_name == 'release' }}
+        run: python scripts/ci/validate_release_version.py --tag "${{ github.event.release.tag_name }}"
 
       - name: Extract version and git SHA
         id: get_version

--- a/.github/workflows/post-release-version-bump.yml
+++ b/.github/workflows/post-release-version-bump.yml
@@ -9,7 +9,7 @@ permissions:
 
 jobs:
   bump-main-to-next-patch:
-    if: github.event.release.target_commitish == 'main'
+    if: github.event.release.target_commitish == 'main' && github.event.release.prerelease == false
     runs-on: ubuntu-latest
     env:
       RELEASE_BUMP_PAT: ${{ secrets.RELEASE_BUMP_PAT }}
@@ -36,6 +36,18 @@ jobs:
         with:
           python-version: "3.14"
 
+      - name: Validate released tag against package version
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          release_pyproject="${RUNNER_TEMP}/release-pyproject.toml"
+          git show "${RELEASE_TAG}:pyproject.toml" > "${release_pyproject}"
+          python scripts/ci/validate_release_version.py \
+            --tag "${RELEASE_TAG}" \
+            --pyproject "${release_pyproject}"
+
       - name: Install bump-my-version
         shell: bash
         run: |
@@ -43,27 +55,51 @@ jobs:
           python -m pip install --upgrade pip
           pip install bump-my-version==1.3.0
 
-      - name: Bump patch version
+      - name: Bump patch version exactly once
         id: bump
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
         shell: bash
         run: |
           set -euo pipefail
 
+          RELEASE_VERSION="$(
+            python3 -c 'import os; from scripts.ci.validate_release_version import normalize_release_tag; print(normalize_release_tag(os.environ["RELEASE_TAG"]))'
+          )"
+          EXPECTED_VERSION="$(
+            RELEASE_VERSION="$RELEASE_VERSION" python3 -c 'import os; from scripts.ci.validate_release_version import next_patch_version; print(next_patch_version(os.environ["RELEASE_VERSION"]))'
+          )"
           CURRENT_VERSION="$(
             python3 -c "import tomllib; from pathlib import Path; print(tomllib.loads(Path('pyproject.toml').read_text(encoding='utf-8'))['project']['version'])"
           )"
+
+          echo "current=$CURRENT_VERSION" >> "$GITHUB_OUTPUT"
+          echo "new=$EXPECTED_VERSION" >> "$GITHUB_OUTPUT"
+
+          if [[ "$CURRENT_VERSION" == "$EXPECTED_VERSION" ]]; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            echo "main is already at expected post-release version $EXPECTED_VERSION; nothing to do."
+            exit 0
+          fi
+
+          if [[ "$CURRENT_VERSION" != "$RELEASE_VERSION" ]]; then
+            echo "::error::main version $CURRENT_VERSION is neither released version $RELEASE_VERSION nor expected post-release version $EXPECTED_VERSION."
+            exit 1
+          fi
 
           bump-my-version bump patch
 
           NEW_VERSION="$(
             python3 -c "import tomllib; from pathlib import Path; print(tomllib.loads(Path('pyproject.toml').read_text(encoding='utf-8'))['project']['version'])"
           )"
-
-          echo "current=$CURRENT_VERSION" >> "$GITHUB_OUTPUT"
-          echo "new=$NEW_VERSION" >> "$GITHUB_OUTPUT"
+          if [[ "$NEW_VERSION" != "$EXPECTED_VERSION" ]]; then
+            echo "::error::version bump produced $NEW_VERSION; expected $EXPECTED_VERSION."
+            exit 1
+          fi
+          echo "changed=true" >> "$GITHUB_OUTPUT"
 
       - name: Commit and push version bump
-        if: steps.bump.outputs.current != steps.bump.outputs.new
+        if: steps.bump.outputs.changed == 'true'
         env:
           NEW_VERSION: ${{ steps.bump.outputs.new }}
           RELEASE_TAG: ${{ github.event.release.tag_name }}

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -17,11 +17,18 @@ jobs:
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          ref: ${{ github.event_name == 'release' && github.event.release.tag_name || github.ref }}
+          persist-credentials: false
 
       - name: Set up Python
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
         with:
           python-version: 3.x
+
+      - name: Validate release tag against package version
+        if: ${{ github.event_name == 'release' }}
+        run: python scripts/ci/validate_release_version.py --tag "${{ github.event.release.tag_name }}"
 
       - name: Install build dependencies
         run: |

--- a/.github/workflows/test-and-coverage.yml
+++ b/.github/workflows/test-and-coverage.yml
@@ -22,15 +22,17 @@ jobs:
         python-version: ["3.11", "3.12", "3.13", "3.14"]
 
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: ${{ matrix.python-version }}
 
       - name: Cache pip dependencies
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-py${{ matrix.python-version }}-pip-${{ hashFiles('**/pyproject.toml') }}
@@ -50,7 +52,7 @@ jobs:
 
       - name: Upload coverage reports to Codecov
         if: matrix.python-version == '3.13'
-        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           slug: jeremiah-k/meshtastic-matrix-relay
@@ -61,7 +63,7 @@ jobs:
 
       - name: Upload test results to Codecov
         if: ${{ !cancelled() }}
-        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           report_type: test_results

--- a/deploy/helm/mmrelay/Chart.yaml
+++ b/deploy/helm/mmrelay/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: mmrelay
 description: A Helm chart for MMRelay - Meshtastic to Matrix relay
 type: application
-version: 1.3.3
-appVersion: 1.3.3
+version: 1.4.0
+appVersion: 1.4.0
 keywords:
   - meshtastic
   - matrix

--- a/deploy/helm/mmrelay/values.yaml
+++ b/deploy/helm/mmrelay/values.yaml
@@ -3,7 +3,7 @@
 # Image configuration
 image:
   repository: ghcr.io/jeremiah-k/mmrelay
-  tag: 1.3.3
+  tag: 1.4.0
   pullPolicy: IfNotPresent
   # If set, overrides tag (format: sha256:abc123...)
   digest: ""

--- a/deploy/k8s/kustomization.yaml
+++ b/deploy/k8s/kustomization.yaml
@@ -9,4 +9,4 @@ images:
   - name: ghcr.io/jeremiah-k/mmrelay
     # Pin to a stable release by default for predictable deployments.
     # Use overlays/digest for immutable production pinning.
-    newTag: 1.3.3
+    newTag: 1.4.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mmrelay"
-version = "1.3.8"
+version = "1.4.0"
 description = "Bridge between Meshtastic mesh networks and Matrix chat rooms"
 readme = "README.md"
 requires-python = ">=3.11"
@@ -78,7 +78,7 @@ where = ["src"]
 "*" = ["__pycache__/*", "*.py[cod]"]
 
 [tool.bumpversion]
-current_version = "1.3.8"
+current_version = "1.4.0"
 parse = '(?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)'
 serialize = ["{major}.{minor}.{patch}"]
 search = "{current_version}"

--- a/scripts/ci/validate_release_version.py
+++ b/scripts/ci/validate_release_version.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+"""Verify that a GitHub release tag matches the package version exactly."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+import tomllib
+from pathlib import Path
+
+_RELEASE_TAG_RE = re.compile(r"\d+\.\d+\.\d+(?:[.-][0-9A-Za-z]+)*\Z")
+
+
+def normalize_release_tag(tag: str) -> str:
+    """Return the version encoded by a validated release tag."""
+    normalized = tag.strip()
+    if normalized.startswith("v"):
+        normalized = normalized[1:]
+    if not normalized or _RELEASE_TAG_RE.fullmatch(normalized) is None:
+        raise ValueError(f"Release tag {tag!r} is not a supported version tag")
+    return normalized
+
+
+def next_patch_version(version: str) -> str:
+    """Return the next patch version for a stable ``major.minor.patch`` version."""
+    match = re.fullmatch(r"(\d+)\.(\d+)\.(\d+)", version)
+    if match is None:
+        raise ValueError(
+            f"Post-release bump requires a stable major.minor.patch version, got {version!r}"
+        )
+    major, minor, patch = (int(part) for part in match.groups())
+    return f"{major}.{minor}.{patch + 1}"
+
+
+def read_project_version(pyproject_path: Path) -> str:
+    """Read the PEP 621 project version from ``pyproject.toml``."""
+    with pyproject_path.open("rb") as pyproject_file:
+        pyproject = tomllib.load(pyproject_file)
+    try:
+        version = pyproject["project"]["version"]
+    except (KeyError, TypeError) as exc:
+        raise ValueError(
+            f"Unable to read project.version from {pyproject_path}"
+        ) from exc
+    if not isinstance(version, str) or not version:
+        raise ValueError(f"Invalid project.version in {pyproject_path}")
+    return version
+
+
+def validate_release_version(tag: str, pyproject_path: Path) -> str:
+    """Validate *tag* against *pyproject_path* and return the package version."""
+    tag_version = normalize_release_tag(tag)
+    project_version = read_project_version(pyproject_path)
+    if tag_version != project_version:
+        raise ValueError(
+            "Release tag/version mismatch: "
+            f"tag {tag!r} resolves to {tag_version!r}, "
+            f"but project.version is {project_version!r}"
+        )
+    return project_version
+
+
+def parse_args() -> argparse.Namespace:
+    """Parse command-line arguments."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--tag", required=True, help="GitHub release tag")
+    parser.add_argument(
+        "--pyproject",
+        type=Path,
+        default=Path("pyproject.toml"),
+        help="Path to pyproject.toml",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    """Run release-version validation."""
+    args = parse_args()
+    try:
+        version = validate_release_version(args.tag, args.pyproject)
+    except (OSError, tomllib.TOMLDecodeError, ValueError) as exc:
+        print(f"::error::{exc}", file=sys.stderr)
+        return 1
+    print(f"Release tag {args.tag!r} matches project version {version!r}.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_release_version_validation.py
+++ b/tests/test_release_version_validation.py
@@ -1,0 +1,63 @@
+"""Tests for release tag and package-version validation."""
+
+from pathlib import Path
+
+import pytest
+
+from scripts.ci.validate_release_version import (
+    next_patch_version,
+    normalize_release_tag,
+    read_project_version,
+    validate_release_version,
+)
+
+
+def _write_pyproject(path: Path, version: str) -> Path:
+    pyproject_path = path / "pyproject.toml"
+    pyproject_path.write_text(
+        f'[project]\nname = "mmrelay"\nversion = "{version}"\n',
+        encoding="utf-8",
+    )
+    return pyproject_path
+
+
+@pytest.mark.parametrize("tag", ["1.4.0", "v1.4.0"])
+def test_normalize_release_tag_accepts_supported_tags(tag: str) -> None:
+    assert normalize_release_tag(tag) == "1.4.0"
+
+
+@pytest.mark.parametrize("tag", ["", "v", "release-1.4.0", "1.4", "1.4.0+local"])
+def test_normalize_release_tag_rejects_unsupported_tags(tag: str) -> None:
+    with pytest.raises(ValueError, match="not a supported version tag"):
+        normalize_release_tag(tag)
+
+
+
+@pytest.mark.parametrize(
+    ("version", "expected"),
+    [("1.4.0", "1.4.1"), ("1.4.9", "1.4.10"), ("2.0.0", "2.0.1")],
+)
+def test_next_patch_version_increments_stable_release(
+    version: str, expected: str
+) -> None:
+    assert next_patch_version(version) == expected
+
+
+@pytest.mark.parametrize("version", ["1.4", "1.4.0-rc1", "1.4.0.dev1"])
+def test_next_patch_version_rejects_non_stable_versions(version: str) -> None:
+    with pytest.raises(ValueError, match="stable major.minor.patch"):
+        next_patch_version(version)
+
+def test_read_project_version_reads_pep621_metadata(tmp_path: Path) -> None:
+    assert read_project_version(_write_pyproject(tmp_path, "1.4.0")) == "1.4.0"
+
+
+def test_validate_release_version_accepts_exact_match(tmp_path: Path) -> None:
+    pyproject_path = _write_pyproject(tmp_path, "1.4.0")
+    assert validate_release_version("v1.4.0", pyproject_path) == "1.4.0"
+
+
+def test_validate_release_version_rejects_mismatch(tmp_path: Path) -> None:
+    pyproject_path = _write_pyproject(tmp_path, "1.4.0")
+    with pytest.raises(ValueError, match="mismatch"):
+        validate_release_version("1.4.1", pyproject_path)


### PR DESCRIPTION
## Summary

Prepare MMRelay 1.4.0 for a coordinated package, container, Windows, Helm, and
Kubernetes release.

- Set package and deployment metadata to 1.4.0.
- Build release artifacts from the release tag rather than a moving `main`.
- Validate that the release tag matches `project.version` before publishing.
- Keep the post-release patch bump deterministic, stable-release-only, and
  rerun-safe.
- Avoid persisting checkout credentials where CI does not need them.
- Add focused tests for release-tag normalization, project-version validation,
  and next-patch calculation.

These changes reduce the chance of publishing mismatched artifacts or racing
the automated post-release version bump.