### PR TITLE
docs: consolidate 1.4 user and upgrade guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,105 +1,70 @@
 # MMRelay
 
-## (Meshtastic <=> Matrix Relay)
+**Meshtastic ↔ Matrix Relay**
 
-A powerful and easy-to-use relay between Meshtastic devices and Matrix chat rooms, allowing seamless communication across platforms. This opens the door for bridging Meshtastic devices to [many other platforms](https://matrix.org/bridges/).
+MMRelay is a self-hosted bridge between a Meshtastic meshnet and Matrix. It runs
+as a long-lived service, connects to one Meshtastic node, logs in to Matrix with
+a bot account, and relays eligible traffic between configured Meshtastic
+channels and Matrix rooms.
 
-## Features
+`Meshtastic meshnet ⇄ Meshtastic node ⇄ MMRelay ⇄ Matrix rooms`
 
-- Bidirectional message relay between Meshtastic devices and Matrix chat rooms, capable of supporting multiple meshnets
-- Supports serial, network, and BLE connections for Meshtastic devices
-- Custom fields are embedded in Matrix messages for relaying messages between multiple meshnets
-- Truncates long messages to fit within Meshtastic's payload size
-- SQLite database to store node information for improved functionality
-- Customizable logging level for easy debugging
-- Configurable through a simple YAML file
-- Supports mapping multiple rooms and channels 1:1
-- Relays messages to/from an MQTT broker, if configured in the Meshtastic firmware
-- Bidirectional replies and reactions support
-- Native Docker support
-- Supports encrypted Matrix rooms 🔐 (Matrix E2EE)
-- Unified directory structure 📁 (New in v1.3)
+## How it works at a glance
 
-> **Encryption note**: MMRelay uses [**mindroom-nio**](https://github.com/mindroom-ai/mindroom-nio) with **vodozemac** for Matrix E2EE. With MMRelay's supported mindroom-nio provider, encrypted sessions make a best-effort attempt to cross-sign the Matrix bot account's own Matrix client device without verifying other users; startup continues with a warning when the provider or homeserver cannot complete it. This is Matrix client key management only: it does not sign Meshtastic nodes, link identities across Matrix and Meshtastic, or add cross-platform verification. Run `mmrelay auth login` once if the homeserver requires password-based authentication for the initial upload. If the local cross-signing sidecar was lost but Matrix already has an identity, `mmrelay auth login --reset-cross-signing` provides an explicit password-authenticated recovery path without first logging out; it replaces the server identity, so other clients may require verification again. Most users, including Docker deployments and clean pipx/PyPI installs, should not need to do anything else. If you maintain a developer venv/editable install or an older in-place upgraded Python environment, verify that matrix-nio is not still installed alongside mindroom-nio. See the [E2EE Setup Guide](docs/E2EE.md) and the [v1.3 Migration Guide](docs/MIGRATION_1.3.md).
+- **Meshtastic side:** MMRelay connects to a Meshtastic node over **Serial**, **BLE**, or **TCP/network** (for example, a node reachable over Wi-Fi).
+- **Matrix side:** MMRelay joins configured rooms using a dedicated Matrix bot account.
+- **Room/channel mapping:** each configured Matrix room is associated with a Meshtastic channel number. Multiple Matrix rooms may use the same channel.
+- **Bidirectional relay:** eligible mesh traffic can be posted to mapped Matrix rooms, and eligible Matrix traffic can be transmitted on the mapped Meshtastic channel.
+- **Identity boundary:** messages posted into Matrix are sent by the MMRelay bot. Meshtastic sender names and node IDs are preserved as attribution; they are not Matrix-authenticated identities.
+
+For the full conceptual model—including meshnet terminology, the recommended
+relay-node setup, message flow, mapping behavior, and the identity/trust
+boundary—see **[How MMRelay Works](https://github.com/jeremiah-k/meshtastic-matrix-relay/wiki/How-MMRelay-Works)**.
+
+## Start here
+
+- **[Installation and setup](docs/INSTRUCTIONS.md)** — install MMRelay and create a configuration
+- **[Getting started with Matrix](https://github.com/jeremiah-k/meshtastic-matrix-relay/wiki/Getting-Started-With-Matrix-&-MM-Relay)** — Matrix basics and account setup
+- **[E2EE setup](docs/E2EE.md)** — encrypted Matrix rooms and bot-device identity
+- **[Docker](docs/DOCKER.md)** · **[Helm](docs/HELM.md)** · **[Kubernetes](docs/KUBERNETES.md)** — deployment options
+- **[What's new in 1.4](docs/WHATS_NEW_1.4.md)** — release and upgrade guidance
+- **[Documentation index](docs/README.md)** — all versioned project documentation
+
+## Highlights
+
+- Bidirectional Meshtastic ↔ Matrix message relay
+- Multiple meshnets and configurable room/channel mappings
+- Serial, BLE, and TCP/network Meshtastic connections
+- Matrix end-to-end encryption support
+- Replies and reactions across the bridge
+- Message formatting and payload-size handling for Meshtastic
+- SQLite-backed node/message state
+- Docker and Kubernetes deployment support
+- Core, community, and local plugin support
+- Optional MQTT integration through Meshtastic firmware
+
+> **E2EE:** MMRelay uses [mindroom-nio](https://github.com/mindroom-ai/mindroom-nio)
+> with vodozemac for encrypted Matrix rooms. Cross-signing applies to the Matrix
+> bot device only; it does not authenticate Meshtastic identities. See the
+> [E2EE guide](docs/E2EE.md), especially before resetting authentication or
+> cross-signing state.
 >
-> **Improved BLE stability (v1.3.3)**: The Meshtastic Python library has been replaced with [mtjk](https://github.com/jeremiah-k/mtjk), a fork with BLE reliability improvements (auto-reconnection, state management, notification recovery) along with thread-safety and connection handling fixes. Changes may be upstreamed selectively once they've been battle-tested here. See the [Refactor Program](https://github.com/jeremiah-k/mtjk/blob/develop/REFACTOR_PROGRAM.md) for scope and rationale.
-
-## Documentation
-
-MMRelay supports multiple deployment methods including pip/pipx, Docker, and Kubernetes. For complete setup instructions and all deployment options, see:
-
-- [Installation Instructions](docs/INSTRUCTIONS.md) - Setup and configuration guide
-- [What's New in v1.3](docs/WHATS_NEW_1.3.md) - Latest release changes and migration info
-- [Migration Guide for v1.3](docs/MIGRATION_1.3.md) - Upgrading from v1.2 or earlier
-- [Docker Guide](docs/DOCKER.md) - Docker deployment methods
-- [Kubernetes Guide](docs/KUBERNETES.md) - Kubernetes deployment guide
-- [E2EE Setup Guide](docs/E2EE.md) - Matrix End-to-End Encryption configuration
-
----
+> **Meshtastic library:** MMRelay uses [mtjk](https://github.com/jeremiah-k/mtjk),
+> a Meshtastic Python fork with additional BLE, connection-lifecycle, and
+> thread-safety work used by this project.
 
 ## Plugins
 
-MMRelay supports plugins for extending its functionality, enabling customization and enhancement of the relay to suit specific needs.
+MMRelay can be extended with built-in core plugins, Git-managed community
+plugins, and local custom plugins. Plugins run inside the MMRelay process, so
+install third-party code only from sources you trust.
 
-### Core Plugins
+- [Core Plugins](https://github.com/jeremiah-k/meshtastic-matrix-relay/wiki/Core-Plugins)
+- [Community Plugin List](https://github.com/jeremiah-k/meshtastic-matrix-relay/wiki/Community-Plugin-List)
+- [Plugin Development Guide](https://github.com/jeremiah-k/meshtastic-matrix-relay/wiki/Plugin-Development-Guide)
 
-Generate a map of your nodes:
+## Community
 
-![Map Plugin Screenshot](https://user-images.githubusercontent.com/1770544/235247915-47750b4f-d505-4792-a458-54a5f24c1523.png)
-
-Produce high-level details about your mesh:
-
-![Mesh Details Screenshot](https://user-images.githubusercontent.com/1770544/235245873-1ddc773b-a4cd-4c67-b0a5-b55a29504b73.png)
-
-See the full list of [core plugins](https://github.com/jeremiah-k/meshtastic-matrix-relay/wiki/Core-Plugins).
-
-### Plugin System
-
-MMRelay supports three plugin types:
-
-- **Core Plugins**: Built in with MMRelay
-- **Community Plugins**: Git-based plugins that MMRelay syncs for you
-- **Custom Plugins**: Local/manual plugins for private use and development
-
-MMRelay manages plugin directories under `MMRELAY_HOME` (default `~/.mmrelay`).
-Most users only need `config.yaml`; path details matter mainly when authoring custom plugins.
-
-Check the [Community Plugins Development Guide](https://github.com/jeremiah-k/meshtastic-matrix-relay/wiki/Community-Plugin-Development-Guide) in our wiki to get started.
-
-✨️ Visit the [Community Plugins List](https://github.com/jeremiah-k/meshtastic-matrix-relay/wiki/Community-Plugin-List)!
-
-### Install a Community Plugin
-
-Add the repository under the `community-plugins` section in `config.yaml`:
-
-```yaml
-community-plugins:
-  example-plugin:
-    active: true
-    repository: https://github.com/jeremiah-k/mmr-plugin-template.git
-    commit: 0123456789abcdef0123456789abcdef01234567
-    install_requirements: true
-```
-
-- Community plugins run in the same MMRelay process and inherit its permissions. Use trusted sources.
-- Dependency installation is per-plugin and defaults to off (`install_requirements: false`).
-- Prefer commit-pinned refs.
-- Explicit `branch` and `tag` refs are allowed for dependency install, but MMRelay logs warnings.
-- Missing ref (implicit default branch) is not eligible for dependency install.
-- Dependencies install once per resolved local commit and are skipped when unchanged.
-
----
-
-## Getting Started with Matrix
-
-See our Wiki page [Getting Started With Matrix & MMRelay](https://github.com/jeremiah-k/meshtastic-matrix-relay/wiki/Getting-Started-With-Matrix-&-MM-Relay).
-
----
-
-## Already on Matrix?
-
-Join us!
-
-- Our project's room: [#mmrelay:matrix.org](https://matrix.to/#/#mmrelay:matrix.org)
-- Part of the Meshnet Club Matrix space: [#meshnetclub:matrix.org](https://matrix.to/#/#meshnetclub:matrix.org)
-- Public Relay Room: [#mmrelay-relay-room:matrix.org](https://matrix.to/#/#mmrelay-relay-room:matrix.org) - Where we bridge multiple meshnets. Feel free to join us, with or without a relay!
+- Project room: [#mmrelay:matrix.org](https://matrix.to/#/#mmrelay:matrix.org)
+- Meshnet Club space: [#meshnetclub:matrix.org](https://matrix.to/#/#meshnetclub:matrix.org)
+- Public relay room: [#mmrelay-relay-room:matrix.org](https://matrix.to/#/#mmrelay-relay-room:matrix.org)

--- a/docs/ADVANCED_CONFIGURATION.md
+++ b/docs/ADVANCED_CONFIGURATION.md
@@ -125,8 +125,8 @@ meshtastic:
 - `ENCRYPTED` is a log/display label, not a valid override value.
 - `chat_portnums` only makes a packet relay-eligible; Matrix delivery still requires a usable channel. If channel info is missing, plugins still run but the Matrix relay leg is skipped.
 
-For implementation details, rationale, and edge cases, see
-[`docs/dev/meshtastic_packet_routing_policy.md`](dev/meshtastic_packet_routing_policy.md).
+The routing checks above are applied before Matrix delivery; plugins may still
+observe packets that are relay-ineligible when their own subscriptions permit it.
 
 ## Meshtastic Health Check Overrides
 

--- a/docs/ADVANCED_CONFIGURATION.md
+++ b/docs/ADVANCED_CONFIGURATION.md
@@ -125,8 +125,9 @@ meshtastic:
 - `ENCRYPTED` is a log/display label, not a valid override value.
 - `chat_portnums` only makes a packet relay-eligible; Matrix delivery still requires a usable channel. If channel info is missing, plugins still run but the Matrix relay leg is skipped.
 
-The routing checks above are applied before Matrix delivery; plugins may still
-observe packets that are relay-ineligible when their own subscriptions permit it.
+The routing checks above are applied before Matrix delivery. Except for packets
+dropped by `disabled_portnums`, plugins may still observe relay-ineligible
+packets when their own subscriptions permit it.
 
 ## Meshtastic Health Check Overrides
 

--- a/docs/HELM.md
+++ b/docs/HELM.md
@@ -57,7 +57,7 @@ helm install mmrelay ./deploy/helm/mmrelay \
 # Optional but recommended: pin image tag explicitly for repeatable runs
 helm upgrade --install mmrelay ./deploy/helm/mmrelay \
   --namespace mmrelay \
-  --set image.tag=1.3.3
+  --set image.tag=1.4.0
 ```
 
 ### 6. Verify Deployment
@@ -76,7 +76,7 @@ The Helm chart is highly configurable. Key options include:
 ```yaml
 image:
   repository: ghcr.io/jeremiah-k/mmrelay
-  tag: 1.3.3
+  tag: 1.4.0
   pullPolicy: IfNotPresent
   # Pin by digest for production (immutable)
   digest: ""
@@ -88,7 +88,7 @@ image:
 
 ```bash
 helm upgrade mmrelay ./deploy/helm/mmrelay \
-  --set image.tag=1.3.3 \
+  --set image.tag=1.4.0 \
   --namespace mmrelay
 ```
 
@@ -515,7 +515,7 @@ If upgrading from 1.2.x or earlier, follow `docs/MIGRATION_1.3.md` first.
 ```bash
 helm upgrade mmrelay ./deploy/helm/mmrelay \
   --namespace mmrelay \
-  --set image.tag=1.3.3
+  --set image.tag=1.4.0
 ```
 
 ### Rolling Restart

--- a/docs/KUBERNETES.md
+++ b/docs/KUBERNETES.md
@@ -508,7 +508,7 @@ kubectl exec -n mmrelay <pod-name> -- mmrelay verify-migration
 kubectl exec -n mmrelay <pod-name> -- mmrelay doctor
 ```
 
-Deprecation timeline: legacy credential/location fallbacks are supported in v1.3 and planned for removal in v1.4.
+Deprecation timeline: legacy credential/location fallback and migration tooling remain available through the v1.4 release series as a final upgrade bridge and are planned for removal in v1.5.
 
 ### Disaster recovery checklist
 

--- a/docs/MIGRATION_1.3.md
+++ b/docs/MIGRATION_1.3.md
@@ -6,7 +6,7 @@ This guide helps you upgrade from any legacy layout to the v1.3 unified HOME mod
 
 MMRelay now uses a single MMRELAY_HOME root for all runtime state:
 
-> **Deprecation Note**: Legacy credential/location fallback is supported until v1.4; warnings will be emitted until you migrate. Plan to migrate before upgrading to v1.4.
+> **Deprecation Note**: MMRelay 1.4 is the final release series with legacy credential/location fallback and migration tooling. Warnings continue until you migrate; complete migration before upgrading to v1.5.
 
 - Credentials (moved to `matrix/` subdirectory)
 - Database (moved to `database/` subdirectory)

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,81 +1,58 @@
 # MMRelay Documentation
 
-Welcome to the MMRelay documentation! This directory contains comprehensive guides for setting up and using MMRelay.
+The repository documentation is for **versioned setup, deployment, upgrade, and
+operator guidance**. Broader conceptual and community documentation lives in the
+[MMRelay wiki](https://github.com/jeremiah-k/meshtastic-matrix-relay/wiki).
 
-## Getting Started
+## Understand MMRelay
 
-- **[Installation Guide](INSTRUCTIONS.md)** - Complete setup instructions for MMRelay
-- **[Migration Guide for v1.3](MIGRATION_1.3.md)** - Upgrading from older versions to unified HOME model
-- **[E2EE Guide](E2EE.md)** - Encrypted Matrix rooms (Matrix E2EE) setup and usage
-- **[Docker Guide](DOCKER.md)** - Docker deployment and configuration
-- **[Helm Guide](HELM.md)** - Kubernetes Helm chart deployment guide
+- **[How MMRelay Works](https://github.com/jeremiah-k/meshtastic-matrix-relay/wiki/How-MMRelay-Works)** — meshnet, relay node, channel/room mapping, message flow, and identity boundary
+- **[Getting Started with Matrix](https://github.com/jeremiah-k/meshtastic-matrix-relay/wiki/Getting-Started-With-Matrix-&-MM-Relay)** — Matrix basics for new MMRelay operators
 
-## Advanced Configuration
+## Install and deploy
 
-- **[Advanced Configuration](ADVANCED_CONFIGURATION.md)** - Advanced features like message prefixes, packet routing overrides, health-check tuning, debug logging, and environment variables
+- **[Installation Guide](INSTRUCTIONS.md)** — pip/pipx setup and primary configuration workflow
+- **[Docker Guide](DOCKER.md)** — Docker deployment
+- **[Helm Guide](HELM.md)** — Kubernetes deployment with Helm
+- **[Kubernetes Guide](KUBERNETES.md)** — static-manifest deployment
 
-## Release-Specific Documents
+## Configure and operate
 
-- **[What's New in 1.4.0](WHATS_NEW_1.4.md)** - Python 3.11 minimum and upgrade guidance
-- **[What's New in 1.3.0](WHATS_NEW_1.3.md)** - Release summary and changes overview
-- **[What's New in 1.2](WHATS_NEW_1.2.md)** - Previous release notes (historical)
+- **[E2EE Guide](E2EE.md)** — encrypted rooms, device identity, and cross-signing recovery
+- **[Advanced Configuration](ADVANCED_CONFIGURATION.md)** — message formatting, packet routing, health checks, debug logging, and environment overrides
 
-## File Locations
+## Upgrade and release notes
 
-| File          | Purpose               | Location                             |
-| ------------- | --------------------- | ------------------------------------ |
-| Configuration | Main settings         | `~/.mmrelay/config.yaml`             |
+- **[What's New in 1.4.0](WHATS_NEW_1.4.md)** — 1.4 release summary and upgrade guidance
+- **[Migration Guide for v1.3 layout](MIGRATION_1.3.md)** — moving older installations to the unified MMRelay home layout
+- **[What's New in 1.3.0](WHATS_NEW_1.3.md)** — historical 1.3 release summary
+- **[What's New in 1.2](WHATS_NEW_1.2.md)** — historical 1.2 release notes
+
+## Runtime file locations
+
+| File          | Purpose               | Default location                    |
+| ------------- | --------------------- | ----------------------------------- |
+| Configuration | Main settings         | `~/.mmrelay/config.yaml`            |
 | Credentials   | Matrix authentication | `~/.mmrelay/matrix/credentials.json` |
-| E2EE Store    | Encryption keys       | `~/.mmrelay/matrix/store/`           |
-| Logs          | Application logs      | `~/.mmrelay/logs/`                   |
+| E2EE Store    | Encryption keys       | `~/.mmrelay/matrix/store/`          |
+| Logs          | Application logs      | `~/.mmrelay/logs/`                  |
 
-## Developer Documentation
+Actual paths can vary when `MMRELAY_HOME`, installer-specific locations, or
+container mounts are used. The deployment guides document those cases.
 
-- **[Constants Reference](dev/CONSTANTS.md)** - Internal configuration constants and values
-- **[Meshtastic Packet Routing Policy](dev/meshtastic_packet_routing_policy.md)** - Inbound packet routing semantics and design notes
-- **[E2EE Implementation Notes](dev/archive/E2EE_IMPLEMENTATION_NOTES.md)** - Technical details of E2EE implementation
+## Developer documentation
 
-## Documentation Structure
+- **[Constants Reference](dev/CONSTANTS.md)** — internal configuration constants
+- **[Testing Guide](dev/TESTING_GUIDE.md)** — project testing patterns and ownership
+- **[Windows Installer Build Guide](dev/INNO_SETUP_GUIDE.md)** — installer maintenance
+- **[BLE Compatibility Notes](dev/BLE_DUAL_LIBRARY_COMPATIBILITY.md)** — BLE library compatibility design
+- **[Matrix Compatibility Plan](dev/MATRIX_DUAL_LIBRARY_COMPATIBILITY_PLAN.md)** — Matrix-provider compatibility design
+- **[Archived implementation notes](dev/archive/)** — historical design and migration material
 
-```bash
-docs/
-├── README.md                 # This file - documentation index
-├── INSTRUCTIONS.md           # Main installation and setup guide
-├── MIGRATION_1.3.md         # Migration guide for upgrading from older versions
-├── WHATS_NEW_1.4.md          # 1.4 runtime-support changes
-├── WHATS_NEW_1.3.md          # 1.3 release summary
-├── WHATS_NEW_1.2.md          # 1.2 release notes (historical)
-├── E2EE.md                  # End-to-End Encryption guide
-├── DOCKER.md                # Docker deployment guide
-├── KUBERNETES.md            # Static manifest deployment guide
-├── HELM.md                  # Helm chart deployment guide
-├── ADVANCED_CONFIGURATION.md # Advanced configuration options
-└── dev/                     # Developer documentation
-    ├── CONSTANTS.md         # Internal configuration constants
-    ├── meshtastic_packet_routing_policy.md # Packet routing policy internals
-    ├── INNO_SETUP_GUIDE.md  # Windows installer build guide
-    ├── TESTING_GUIDE.md     # Testing patterns and practices
-    ├── RELEASE_1.3.md       # Release checklist (internal)
-    └── archive/             # Historical planning documents
-        ├── DATA_LAYOUT_MIGRATION.md
-        ├── E2EE_IMPLEMENTATION_NOTES.md  # E2EE technical details
-        ├── V1_3_DIRECTORY_REDESIGN.md
-        ├── V1_3_MIGRATION_IMPROVEMENTS_PLAN.md
-        ├── UPGRADE_TEST_PLAN.md
-        └── UPGRADE_TEST_EXECUTION_CHECKLIST.md
-```
+## Getting help
 
-## Getting Help
-
-1. **Check the relevant guide** for your specific use case
-2. **Review troubleshooting sections** in each guide
-3. **Validate your configuration** with `mmrelay config check`
-4. **Enable debug logging** for detailed diagnostics
-5. **Ask for help** in the MMRelay Matrix room with your configuration and log excerpts
-
-## Version Information
-
-- **Next Release**: v1.4.0
-- **Python Requirement (v1.4+)**: 3.11+
-- **Supported Platforms**: Linux, macOS, Windows (E2EE not available on Windows)
-- **Key Features**: Meshtastic ↔ Matrix relay, encrypted Matrix rooms (Matrix E2EE), Docker deployment, Plugin system
+1. Start with the guide for your deployment or problem area.
+2. Run `mmrelay config check` for configuration validation.
+3. Run `mmrelay doctor` for general diagnostics.
+4. Enable targeted debug logging when troubleshooting a connection or provider.
+5. Ask in [#mmrelay:matrix.org](https://matrix.to/#/#mmrelay:matrix.org) with relevant configuration excerpts and logs, with secrets removed.

--- a/docs/WHATS_NEW_1.3.md
+++ b/docs/WHATS_NEW_1.3.md
@@ -40,4 +40,4 @@ Quick overview:
 ## Notes
 
 - Meshtastic devices support one active client connection at a time
-- Legacy credential/location fallback is supported until v1.4; migrate before upgrading to v1.4
+- MMRelay 1.4 is the final release series with legacy credential/location fallback and migration tooling; migrate before upgrading to v1.5

--- a/docs/WHATS_NEW_1.4.md
+++ b/docs/WHATS_NEW_1.4.md
@@ -1,34 +1,92 @@
 # What's New in 1.4.0
 
-MMRelay 1.4.0 raises the minimum supported Python version to 3.11.
+MMRelay 1.4.0 is primarily a reliability, encryption, and platform-baseline
+release. It raises the minimum Python version to 3.11 and incorporates the BLE,
+Matrix E2EE, and logging hardening developed since 1.3.8.
 
-## Why the Python floor changed
+## Before upgrading
+
+1. Upgrade the runtime to Python 3.11 or newer.
+2. If you still use pre-1.3 file locations or legacy `MMRELAY_*_DIR`
+   environment variables, run `mmrelay migrate --dry-run`, then `mmrelay
+   migrate` and `mmrelay verify-migration`.
+3. Back up the Matrix E2EE store, credentials, and cross-signing sidecar
+   together before changing authentication or storage.
+4. For containers or Kubernetes, update the image tag to `1.4.0` after the
+   release image is available.
+
+## Python 3.11 minimum
 
 Matplotlib 3.11 requires Python 3.11 or newer. MMRelay uses Matplotlib for
-telemetry graphs, so retaining Python 3.10 in the package metadata would
-advertise an environment that cannot install MMRelay's required dependencies.
-The map plugin is unaffected; it uses py-staticmaps and Pillow rather than
-Matplotlib.
+telemetry graphs, so retaining Python 3.10 in package metadata would advertise
+an environment that cannot install the required dependency stack.
 
-Python 3.10 is also in security-fix-only maintenance and reaches end of life in
-October 2026. Moving the floor now keeps MMRelay aligned with its actively
-maintained dependency stack and removes Python 3.10-only compatibility code.
-
-## Upgrade guidance
-
-Before installing MMRelay 1.4.0 or newer, upgrade the runtime to Python 3.11 or
-newer and recreate the virtual environment or pipx installation so compiled
+Python 3.10 systems can remain on the final MMRelay 1.3.x release. Recreate
+virtual environments or pipx installations after upgrading Python so compiled
 packages are installed for the new interpreter.
 
-Python 3.10 systems can remain on the final MMRelay 1.3.x release. Operators who
-need a custom dependency set may continue to install and maintain an older
-source checkout, but that environment is outside the supported 1.4 release
-matrix.
+## Matrix E2EE and device identity
+
+MMRelay now uses mindroom-nio 0.40 and verifies the bot device's server-visible
+cross-signing chain rather than treating local state alone as proof of trust.
+The relay can create or reuse its bot-account cross-signing identity and sign
+its own Matrix device. It does not verify other users or link Matrix identity
+to Meshtastic identity.
+
+Normal startup fails closed when the homeserver already has a cross-signing
+identity but the matching local private sidecar is unavailable. It does not
+silently rotate the account trust root. If the sidecar is irrecoverably lost,
+`mmrelay auth login --reset-cross-signing` provides an explicit,
+password-authenticated recovery path. That reset replaces the account's
+cross-signing identity, so other Matrix clients may require verification again.
+See [E2EE.md](E2EE.md) before using it.
+
+## BLE and Meshtastic reliability
+
+The Meshtastic dependency is the mtjk fork, currently pinned to the tested
+release in `pyproject.toml`. The 1.4 work includes additional relay-side BLE
+shutdown protection, daemonized worker handling, stale-work cleanup, and probe
+timing that waits for startup/reconnect stabilization before sending metadata
+traffic.
+
+These relay safeguards complement mtjk's own BLE lifecycle and reconnect
+handling; they do not replace it.
+
+## Logging reliability
+
+File logging now uses one shared rotating handler with consistent path
+expansion and refresh behavior. Component loggers are reattached when logging
+configuration is refreshed, and path-reporting commands agree with the file
+actually being written.
+
+## Final legacy-layout migration window
+
+The previously announced removal of v1.3 legacy-layout compatibility is deferred
+one release. **The 1.4 release series is the final bridge release that ships the
+legacy path fallbacks and `migrate`/`verify-migration` tooling.**
+
+This is intentional: users upgrading directly from MMRelay 1.2 or older should
+not have to install an intermediate 1.3 build merely to move their data. Finish
+migration during 1.4. Legacy layout compatibility and migration commands are
+planned for removal in 1.5.
+
+See [MIGRATION_1.3.md](MIGRATION_1.3.md) for the migration procedure.
+
+## Packaging and dependency updates
+
+The release also rolls forward the supported dependency and CI stack, including
+Python 3.11-3.14 testing, mindroom-nio 0.40, recent mtjk releases, and current
+pinned GitHub Actions/container dependencies.
+
+Release workflows validate that the release tag matches `project.version`
+before publishing package, container, or Windows installer artifacts, preventing
+an automated post-release version bump from racing release builds.
 
 ## Maintainer notes
 
-- Package metadata, runtime checks, mypy, Windows guidance, and CI all use the
-  same Python 3.11 minimum.
-- Matplotlib is updated to 3.11.1 after the Python floor change.
-- The Python 3.10 fallback parser in the source-checkout version helper is
-  removed in favor of the Python 3.11 standard-library `tomllib` module.
+- Package metadata, runtime checks, type checking, Windows guidance, and CI use
+  the same Python 3.11 minimum.
+- The Python 3.10 source-checkout TOML fallback is gone in favor of Python
+  3.11's standard-library `tomllib`.
+- Large plugin/CLI/connection refactors are intentionally deferred unless they
+  fix a demonstrated release-blocking defect.

--- a/docs/WHATS_NEW_1.4.md
+++ b/docs/WHATS_NEW_1.4.md
@@ -7,13 +7,12 @@ Matrix E2EE, and logging hardening developed since 1.3.8.
 ## Before upgrading
 
 1. Upgrade the runtime to Python 3.11 or newer.
-2. If you still use pre-1.3 file locations or legacy `MMRELAY_*_DIR`
-   environment variables, run `mmrelay migrate --dry-run`, then `mmrelay
-   migrate` and `mmrelay verify-migration`.
-3. Back up the Matrix E2EE store, credentials, and cross-signing sidecar
+2. Back up the Matrix E2EE store, credentials, and cross-signing sidecar
    together before changing authentication or storage.
-4. For containers or Kubernetes, update the image tag to `1.4.0` after the
+3. For containers or Kubernetes, update the image tag to `1.4.0` after the
    release image is available.
+
+After installing 1.4, run the migration commands for legacy layouts.
 
 ## Python 3.11 minimum
 


### PR DESCRIPTION
## Summary

Refresh MMRelay's documentation for 1.4 while keeping the README focused as a
project landing page rather than duplicating the full manual.

- Clarify what MMRelay is, how the Meshtastic ↔ Matrix bridge works, and the
  identity boundary between mesh attribution and the Matrix bot account.
- Direct deeper conceptual material to the wiki and version-specific operator
  guidance to repository `docs/`.
- Document the Python 3.11 baseline, Matrix E2EE/cross-signing behavior, BLE
  reliability work, logging changes, and dependency updates in 1.4.
- Document 1.4 as the final legacy-layout migration window before planned
  removal in 1.5.
- Refresh Docker, Helm, Kubernetes, migration, configuration, and upgrade
  navigation.
- Clarify the last-resort cross-signing reset procedure and point users to the
  E2EE guide before using it.

The result is a shorter, clearer entry point with the detailed operational
documentation kept in the appropriate versioned guides.